### PR TITLE
Further enhancements in preparation for Internet Archive bulk upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to thoth-dissemination will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+  - Basic functionality for uploading files and metadata to Internet Archive, OAPEN, ScienceOpen, and platforms using SWORD v2 (as implemented for DSpace v7)

--- a/config.env.template
+++ b/config.env.template
@@ -12,3 +12,7 @@ so_ftp_pw=
 # OAPEN FTP server credentials
 oapen_ftp_user=
 oapen_ftp_pw=
+
+# University of Cambridge Apollo DSpace 7 test server credentials
+cam_ds7_user=
+cam_ds7_pw=

--- a/disseminator.py
+++ b/disseminator.py
@@ -6,6 +6,8 @@ Call custom workflows to retrieve work-related files and metadata
 and upload them in the appropriate format to various platforms.
 """
 
+__version__ = 'unversioned'
+
 import argparse
 import logging
 from dotenv import load_dotenv
@@ -47,7 +49,7 @@ ARGS = [
 
 def run(work_id, platform, export_url):
     """Execute a dissemination uploader based on input parameters"""
-    uploader = UPLOADERS[platform](work_id, export_url)
+    uploader = UPLOADERS[platform](work_id, export_url, __version__)
     uploader.run()
 
 

--- a/disseminator.py
+++ b/disseminator.py
@@ -13,11 +13,13 @@ from pathlib import Path
 from iauploader import IAUploader
 from oapenuploader import OAPENUploader
 from souploader import SOUploader
+from swordv2uploader import SwordV2Uploader
 
 UPLOADERS = {
     "InternetArchive": IAUploader,
     "OAPEN": OAPENUploader,
     "ScienceOpen": SOUploader,
+    "SWORD": SwordV2Uploader,
 }
 
 ARGS = [

--- a/disseminator.py
+++ b/disseminator.py
@@ -49,6 +49,7 @@ ARGS = [
 
 def run(work_id, platform, export_url):
     """Execute a dissemination uploader based on input parameters"""
+    logging.info('Beginning upload of {} to {}'.format(work_id, platform))
     uploader = UPLOADERS[platform](work_id, export_url, __version__)
     uploader.run()
 

--- a/iauploader.py
+++ b/iauploader.py
@@ -93,6 +93,8 @@ class IAUploader(Uploader):
             'language': languages,
             'issn': issns,
             'volume': volume,
+            # Custom field helping future users determine what logic was used to create an upload
+            'thoth-dissemination-service': self.version,
         }
 
         return ia_metadata

--- a/iauploader.py
+++ b/iauploader.py
@@ -62,6 +62,14 @@ class IAUploader(Uploader):
         # IA doesn't set a standard so representations vary across the archive
         subjects = [n.get('subjectCode')
                     for n in work_metadata.get('subjects')]
+        # language/issn/volume not currently supported in thothlibrary (latest release v0.15.0)
+        languages = [n.get('languageCode')
+                     for n in work_metadata.get('languages')]
+        issns = [n.get('series').get(key) for n in work_metadata.get(
+            'issues') for key in ['issnPrint', 'issnDigital']]
+        # IA only accepts a single volume number
+        volume = next(iter([str(n.get('issueOrdinal'))
+                      for n in work_metadata.get('issues')]), None)
         ia_metadata = {
             # All fields are non-mandatory
             # Any None values or empty lists are ignored by IA on ingest
@@ -84,6 +92,9 @@ class IAUploader(Uploader):
             # https://help.archive.org/help/uploading-a-basic-guide/ requests no more than
             # 10 subject tags, but additional tags appear to be accepted without error
             'subject': subjects,
+            'language': languages,
+            'issn': issns,
+            'volume': volume,
         }
 
         return ia_metadata

--- a/iauploader.py
+++ b/iauploader.py
@@ -62,7 +62,6 @@ class IAUploader(Uploader):
         # IA doesn't set a standard so representations vary across the archive
         subjects = [n.get('subjectCode')
                     for n in work_metadata.get('subjects')]
-        # language/issn/volume not currently supported in thothlibrary (latest release v0.15.0)
         languages = [n.get('languageCode')
                      for n in work_metadata.get('languages')]
         issns = [n.get('series').get(key) for n in work_metadata.get(

--- a/iauploader.py
+++ b/iauploader.py
@@ -20,8 +20,7 @@ class IAUploader(Uploader):
         # Use Thoth ID as unique identifier (URL will be in format `archive.org/details/[identifier]`)
         filename = self.work_id
 
-        # Metadata file format TBD: use CSV for now
-        metadata_bytes = self.get_formatted_metadata('csv::thoth')
+        metadata_bytes = self.get_formatted_metadata('json::thoth')
         pdf_bytes = self.get_pdf_bytes()
 
         # Convert Thoth work metadata into Internet Archive format
@@ -31,7 +30,7 @@ class IAUploader(Uploader):
             identifier=filename,
             files={
                 '{}.pdf'.format(filename): BytesIO(pdf_bytes),
-                '{}.csv'.format(filename): BytesIO(metadata_bytes),
+                '{}.json'.format(filename): BytesIO(metadata_bytes),
             },
             metadata=ia_metadata,
             access_key=environ.get('ia_s3_access'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pysftp==0.2.9
 python-dotenv==0.19.2
 requests==2.28.1
 sword2==0.3.0
-thothlibrary==0.14.0
+thothlibrary==0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ internetarchive==3.0.2
 pysftp==0.2.9
 python-dotenv==0.19.2
 requests==2.28.1
+sword2==0.3.0
 thothlibrary==0.14.0

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -124,7 +124,6 @@ class SwordV2Uploader(Uploader):
         for isbn in [n.get('isbn').replace(
                 '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
             sword_metadata.add_field("dcterms_identifier", isbn)
-        # language not currently supported in thothlibrary (latest release v0.15.0)
         for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
             sword_metadata.add_field("dcterms_language", language)
 

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -117,5 +117,8 @@ class SwordV2Uploader(Uploader):
         for isbn in [n.get('isbn').replace(
                 '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
             sword_metadata.add_field("dcterms_identifier", isbn)
+        # language not currently supported in thothlibrary (latest release v0.15.0)
+        for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
+            sword_metadata.add_field("dcterms_language", language)
 
         return sword_metadata

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -39,7 +39,14 @@ class SwordV2Uploader(Uploader):
         try:
             receipt = conn.create(
                 col_iri="https://dspace7-back.lib.cam.ac.uk/server/swordv2/collection/1810/339712",
-                metadata_entry=sword_metadata,
+                # Hacky workaround for an issue with mishandling of encodings within sword2 library,
+                # which meant metadata containing special characters could not be submitted.
+                # Although the `metadata_entry` parameter ought to be of type `Entry`, sending a
+                # `str` as below triggers no errors. Ultimately it's passed to `http/client.py/_encode()`,
+                # which defaults to encoding it as 'latin-1'. Pre-emptively encoding/decoding it here
+                # seems to mean that the string sent to the server is in correct utf-8 format.
+                metadata_entry=str(sword_metadata).encode(
+                    'utf-8').decode('latin-1'),
                 in_progress=True,
             )
         except sword2.exceptions.Forbidden:

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Retrieve and disseminate files and metadata to a server using SWORD v2
+"""
+
+import logging
+import sys
+import sword2
+from io import BytesIO
+from os import environ
+from uploader import Uploader
+
+
+class SwordV2Uploader(Uploader):
+    """Dissemination logic for SWORD v2"""
+    # using UCamApollo DSpace 7 as hard-coded logic for now.
+
+    def upload_to_platform(self):
+        """Upload work in required format to SWORD v2"""
+
+        # Convert Thoth work metadata into SWORD v2 format
+        sword_metadata = self.parse_metadata()
+
+        # Set up SWORD v2 endpoint connection
+        conn = sword2.Connection(
+            service_document_iri="https://dspace7-back.lib.cam.ac.uk/server/swordv2/collection/1810/339712",
+            user_name=environ.get('cam_ds7_user'),
+            user_pass=environ.get('cam_ds7_pw'),
+        )
+
+        try:
+            receipt = conn.create(
+                col_iri="https://dspace7-back.lib.cam.ac.uk/server/swordv2/collection/1810/339712",
+                metadata_entry=sword_metadata,
+                in_progress=True,
+            )
+        except sword2.exceptions.Forbidden:
+            logging.error(
+                'Could not connect to SWORD v2 server: authorisation failed')
+            sys.exit(1)
+
+        if receipt.code != 201:
+            logging.error(
+                'Error uploading to SWORD v2')
+            sys.exit(1)
+
+        logging.info(
+            'Successfully uploaded to SWORD v2 at {}'.format(receipt.location))
+
+    def parse_metadata(self):
+        """Convert work metadata into SWORD v2 format"""
+        work_metadata = self.metadata.get('data').get('work')
+        sword_metadata = sword2.Entry(
+            title=work_metadata.get('fullTitle')
+        )
+
+        return sword_metadata

