### PR TITLE
Enable automatic monthly uploads of new works to Figshare (Loughborough repository)

### DIFF
--- a/.github/workflows/fs_bulk_disseminate.yml
+++ b/.github/workflows/fs_bulk_disseminate.yml
@@ -1,5 +1,5 @@
 # Purpose: upload newly-published works from Thoth to (Loughborough) Figshare.
-# Uploads all active Thoth works with a publication date in the previous month.
+# Uploads all active Thoth works with a publication date within the previous calendar month.
 # Work must have a valid URL supplied for at least one Publication Canonical Location.
 # Must also have a Long Abstract, a Licence, at least one Main Contribution
 # and at least one Subject with type Keyword.
@@ -10,10 +10,13 @@ name: fs-bulk-disseminate
 
 on:
   schedule:
-    # 'at 00:15 on day-of-month 1'
-    # (scheduling is not guaranteed; runs at the start of the hour
-    # are more likely to be delayed)
-    - cron: '15 0 1 * *'
+    # 'at 05:55 on day-of-month 5'
+    # There might be a delay between a book being published and the publisher
+    # correctly setting its publication date and Active status in Thoth.
+    # Therefore, this action is run a few days after the start of the month,
+    # to minimise situations where e.g. a book which was published on the 31st, but
+    # whose record was not updated until the 1st, is missed out of both months' runs.
+    - cron: '55 5 5 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fs_bulk_disseminate.yml
+++ b/.github/workflows/fs_bulk_disseminate.yml
@@ -10,13 +10,13 @@ name: fs-bulk-disseminate
 
 on:
   schedule:
-    # 'at 05:55 on day-of-month 5'
+    # 'at 04:40 on day-of-month 7'
     # There might be a delay between a book being published and the publisher
     # correctly setting its publication date and Active status in Thoth.
     # Therefore, this action is run a few days after the start of the month,
     # to minimise situations where e.g. a book which was published on the 31st, but
     # whose record was not updated until the 1st, is missed out of both months' runs.
-    - cron: '55 5 5 * *'
+    - cron: '40 4 7 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fs_bulk_disseminate.yml
+++ b/.github/workflows/fs_bulk_disseminate.yml
@@ -1,0 +1,26 @@
+# Purpose: upload newly-published works from Thoth to (Loughborough) Figshare.
+# Uploads all active Thoth works with a publication date in the previous month.
+# Work must have a valid URL supplied for at least one Publication Canonical Location.
+# Must also have a Long Abstract, a Licence, at least one Main Contribution
+# and at least one Subject with type Keyword.
+# Figshare credentials for a user with write permissions to the Thoth
+# Archiving Network group (e.g. Thoth Archive Admin) must be present as a
+# repository secret named FIGSHARE_TOKEN.
+name: fs-bulk-disseminate
+
+on:
+  schedule:
+    # 'at 00:15 on day-of-month 1'
+    # (scheduling is not guaranteed; runs at the start of the hour
+    # are more likely to be delayed)
+    - cron: '15 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  fs-bulk-disseminate:
+    uses: ./.github/workflows/bulk_disseminate.yml
+    with:
+      platform: 'Figshare'
+      env_publishers: ${{ vars.FS_ENV_PUBLISHERS }}
+      env_exceptions: ${{ vars.FS_ENV_EXCEPTIONS }}
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  - GitHub Actions for recurring automatic uploads of newly published works to Figshare
 
 ## [[0.1.8]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v0.1.8) - 2023-08-23
 ### Changed


### PR DESCRIPTION
Extends existing automated dissemination logic.

Ideally we want to avoid attempting to upload works which were already uploaded in previous batches. This would show up as a failure on the Actions dashboard, and the more "benign" failures we get, the more likely we are to miss genuine failures.

For IA, it's easy to find the full set of existing uploads and filter them out beforehand. Figshare doesn't provide this ability. For Crossref (where re-uploads don't matter anyway), a record's eligibility for upload is based on its last update timestamp, so we can reliably filter for anything updated since the last run. However, here, we ideally want to find "all works which were published since the last run". Since "time of publication" isn't automatically recorded in the database in the same way as "time of last update", we can't rely on strict date/time cutoffs.

The solution chosen is to search for everything marked as Active with a publication date within the previous calendar month (for a monthly upload schedule), but to only do this search a few days after the start of the month. This minimises potential issues to do with timezones, datelines, daylight savings, and (above all) publishers not getting around to updating a work's Thoth record until a day or so after its actual publication date.

Our ultimate goal (as previously discussed) is to implement a mechanism for triggering automated dissemination as soon as a work is set to Active. This would be the most reliable way to avoid such issues.