### PR TITLE
Update GitHub Actions dependencies to use Node 20 instead of Node 16

### DIFF
--- a/.github/workflows/bulk_disseminate.yml
+++ b/.github/workflows/bulk_disseminate.yml
@@ -22,10 +22,10 @@ jobs:
       NEW_IDS: ${{ steps.get-ids.outputs.NEW_IDS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/disseminate.yml
+++ b/.github/workflows/disseminate.yml
@@ -21,7 +21,7 @@ jobs:
         work-id: ${{ fromJSON(inputs.work-ids) }}
     steps:
       - name: Make all platform credentials available to later steps (with names lowercased)
-        uses: oNaiPs/secrets-to-env-action@v1
+        uses: oNaiPs/secrets-to-env-action@v1.5
         with:
           secrets: ${{ toJSON(secrets) }}
           convert: lower

--- a/.github/workflows/docker_build_and_push_to_dockerhub.yml
+++ b/.github/workflows/docker_build_and_push_to_dockerhub.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -23,17 +23,17 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/manual_disseminate.yml
+++ b/.github/workflows/manual_disseminate.yml
@@ -9,6 +9,7 @@
 # named IA_S3_ACCESS (access key) and IA_S3_SECRET (secret key).
 # It is advised not to upload until the work is published and all metadata finalised.
 name: manual-disseminate
+run-name: 'manual-disseminate to ${{ github.event.inputs.platform }}: ${{ github.event.inputs.workIds }}'
 
 on:
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+  - Upgraded GitHub Actions dependencies from Node 16 to 20 (`docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, `docker/build-push-action@v5`, `actions/checkout@v4`, `actions/setup-python@v5`, `oNaiPs/secrets-to-env-action@v1.5`)
 
 ## [[0.1.9]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v0.1.9) - 2023-12-05
 ### Added


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Tested on fork (apart from Docker changes) and looks fine.