--- a/uploader.py
+++ b/uploader.py
@@ -7,7 +7,7 @@ import logging
 import sys
 import json
 import requests
-from thothlibrary import ThothClient
+from thothlibrary import ThothClient, ThothError
 
 
 class Uploader():
@@ -27,7 +27,13 @@ class Uploader():
     def get_thoth_metadata(self):
         """Retrieve JSON-formatted work metadata from Thoth GraphQL API via Thoth Client"""
         thoth = ThothClient()
-        metadata_string = thoth.work_by_id(self.work_id, raw=True)
+        try:
+            metadata_string = thoth.work_by_id(self.work_id, raw=True)
+        except ThothError:
+            logging.error(
+                # Don't include full error text as it's lengthy (contains full query/response)
+                'Error retrieving work metadata from GraphQL API: work ID may be incorrect')
+            sys.exit(1)
 
         # Convert string value to JSON value
         try:

--- a/uploader.py
+++ b/uploader.py
@@ -13,11 +13,12 @@ from thothlibrary import ThothClient
 class Uploader():
     """Generic logic to retrieve and disseminate files and metadata"""
 
-    def __init__(self, work_id, export_url):
+    def __init__(self, work_id, export_url, version):
         """Save argument values and retrieve and store JSON-formatted work metadata"""
         self.work_id = work_id
         self.export_url = export_url
         self.metadata = self.get_thoth_metadata()
+        self.version = version
 
     def run(self):
         """Execute upload logic specific to the selected platform"""

--- a/uploader.py
+++ b/uploader.py
@@ -99,6 +99,7 @@ class Uploader():
 
         return cover_url
 
+    # Function not currently used
     def get_pb_isbn(self):
         """Extract paperback ISBN from work metadata"""
         pb_isbn = None


### PR DESCRIPTION
PR contains improvements to existing Internet Archive logic, as well as new SWORD v2 functionality. Merging in preparation for creating a release. We should hopefully soon be able to stress-test `thoth-dissemination` by using it to bulk-upload publishers' back catalogues to the Internet Archive, and a tagged release will help with tracking exactly what logic was used to upload specific works, in the event that we wish to enhance the process in future (and perhaps update existing uploads).