### PR TITLE
Enhance SWORD2 logic as part of CUL pilot discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ docker run --rm ${imagename} ./disseminator.py --work ${work_id} --platform ${pl
 ### Options
 `--work` = Thoth ID of work to be disseminated
 
-`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `SWORD`, `Crossref`, `Figshare`)
+`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`)
 
 See also `--help`.

--- a/culuploader.py
+++ b/culuploader.py
@@ -14,5 +14,13 @@ class CULUploader(DSpaceUploader):
         service_document_iri = 'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/servicedocument'
         collection_iri = 'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7'
         metadata_profile = MetadataProfile.JISC_ROUTER
-        super().__init__(work_id, export_url, client_url, version, user_name_string, user_pass_string,
-                         service_document_iri, collection_iri, metadata_profile)
+        super().__init__(
+            work_id,
+            export_url,
+            client_url,
+            version,
+            user_name_string,
+            user_pass_string,
+            service_document_iri,
+            collection_iri,
+            metadata_profile)

--- a/culuploader.py
+++ b/culuploader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Retrieve and disseminate files and metadata to Cambridge University Library DSpace
+Retrieve and disseminate files and metadata to
+Cambridge University Library DSpace
 """
 
 from dspaceuploader import DSpaceUploader, MetadataProfile
@@ -11,8 +12,12 @@ class CULUploader(DSpaceUploader):
         """Set CUL-specific parameters and pass them to DSpaceUploader"""
         user_name_string = 'cam_ds7_user'
         user_pass_string = 'cam_ds7_pw'
-        service_document_iri = 'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/servicedocument'
-        collection_iri = 'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7'
+        service_document_iri = (
+            'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/servicedocument'
+        )
+        collection_iri = (
+            'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7'
+        )
         metadata_profile = MetadataProfile.JISC_ROUTER
         super().__init__(
             work_id,

--- a/culuploader.py
+++ b/culuploader.py
@@ -16,7 +16,8 @@ class CULUploader(DSpaceUploader):
             'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/servicedocument'
         )
         collection_iri = (
-            'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7'
+            'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/'
+            '7'
         )
         metadata_profile = MetadataProfile.JISC_ROUTER
         super().__init__(

--- a/culuploader.py
+++ b/culuploader.py
@@ -7,12 +7,12 @@ from dspaceuploader import DSpaceUploader, MetadataProfile
 
 
 class CULUploader(DSpaceUploader):
-    def __init__(self, work_id, export_url, version):
+    def __init__(self, work_id, export_url, client_url, version):
         """Set CUL-specific parameters and pass them to DSpaceUploader"""
         user_name_string = 'cam_ds7_user'
         user_pass_string = 'cam_ds7_pw'
         service_document_iri = 'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/servicedocument'
         collection_iri = 'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7'
         metadata_profile = MetadataProfile.JISC_ROUTER
-        super().__init__(work_id, export_url, version, user_name_string, user_pass_string,
+        super().__init__(work_id, export_url, client_url, version, user_name_string, user_pass_string,
                          service_document_iri, collection_iri, metadata_profile)

--- a/culuploader.py
+++ b/culuploader.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""
+Retrieve and disseminate files and metadata to Cambridge University Library DSpace
+"""
+
+from dspaceuploader import DSpaceUploader, MetadataProfile
+
+
+class CULUploader(DSpaceUploader):
+    def __init__(self, work_id, export_url, version):
+        """Set CUL-specific parameters and pass them to DSpaceUploader"""
+        user_name_string = 'cam_ds7_user'
+        user_pass_string = 'cam_ds7_pw'
+        service_document_iri = 'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/servicedocument'
+        collection_iri = 'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7'
+        metadata_profile = MetadataProfile.JISC_ROUTER
+        super().__init__(work_id, export_url, version, user_name_string, user_pass_string,
+                         service_document_iri, collection_iri, metadata_profile)

--- a/disseminator.py
+++ b/disseminator.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from iauploader import IAUploader
 from oapenuploader import OAPENUploader
 from souploader import SOUploader
-from swordv2uploader import SwordV2Uploader
+from culuploader import CULUploader
 from crossrefuploader import CrossrefUploader
 from fsuploader import FigshareUploader
 
@@ -24,7 +24,7 @@ UPLOADERS = {
     "InternetArchive": IAUploader,
     "OAPEN": OAPENUploader,
     "ScienceOpen": SOUploader,
-    "SWORD": SwordV2Uploader,
+    "CUL": CULUploader,
     "Crossref": CrossrefUploader,
     "Figshare": FigshareUploader,
 }

--- a/disseminator.py
+++ b/disseminator.py
@@ -48,15 +48,22 @@ ARGS = [
         "action": "store",
         "default": "https://export.thoth.pub",
         "help": "Thoth's Export API endpoint URL",
+    }, {
+        "val": "--client-url",
+        "dest": "client_url",
+        "action": "store",
+        "default": None,
+        "help": "URL of GraphQL API endpoint to use with Thoth Client",
     }
 ]
 
 
-def run(work_id, platform, export_url):
+def run(work_id, platform, export_url, client_url):
     """Execute a dissemination uploader based on input parameters"""
     logging.info('Beginning upload of {} to {}'.format(work_id, platform))
     try:
-        uploader = UPLOADERS[platform](work_id, export_url, __version__)
+        uploader = UPLOADERS[platform](
+            work_id, export_url, client_url, __version__)
     except KeyError:
         logging.error('{} not supported: platform must be one of {}'.format(
             platform, UPLOADERS_STR))
@@ -91,4 +98,5 @@ if __name__ == '__main__':
     dotenv_path = Path('./config.env')
     load_dotenv(dotenv_path=dotenv_path)
     ARGUMENTS = get_arguments()
-    run(ARGUMENTS.work_id, ARGUMENTS.platform, ARGUMENTS.export_url)
+    run(ARGUMENTS.work_id, ARGUMENTS.platform,
+        ARGUMENTS.export_url, ARGUMENTS.client_url)

--- a/dspaceuploader.py
+++ b/dspaceuploader.py
@@ -9,7 +9,24 @@ from swordv2uploader import SwordV2Uploader, MetadataProfile
 class DSpaceUploader(SwordV2Uploader):
     # Currently DSpace dissemination is only implemented via SWORDv2
     # This class will be extended once we implement e.g. DSpace REST API
-    def __init__(self, work_id, export_url, client_url, version, user_name_string, user_pass_string,
-                 service_document_iri, collection_iri, metadata_profile):
-        super().__init__(work_id, export_url, client_url, version, user_name_string, user_pass_string,
-                         service_document_iri, collection_iri, metadata_profile)
+    def __init__(
+            self,
+            work_id,
+            export_url,
+            client_url,
+            version,
+            user_name_string,
+            user_pass_string,
+            service_document_iri,
+            collection_iri,
+            metadata_profile):
+        super().__init__(
+            work_id,
+            export_url,
+            client_url,
+            version,
+            user_name_string,
+            user_pass_string,
+            service_document_iri,
+            collection_iri,
+            metadata_profile)

--- a/dspaceuploader.py
+++ b/dspaceuploader.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""
+Retrieve and disseminate files and metadata to a DSpace repository
+"""
+
+from swordv2uploader import SwordV2Uploader, MetadataProfile
+
+
+class DSpaceUploader(SwordV2Uploader):
+    # Currently DSpace dissemination is only implemented via SWORDv2
+    # This class will be extended once we implement e.g. DSpace REST API
+    def __init__(self, work_id, export_url, version, user_name_string, user_pass_string,
+                 service_document_iri, collection_iri, metadata_profile):
+        super().__init__(work_id, export_url, version, user_name_string, user_pass_string,
+                         service_document_iri, collection_iri, metadata_profile)

--- a/dspaceuploader.py
+++ b/dspaceuploader.py
@@ -9,7 +9,7 @@ from swordv2uploader import SwordV2Uploader, MetadataProfile
 class DSpaceUploader(SwordV2Uploader):
     # Currently DSpace dissemination is only implemented via SWORDv2
     # This class will be extended once we implement e.g. DSpace REST API
-    def __init__(self, work_id, export_url, version, user_name_string, user_pass_string,
+    def __init__(self, work_id, export_url, client_url, version, user_name_string, user_pass_string,
                  service_document_iri, collection_iri, metadata_profile):
-        super().__init__(work_id, export_url, version, user_name_string, user_pass_string,
+        super().__init__(work_id, export_url, client_url, version, user_name_string, user_pass_string,
                          service_document_iri, collection_iri, metadata_profile)

--- a/fsuploader.py
+++ b/fsuploader.py
@@ -260,7 +260,7 @@ class FigshareUploader(Uploader):
         """
         # fullName is mandatory so we do not expect KeyErrors
         authors = [{'name': n['fullName']} for n in metadata.get('contributions')
-                   if n.get('mainContribution') == True]
+                   if n.get('mainContribution') is True]
         if len(authors) < 1:
             logging.error(
                 'Cannot upload to Figshare: Work must have at least one Main Contribution')

--- a/fsuploader.py
+++ b/fsuploader.py
@@ -125,9 +125,8 @@ class FigshareUploader(Uploader):
     def parse_metadata(self):
         """Convert work metadata into Figshare format."""
         work_metadata = self.metadata.get('data').get('work')
-        try:
-            long_abstract = work_metadata.get('longAbstract')
-        except KeyError:
+        long_abstract = work_metadata.get('longAbstract')
+        if long_abstract is None:
             logging.error(
                 'Cannot upload to Figshare: Work must have a Long Abstract')
             sys.exit(1)

--- a/fsuploader.py
+++ b/fsuploader.py
@@ -18,9 +18,9 @@ from uploader import Uploader, PUB_FORMATS
 class FigshareUploader(Uploader):
     """Dissemination logic for Figshare"""
 
-    def __init__(self, work_id, export_url, version):
+    def __init__(self, work_id, export_url, client_url, version):
         """Instantiate class for accessing Figshare API."""
-        super().__init__(work_id, export_url, version)
+        super().__init__(work_id, export_url, client_url, version)
         try:
             api_token = self.get_credential_from_env(
                 'figshare_token', 'Figshare')

--- a/iauploader.py
+++ b/iauploader.py
@@ -102,7 +102,8 @@ class IAUploader(Uploader):
         # Repeatable fields such as 'creator', 'isbn', 'subject'
         # can be set by submitting a list of values
         creators = [n.get('fullName')
-                    for n in work_metadata.get('contributions') if n.get('mainContribution') is True]
+                    for n in work_metadata.get('contributions')
+                    if n.get('mainContribution') is True]
         # IA metadata schema suggests hyphens should be omitted,
         # although including them does not cause any errors
         isbns = [n.get('isbn').replace(

--- a/iauploader.py
+++ b/iauploader.py
@@ -102,7 +102,7 @@ class IAUploader(Uploader):
         # Repeatable fields such as 'creator', 'isbn', 'subject'
         # can be set by submitting a list of values
         creators = [n.get('fullName')
-                    for n in work_metadata.get('contributions') if n.get('mainContribution') == True]
+                    for n in work_metadata.get('contributions') if n.get('mainContribution') is True]
         # IA metadata schema suggests hyphens should be omitted,
         # although including them does not cause any errors
         isbns = [n.get('isbn').replace(

--- a/obtain_new_ids.py
+++ b/obtain_new_ids.py
@@ -216,7 +216,8 @@ class FigshareIDFinder(IDFinder):
                 break
             offset += 1
             next_work = next_batch[0]
-            next_work_pub_date = datetime.strptime(next_work.publicationDate, "%Y-%m-%d").date()
+            next_work_pub_date = datetime.strptime(
+                next_work.publicationDate, "%Y-%m-%d").date()
             if next_work_pub_date > previous_month_end:
                 # This work will be handled in next month's run - don't cause duplication
                 continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pysftp==0.2.9
 python-dotenv==0.19.2
 requests==2.31.0
 sword2==0.3.0
-thothlibrary==0.20.1
+thothlibrary==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pysftp==0.2.9
 python-dotenv==0.19.2
 requests==2.31.0
 sword2==0.3.0
-thothlibrary==0.22.0
+thothlibrary==0.25.0

--- a/requirements_obtain_new_ids.txt
+++ b/requirements_obtain_new_ids.txt
@@ -1,2 +1,2 @@
 internetarchive==3.0.2
-thothlibrary==0.20.0
+thothlibrary==0.22.0

--- a/requirements_obtain_new_ids.txt
+++ b/requirements_obtain_new_ids.txt
@@ -1,2 +1,2 @@
 internetarchive==3.0.2
-thothlibrary==0.22.0
+thothlibrary==0.25.0

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -131,104 +131,105 @@ class SwordV2Uploader(Uploader):
         basic_metadata = sword2.Entry(
             # swordv2-server.simpledc.abstract
             # swordv2-server.atom.summary
-            dc_description_abstract=work_metadata.get('longAbstract'),
+            dcterms_description_abstract=work_metadata.get('longAbstract'),
             # swordv2-server.simpledc.description
-            dc_description=work_metadata.get('longAbstract'),
+            dcterms_description=work_metadata.get('longAbstract'),
             # swordv2-server.simpledc.accessRights
             # swordv2-server.simpledc.rights
             # swordv2-server.simpledc.rightsHolder
             # swordv2-server.atom.rights
-            dc_rights=work_metadata.get('license'),
+            dcterms_rights=work_metadata.get('license'),
             # swordv2-server.simpledc.available
-            dc_date_available=work_metadata.get('publicationDate'),
+            dcterms_date_available=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.created
             # swordv2-server.atom.published
             # swordv2-server.atom.updated
-            dc_date_created=work_metadata.get('publicationDate'),
+            dcterms_date_created=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.date
-            dc_date=work_metadata.get('publicationDate'),
+            dcterms_date=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.issued
-            dc_date_issued=work_metadata.get('publicationDate'),
+            dcterms_date_issued=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.publisher
-            dc_publisher=self.get_publisher_name(),
+            dcterms_publisher=self.get_publisher_name(),
             # swordv2-server.simpledc.coverage
-            dc_coverage='open access',
+            dcterms_coverage='open access',
             # swordv2-server.simpledc.spatial
-            dc_coverage_spatial='global',
+            dcterms_coverage_spatial='global',
             # swordv2-server.simpledc.temporal
-            dc_coverage_temporal='all time',
+            dcterms_coverage_temporal='all time',
             # swordv2-server.simpledc.title
             # swordv2-server.atom.title
-            dc_title=work_metadata.get('fullTitle'),
+            dcterms_title=work_metadata.get('fullTitle'),
             # swordv2-server.simpledc.type
             # "Recommended practice is to use a controlled vocabulary such as the DCMI Type Vocabulary"
             # (see https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#section-7)
-            dc_type='text',
+            dcterms_type='text',
+            #^should we Include the dcmitype namespace for this?
 
             # TODO Thoth stores relations/references but not currently retrieved by Thoth Client:
             # # swordv2-server.simpledc.isPartOf
-            # dc_relation_ispartof=
+            # dcterms_relation_ispartof=
             # # swordv2-server.simpledc.isReplacedBy
-            # dc_relation_isreplacedby=
+            # dcterms_relation_isreplacedby=
             # # swordv2-server.simpledc.references
-            # dc_relation_references=
+            # dcterms_relation_references=
             # # swordv2-server.simpledc.relation
-            # dc_relation=
+            # dcterms_relation=
             # # swordv2-server.simpledc.replaces
-            # dc_relation_replaces=
+            # dcterms_relation_replaces=
 
             # Not appropriate as we may be submitting multiple formats (PDF, XML etc):
             # # swordv2-server.simpledc.extent
-            # dc_format_extent=
+            # dcterms_format_extent=
             # # swordv2-server.simpledc.format
-            # dc_format=
+            # dcterms_format=
             # # swordv2-server.simpledc.medium
-            # dc_format_medium=
+            # dcterms_format_medium=
 
             # Not supported by Thoth:
             # # swordv2-server.simpledc.alternative
-            # dc_title_alternative=
+            # dcterms_title_alternative=
             # # swordv2-server.simpledc.bibliographicCitation
-            # dc_identifier_citation=
+            # dcterms_identifier_citation=
             # # swordv2-server.simpledc.dateAccepted
-            # dc_date_accepted=
+            # dcterms_date_accepted=
             # # swordv2-server.simpledc.dateSubmitted
-            # dc_date_submitted=
+            # dcterms_date_submitted=
             # # swordv2-server.simpledc.isReferencedBy
-            # dc_relation_isreferencedby=
+            # dcterms_relation_isreferencedby=
             # "A related resource that requires the described resource to support its function, delivery, or coherence"
             # # swordv2-server.simpledc.isRequiredBy
-            # dc_relation_isrequiredby=
+            # dcterms_relation_isrequiredby=
             # # swordv2-server.simpledc.modified
-            # dc_date_modified=
+            # dcterms_date_modified=
             # # swordv2-server.simpledc.provenance
-            # dc_description_provenance=
+            # dcterms_description_provenance=
             # "A related resource that is required by the described resource to support its function, delivery, or coherence"
             # # swordv2-server.simpledc.requires
-            # dc_relation_requires=
+            # dcterms_relation_requires=
             # "A related resource from which the described resource is derived"
             # (e.g. print version of scan); most cases would be covered by dc_relation fields
             # # swordv2-server.simpledc.source
-            # dc_source=
+            # dcterms_source=
         )
 
         for contributor in [n.get('fullName') for n in work_metadata.get('contributions') if n.get('mainContribution') == True]:
             # swordv2-server.simpledc.contributor
-            basic_metadata.add_field("dc_contributor", contributor)
+            basic_metadata.add_field("dcterms_contributor", contributor)
             # swordv2-server.simpledc.creator
             # swordv2-server.atom.author
-            basic_metadata.add_field("dc_contributor_author", contributor)
+            basic_metadata.add_field("dcterms_contributor_author", contributor)
         # swordv2-server.simpledc.identifier
-        basic_metadata.add_field("dc_identifier", work_metadata.get('doi'))
+        basic_metadata.add_field("dcterms_identifier", work_metadata.get('doi'))
         for isbn in [n.get('isbn').replace(
                 '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
-            basic_metadata.add_field("dc_identifier", isbn)
+            basic_metadata.add_field("dcterms_identifier", isbn)
         for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
             # swordv2-server.simpledc.language
-            basic_metadata.add_field("dc_language", language)
+            basic_metadata.add_field("dcterms_language", language)
         for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
             # swordv2-server.simpledc.subject
-            basic_metadata.add_field("dc_subject", subject)
+            basic_metadata.add_field("dcterms_subject", subject)
 
         return basic_metadata
 

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -169,16 +169,8 @@ class SwordV2Uploader(Uploader):
             #^should we Include the dcmitype namespace for this?
 
             # TODO Thoth stores relations/references but not currently retrieved by Thoth Client:
-            # # swordv2-server.simpledc.isPartOf
-            # dcterms_relation_ispartof=
-            # # swordv2-server.simpledc.isReplacedBy
-            # dcterms_relation_isreplacedby=
             # # swordv2-server.simpledc.references
             # dcterms_relation_references=
-            # # swordv2-server.simpledc.relation
-            # dcterms_relation=
-            # # swordv2-server.simpledc.replaces
-            # dcterms_relation_replaces=
 
             # Not appropriate as we may be submitting multiple formats (PDF, XML etc):
             # # swordv2-server.simpledc.extent
@@ -233,6 +225,20 @@ class SwordV2Uploader(Uploader):
         for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
             # swordv2-server.simpledc.subject
             basic_metadata.add_field("dcterms_subject", subject)
+        for (relation_type, relation_doi) in [(n.get('relationType'), n.get('relatedWork').get('doi'))
+                for n in work_metadata.get('relations')]:
+            if relation_type == 'IS_PART_OF' or relation_type == 'IS_CHILD_OF':
+                # swordv2-server.simpledc.isPartOf
+                basic_metadata.add_field("dcterms_isPartOf", relation_doi)
+            elif relation_type == 'IS_REPLACED_BY':
+                # swordv2-server.simpledc.isReplacedBy
+                basic_metadata.add_field("dcterms_isReplacedBy", relation_doi)
+            elif relation_type == 'REPLACES':
+                # swordv2-server.simpledc.replaces
+                basic_metadata.add_field("dcterms_replaces", relation_doi)
+            else:
+                # swordv2-server.simpledc.relation
+                basic_metadata.add_field("dcterms_relation", relation_doi)
 
         return basic_metadata
 

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -57,8 +57,8 @@ class SwordV2Uploader(Uploader):
     def upload_to_platform(self):
         """Upload work in required format to SWORD v2"""
 
-        # TODO SWORD2 is designed for deposit rather than retrieval, hence
-        # there's no easy way to search existing items i.e. check for duplicates.
+        # TODO SWORD2 is designed for deposit rather than retrieval, so there's
+        # no easy way to search existing items i.e. check for duplicates.
         # One option would be to 1) call get_resource() on the collection URL,
         # 2) extract all of the item URLs from the atom-xml response,
         # 3) call get_resource() on each URL in turn, and 4) check that none
@@ -92,7 +92,7 @@ class SwordV2Uploader(Uploader):
             deposit_receipt = self.api.complete_deposit(create_receipt.edit)
         except Exception as error:
             # In all cases, we need to delete the partially-created item
-            # For expected failures, log before attempting deletion, then just exit
+            # For expected failures, log before attempting deletion, then exit
             # For unexpected failures, attempt deletion then let program crash
             if isinstance(error, DisseminationError):
                 logging.error(error)
@@ -152,7 +152,8 @@ class SwordV2Uploader(Uploader):
                 'contributions') if n.get('mainContribution') is True]:
             first_name = contribution.get('firstName')
             orcid = contribution.get('contributor').get('orcid')
-            contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(
+            contributor_string = contribution.get(
+                'fullName') if first_name is None else "{}, {}".format(
                 contribution.get('lastName'), first_name)
             if orcid is not None:
                 contributor_string += ' [orcid: {}]'.format(orcid)
@@ -164,7 +165,8 @@ class SwordV2Uploader(Uploader):
         for isbn in [
             n.get('isbn').replace(
                 '-',
-                '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
+                '') for n in work_metadata.get('publications') if n.get('isbn')
+                is not None]:
             cul_pilot_metadata.add_field(
                 "dcterms_identifier", "isbn:{}".format(isbn))
         for language in [n.get('languageCode')
@@ -177,8 +179,9 @@ class SwordV2Uploader(Uploader):
 
     def profile_basic(self):
         """
-        Metadata profile based on DSpace configuration defaults i.e. SWORD profile
-        See https://github.com/DSpace/DSpace/blob/main/dspace/config/modules/swordv2-server.cfg
+        Metadata profile based on DSpace configuration defaults i.e.
+        SWORD profile. See
+        https://github.com/DSpace/DSpace/blob/main/dspace/config/modules/swordv2-server.cfg
         """
         work_metadata = self.metadata.get('data').get('work')
         basic_metadata = sword2.Entry(
@@ -217,11 +220,13 @@ class SwordV2Uploader(Uploader):
             # swordv2-server.atom.title
             dcterms_title=work_metadata.get('fullTitle'),
             # swordv2-server.simpledc.type
-            # "Recommended practice is to use a controlled vocabulary such as the DCMI Type Vocabulary"
-            # (see https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#section-7)
+            # "Recommended practice is to use a controlled vocabulary such as
+            # the DCMI Type Vocabulary" (see
+            # https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#section-7)
             dcterms_type='text',
 
-            # Not appropriate as we may be submitting multiple formats (PDF, XML etc):
+            # Not appropriate as we may be submitting multiple formats
+            # (PDF, XML etc):
             # # swordv2-server.simpledc.extent
             # dcterms_format_extent=
             # # swordv2-server.simpledc.format
@@ -240,18 +245,21 @@ class SwordV2Uploader(Uploader):
             # dcterms_date_submitted=
             # # swordv2-server.simpledc.isReferencedBy
             # dcterms_relation_isreferencedby=
-            # "A related resource that requires the described resource to support its function, delivery, or coherence"
+            # "A related resource that requires the described resource to
+            # support its function, delivery, or coherence"
             # # swordv2-server.simpledc.isRequiredBy
             # dcterms_relation_isrequiredby=
             # # swordv2-server.simpledc.modified
             # dcterms_date_modified=
             # # swordv2-server.simpledc.provenance
             # dcterms_description_provenance=
-            # "A related resource that is required by the described resource to support its function, delivery, or coherence"
+            # "A related resource that is required by the described resource to
+            # support its function, delivery, or coherence"
             # # swordv2-server.simpledc.requires
             # dcterms_relation_requires=
             # "A related resource from which the described resource is derived"
-            # (e.g. print version of scan); most cases would be covered by dc_relation fields
+            # (e.g. print version of scan); most cases would be covered by
+            # dc_relation fields
             # # swordv2-server.simpledc.source
             # dcterms_source=
         )
@@ -271,7 +279,8 @@ class SwordV2Uploader(Uploader):
         for isbn in [
             n.get('isbn').replace(
                 '-',
-                '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
+                '') for n in work_metadata.get('publications') if n.get('isbn')
+                is not None]:
             basic_metadata.add_field("dcterms_identifier", isbn)
         for language in [n.get('languageCode')
                          for n in work_metadata.get('languages')]:
@@ -282,7 +291,8 @@ class SwordV2Uploader(Uploader):
             # swordv2-server.simpledc.subject
             basic_metadata.add_field("dcterms_subject", subject)
         for (relation_type, relation_doi) in [(n.get('relationType'), n.get(
-                'relatedWork').get('doi')) for n in work_metadata.get('relations')]:
+                'relatedWork').get('doi'))
+                for n in work_metadata.get('relations')]:
             if relation_type == 'IS_PART_OF' or relation_type == 'IS_CHILD_OF':
                 # swordv2-server.simpledc.isPartOf
                 basic_metadata.add_field("dcterms_isPartOf", relation_doi)
@@ -301,7 +311,8 @@ class SwordV2Uploader(Uploader):
             (n.get('unstructuredCitation'),
              n.get('doi')) for n in work_metadata.get('references')]:
             # will always have one or the other (if not both)
-            reference = reference_citation if reference_citation else reference_doi
+            reference = (
+                reference_citation if reference_citation else reference_doi)
             # swordv2-server.simpledc.references
             basic_metadata.add_field("dcterms_references", reference)
         basic_metadata.add_field("dcterms_identifier",
@@ -311,7 +322,8 @@ class SwordV2Uploader(Uploader):
 
     def profile_jisc_router(self):
         """
-        Metadata profile based on Jisc Publications Router schema (currently articles-only)
+        Metadata profile based on Jisc Publications Router schema
+        (currently articles-only)
         See https://github.com/jisc-services/Public-Documentation/blob/master/PublicationsRouter/sword-out/DSpace-XML.md
         """
         work_metadata = self.metadata.get('data').get('work')
@@ -330,7 +342,8 @@ class SwordV2Uploader(Uploader):
             # dcterms_bibliographicCitation=
             # dcterms_dateAccepted=
             # "A related resource from which the described resource is derived"
-            # Jisc Router uses this to indicate the article's parent journal; not relevant for books
+            # Jisc Router uses this to indicate the article's parent journal;
+            # not relevant for books
             # dcterms_source=
         )
 
@@ -353,7 +366,8 @@ class SwordV2Uploader(Uploader):
             affiliations = contribution.get('affiliations')
             first_institution = next((a.get('institution').get(
                 'institutionName') for a in affiliations if affiliations), None)
-            contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(
+            contributor_string = contribution.get(
+                'fullName')if first_name is None else "{}, {}".format(
                 contribution.get('lastName'), first_name)
             if orcid is not None:
                 contributor_string += '; orcid: {}'.format(orcid)
@@ -407,9 +421,10 @@ class SwordV2Api:
             service_document_iri=service_document_iri,
             user_name=user_name,
             user_pass=user_pass,
-            # SWORD2 library doesn't handle timeout-related errors gracefully and large files
-            # (e.g. 50MB) can't be fully uploaded within the 30-second default timeout.
-            # Allow lots of leeway. (This otherwise matches the default `http_impl`.)
+            # SWORD2 library doesn't handle timeout-related errors gracefully
+            # and large files (e.g. 50MB) can't be fully uploaded within the
+            # 30-second default timeout. Allow lots of leeway. (This otherwise
+            # matches the default `http_impl`.)
             http_impl=sword2.http_layer.HttpLib2Layer(timeout=120.0)
         )
 
@@ -418,12 +433,14 @@ class SwordV2Api:
         return self.handle_request(
             request_type=RequestType.CREATE_ITEM,
             expected_status=201,
-            # Hacky workaround for an issue with mishandling of encodings within sword2 library,
-            # which meant metadata containing special characters could not be submitted.
-            # Although the `metadata_entry` parameter ought to be of type `Entry`, sending a
-            # `str` as below triggers no errors. Ultimately it's passed to `http/client.py/_encode()`,
-            # which defaults to encoding it as 'latin-1'. Pre-emptively encoding/decoding it here
-            # seems to mean that the string sent to the server is in correct utf-8 format.
+            # Hacky workaround for an issue with mishandling of encodings
+            # within sword2 library, which meant metadata containing special
+            # characters could not be submitted. Although the `metadata_entry`
+            # parameter ought to be of type `Entry`, sending a `str` as below
+            # triggers no errors. Ultimately it's passed to
+            # `http/client.py/_encode()`, which defaults to encoding it as
+            # 'latin-1'. Pre-emptively encoding/decoding it here seems to mean
+            # that the string sent to the server is in correct utf-8 format.
             metadata_entry=str(metadata_entry).encode(
                 'utf-8').decode('latin-1'),
         )
@@ -446,7 +463,10 @@ class SwordV2Api:
         )
 
     def upload_metadata(self, edit_media_iri, payload):
-        """Upload the supplied JSON metadata file (as bytes) under the specified item."""
+        """
+        Upload the supplied JSON metadata file (as bytes)
+        under the specified item.
+        """
         return self.handle_request(
             request_type=RequestType.UPLOAD_METADATA,
             expected_status=201,

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -29,10 +29,10 @@ class MetadataProfile(Enum):
 class SwordV2Uploader(Uploader):
     """Dissemination logic for SWORD v2"""
 
-    def __init__(self, work_id, export_url, version, user_name_string, user_pass_string,
+    def __init__(self, work_id, export_url, client_url, version, user_name_string, user_pass_string,
                  service_document_iri, collection_iri, metadata_profile):
         """Create connection to SWORD v2 endpoint"""
-        super().__init__(work_id, export_url, version)
+        super().__init__(work_id, export_url, client_url, version)
         try:
             user_name = self.get_credential_from_env(
                 user_name_string, 'SWORD v2')

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -101,6 +101,10 @@ class SwordV2Uploader(Uploader):
             logging.error(
                 'Could not connect to SWORD v2 server: authorisation failed')
             sys.exit(1)
+        except sword2.HTTPResponseError as error:
+            logging.error(
+                'Could not connect to SWORD v2 server (status code {})'.format(error.response['status']))
+            sys.exit(1)
 
         if request_receipt.code != expected_status:
             # Placeholder for error message

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -131,105 +131,104 @@ class SwordV2Uploader(Uploader):
         basic_metadata = sword2.Entry(
             # swordv2-server.simpledc.abstract
             # swordv2-server.atom.summary
-            dcterms_description_abstract=work_metadata.get('longAbstract'),
+            dc_description_abstract=work_metadata.get('longAbstract'),
             # swordv2-server.simpledc.description
-            dcterms_description=work_metadata.get('longAbstract'),
+            dc_description=work_metadata.get('longAbstract'),
             # swordv2-server.simpledc.accessRights
             # swordv2-server.simpledc.rights
             # swordv2-server.simpledc.rightsHolder
             # swordv2-server.atom.rights
-            dcterms_rights=work_metadata.get('license'),
+            dc_rights=work_metadata.get('license'),
             # swordv2-server.simpledc.available
-            dcterms_date_available=work_metadata.get('publicationDate'),
+            dc_date_available=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.created
             # swordv2-server.atom.published
             # swordv2-server.atom.updated
-            dcterms_date_created=work_metadata.get('publicationDate'),
+            dc_date_created=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.date
-            dcterms_date=work_metadata.get('publicationDate'),
+            dc_date=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.issued
-            dcterms_date_issued=work_metadata.get('publicationDate'),
+            dc_date_issued=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.publisher
-            dcterms_publisher=self.get_publisher_name(),
+            dc_publisher=self.get_publisher_name(),
             # swordv2-server.simpledc.coverage
-            dcterms_coverage='open access',
+            dc_coverage='open access',
             # swordv2-server.simpledc.spatial
-            dcterms_coverage_spatial='global',
+            dc_coverage_spatial='global',
             # swordv2-server.simpledc.temporal
-            dcterms_coverage_temporal='all time',
+            dc_coverage_temporal='all time',
             # swordv2-server.simpledc.title
             # swordv2-server.atom.title
-            dcterms_title=work_metadata.get('fullTitle'),
+            dc_title=work_metadata.get('fullTitle'),
             # swordv2-server.simpledc.type
             # "Recommended practice is to use a controlled vocabulary such as the DCMI Type Vocabulary"
             # (see https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#section-7)
-            dcterms_type='text',
-            #^should we Include the dcmitype namespace for this?
+            dc_type='text',
 
             # TODO Thoth stores relations/references but not currently retrieved by Thoth Client:
             # # swordv2-server.simpledc.isPartOf
-            # dcterms_relation_ispartof=
+            # dc_relation_ispartof=
             # # swordv2-server.simpledc.isReplacedBy
-            # dcterms_relation_isreplacedby=
+            # dc_relation_isreplacedby=
             # # swordv2-server.simpledc.references
-            # dcterms_relation_references=
+            # dc_relation_references=
             # # swordv2-server.simpledc.relation
-            # dcterms_relation=
+            # dc_relation=
             # # swordv2-server.simpledc.replaces
-            # dcterms_relation_replaces=
+            # dc_relation_replaces=
 
             # Not appropriate as we may be submitting multiple formats (PDF, XML etc):
             # # swordv2-server.simpledc.extent
-            # dcterms_format_extent=
+            # dc_format_extent=
             # # swordv2-server.simpledc.format
-            # dcterms_format=
+            # dc_format=
             # # swordv2-server.simpledc.medium
-            # dcterms_format_medium=
+            # dc_format_medium=
 
             # Not supported by Thoth:
             # # swordv2-server.simpledc.alternative
-            # dcterms_title_alternative=
+            # dc_title_alternative=
             # # swordv2-server.simpledc.bibliographicCitation
-            # dcterms_identifier_citation=
+            # dc_identifier_citation=
             # # swordv2-server.simpledc.dateAccepted
-            # dcterms_date_accepted=
+            # dc_date_accepted=
             # # swordv2-server.simpledc.dateSubmitted
-            # dcterms_date_submitted=
+            # dc_date_submitted=
             # # swordv2-server.simpledc.isReferencedBy
-            # dcterms_relation_isreferencedby=
+            # dc_relation_isreferencedby=
             # "A related resource that requires the described resource to support its function, delivery, or coherence"
             # # swordv2-server.simpledc.isRequiredBy
-            # dcterms_relation_isrequiredby=
+            # dc_relation_isrequiredby=
             # # swordv2-server.simpledc.modified
-            # dcterms_date_modified=
+            # dc_date_modified=
             # # swordv2-server.simpledc.provenance
-            # dcterms_description_provenance=
+            # dc_description_provenance=
             # "A related resource that is required by the described resource to support its function, delivery, or coherence"
             # # swordv2-server.simpledc.requires
-            # dcterms_relation_requires=
+            # dc_relation_requires=
             # "A related resource from which the described resource is derived"
             # (e.g. print version of scan); most cases would be covered by dc_relation fields
             # # swordv2-server.simpledc.source
-            # dcterms_source=
+            # dc_source=
         )
 
         for contributor in [n.get('fullName') for n in work_metadata.get('contributions') if n.get('mainContribution') == True]:
             # swordv2-server.simpledc.contributor
-            basic_metadata.add_field("dcterms_contributor", contributor)
+            basic_metadata.add_field("dc_contributor", contributor)
             # swordv2-server.simpledc.creator
             # swordv2-server.atom.author
-            basic_metadata.add_field("dcterms_contributor_author", contributor)
+            basic_metadata.add_field("dc_contributor_author", contributor)
         # swordv2-server.simpledc.identifier
-        basic_metadata.add_field("dcterms_identifier", work_metadata.get('doi'))
+        basic_metadata.add_field("dc_identifier", work_metadata.get('doi'))
         for isbn in [n.get('isbn').replace(
                 '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
-            basic_metadata.add_field("dcterms_identifier", isbn)
+            basic_metadata.add_field("dc_identifier", isbn)
         for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
             # swordv2-server.simpledc.language
-            basic_metadata.add_field("dcterms_language", language)
+            basic_metadata.add_field("dc_language", language)
         for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
             # swordv2-server.simpledc.subject
-            basic_metadata.add_field("dcterms_subject", subject)
+            basic_metadata.add_field("dc_subject", subject)
 
         return basic_metadata
 

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -37,8 +37,8 @@ class SwordV2Uploader(Uploader):
     def upload_to_platform(self):
         """Upload work in required format to SWORD v2"""
 
-        # Metadata file format TBD: use CSV for now
-        metadata_bytes = self.get_formatted_metadata('csv::thoth')
+        # Metadata file format TBD: use JSON for now
+        metadata_bytes = self.get_formatted_metadata('json::thoth')
         # Can't continue if no PDF file is present
         try:
             pdf_bytes = self.get_publication_bytes('PDF')
@@ -97,8 +97,8 @@ class SwordV2Uploader(Uploader):
                 edit_media_iri=receipt.edit_media,
                 payload=metadata_bytes,
                 # Filename TBD: use work ID for now
-                filename='{}.csv'.format(self.work_id),
-                mimetype='text/csv',
+                filename='{}.json'.format(self.work_id),
+                mimetype='application/json',
                 in_progress=True,
             )
         except sword2.exceptions.Forbidden:

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -110,7 +110,7 @@ class SwordV2Uploader(Uploader):
         discussion with CUL (requiring configuration work on their side)
         """
         work_metadata = self.metadata.get('data').get('work')
-        sword_metadata = sword2.Entry(
+        cul_pilot_metadata = sword2.Entry(
             # All fields are non-mandatory and any None values are ignored on ingest
             # (within Apollo DSpace 7 - yet to test other SWORD2-based platforms)
             # Some of the below fields do not appear to be stored/
@@ -131,17 +131,17 @@ class SwordV2Uploader(Uploader):
             contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(contribution.get('lastName'), first_name)
             if orcid is not None:
                 contributor_string += ' [orcid: {}]'.format(orcid)
-            sword_metadata.add_field("dcterms_contributor", contributor_string)
+            cul_pilot_metadata.add_field("dcterms_contributor", contributor_string)
         for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
-            sword_metadata.add_field("dcterms_subject", subject)
+            cul_pilot_metadata.add_field("dcterms_subject", subject)
         for isbn in [n.get('isbn').replace(
                 '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
-            sword_metadata.add_field("dcterms_identifier", "isbn:{}".format(isbn))
+            cul_pilot_metadata.add_field("dcterms_identifier", "isbn:{}".format(isbn))
         for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
-            sword_metadata.add_field("dcterms_language", language)
-        sword_metadata.add_field("dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
+            cul_pilot_metadata.add_field("dcterms_language", language)
+        cul_pilot_metadata.add_field("dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
 
-        return sword_metadata
+        return cul_pilot_metadata
 
     def profile_basic(self):
         """
@@ -187,7 +187,6 @@ class SwordV2Uploader(Uploader):
             # "Recommended practice is to use a controlled vocabulary such as the DCMI Type Vocabulary"
             # (see https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#section-7)
             dcterms_type='text',
-            #^should we Include the dcmitype namespace for this?
 
             # Not appropriate as we may be submitting multiple formats (PDF, XML etc):
             # # swordv2-server.simpledc.extent

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -29,8 +29,17 @@ class MetadataProfile(Enum):
 class SwordV2Uploader(Uploader):
     """Dissemination logic for SWORD v2"""
 
-    def __init__(self, work_id, export_url, client_url, version, user_name_string, user_pass_string,
-                 service_document_iri, collection_iri, metadata_profile):
+    def __init__(
+            self,
+            work_id,
+            export_url,
+            client_url,
+            version,
+            user_name_string,
+            user_pass_string,
+            service_document_iri,
+            collection_iri,
+            metadata_profile):
         """Create connection to SWORD v2 endpoint"""
         super().__init__(work_id, export_url, client_url, version)
         try:
@@ -139,7 +148,8 @@ class SwordV2Uploader(Uploader):
             dcterms_tableOfContents=work_metadata.get('toc'),
         )
         # Workaround for adding repeatable fields
-        for contribution in [n for n in work_metadata.get('contributions') if n.get('mainContribution') is True]:
+        for contribution in [n for n in work_metadata.get(
+                'contributions') if n.get('mainContribution') is True]:
             first_name = contribution.get('firstName')
             orcid = contribution.get('contributor').get('orcid')
             contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(
@@ -148,13 +158,17 @@ class SwordV2Uploader(Uploader):
                 contributor_string += ' [orcid: {}]'.format(orcid)
             cul_pilot_metadata.add_field(
                 "dcterms_contributor", contributor_string)
-        for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
+        for subject in [n.get('subjectCode')
+                        for n in work_metadata.get('subjects')]:
             cul_pilot_metadata.add_field("dcterms_subject", subject)
-        for isbn in [n.get('isbn').replace(
-                '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
+        for isbn in [
+            n.get('isbn').replace(
+                '-',
+                '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
             cul_pilot_metadata.add_field(
                 "dcterms_identifier", "isbn:{}".format(isbn))
-        for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
+        for language in [n.get('languageCode')
+                         for n in work_metadata.get('languages')]:
             cul_pilot_metadata.add_field("dcterms_language", language)
         cul_pilot_metadata.add_field(
             "dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
@@ -242,27 +256,33 @@ class SwordV2Uploader(Uploader):
             # dcterms_source=
         )
 
-        for contributor in [n.get('fullName') for n in work_metadata.get('contributions') if n.get('mainContribution') is True]:
+        for contributor in [n.get('fullName') for n in work_metadata.get(
+                'contributions') if n.get('mainContribution') is True]:
             # swordv2-server.simpledc.contributor
             basic_metadata.add_field("dcterms_contributor", contributor)
             # swordv2-server.simpledc.creator
             # swordv2-server.atom.author
-            # Doesn't seem to work; not clear how to represent "dc.contributor.author" in dcterms
+            # Doesn't seem to work; not clear how to represent
+            # "dc.contributor.author" in dcterms
             basic_metadata.add_field("dcterms_author", contributor)
         # swordv2-server.simpledc.identifier
         basic_metadata.add_field("dcterms_identifier",
                                  work_metadata.get('doi'))
-        for isbn in [n.get('isbn').replace(
-                '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
+        for isbn in [
+            n.get('isbn').replace(
+                '-',
+                '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
             basic_metadata.add_field("dcterms_identifier", isbn)
-        for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
+        for language in [n.get('languageCode')
+                         for n in work_metadata.get('languages')]:
             # swordv2-server.simpledc.language
             basic_metadata.add_field("dcterms_language", language)
-        for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
+        for subject in [n.get('subjectCode')
+                        for n in work_metadata.get('subjects')]:
             # swordv2-server.simpledc.subject
             basic_metadata.add_field("dcterms_subject", subject)
-        for (relation_type, relation_doi) in [(n.get('relationType'), n.get('relatedWork').get('doi'))
-                                              for n in work_metadata.get('relations')]:
+        for (relation_type, relation_doi) in [(n.get('relationType'), n.get(
+                'relatedWork').get('doi')) for n in work_metadata.get('relations')]:
             if relation_type == 'IS_PART_OF' or relation_type == 'IS_CHILD_OF':
                 # swordv2-server.simpledc.isPartOf
                 basic_metadata.add_field("dcterms_isPartOf", relation_doi)
@@ -275,8 +295,11 @@ class SwordV2Uploader(Uploader):
             else:
                 # swordv2-server.simpledc.relation
                 basic_metadata.add_field("dcterms_relation", relation_doi)
-        for (reference_citation, reference_doi) in [(n.get('unstructuredCitation'), n.get('doi'))
-                                                    for n in work_metadata.get('references')]:
+        for (
+            reference_citation,
+            reference_doi) in [
+            (n.get('unstructuredCitation'),
+             n.get('doi')) for n in work_metadata.get('references')]:
             # will always have one or the other (if not both)
             reference = reference_citation if reference_citation else reference_doi
             # swordv2-server.simpledc.references
@@ -311,15 +334,20 @@ class SwordV2Uploader(Uploader):
             # dcterms_source=
         )
 
-        for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
+        for language in [n.get('languageCode')
+                         for n in work_metadata.get('languages')]:
             jisc_router_metadata.add_field("dcterms_language", language)
-        for isbn in [n.get('isbn').replace(
-                '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
+        for isbn in [
+            n.get('isbn').replace(
+                '-',
+                '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
             jisc_router_metadata.add_field(
                 "dcterms_identifier", "isbn: {}".format(isbn))
-        for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
+        for subject in [n.get('subjectCode')
+                        for n in work_metadata.get('subjects')]:
             jisc_router_metadata.add_field("dcterms_subject", subject)
-        for contribution in [n for n in work_metadata.get('contributions') if n.get('mainContribution') is True]:
+        for contribution in [n for n in work_metadata.get(
+                'contributions') if n.get('mainContribution') is True]:
             first_name = contribution.get('firstName')
             orcid = contribution.get('contributor').get('orcid')
             affiliations = contribution.get('affiliations')
@@ -336,20 +364,24 @@ class SwordV2Uploader(Uploader):
                 jisc_router_metadata.add_field(
                     "dcterms_creator", contributor_string)
             else:
-                jisc_router_metadata.add_field("dcterms_contributor", "{}: {}".format(
-                    contribution_type, contributor_string))
+                jisc_router_metadata.add_field(
+                    "dcterms_contributor", "{}: {}".format(
+                        contribution_type, contributor_string))
         jisc_router_metadata.add_field("dcterms_rights", "Embargo: none")
         jisc_router_metadata.add_field(
             "dcterms_description", "Work version: VoR")
         jisc_router_metadata.add_field(
-            "dcterms_description", "From {} via Thoth".format(self.get_publisher_name()))
+            "dcterms_description",
+            "From {} via Thoth".format(
+                self.get_publisher_name()))
         for funding in work_metadata.get('fundings'):
             funding_string = "Funder: {}".format(
                 funding.get('institution').get('institutionName'))
             ror = funding.get('institution').get('ror')
             doi = funding.get('institution').get('institutionDoi')
             grant_number = funding.get('grantNumber')
-            # Schema states comma-separated but actual Publications Router data is semicolon-separated
+            # Schema states comma-separated but actual Publications Router
+            # data is semicolon-separated
             if ror is not None:
                 funding_string += "; ror: {}".format(ror)
             elif doi is not None:
@@ -366,7 +398,8 @@ class SwordV2Uploader(Uploader):
 
 class SwordV2Api:
 
-    def __init__(self, work_id, user_name, user_pass, service_document_iri, collection_iri):
+    def __init__(self, work_id, user_name, user_pass,
+                 service_document_iri, collection_iri):
         """Set up connection to API."""
         self.work_id = work_id
         self.collection_iri = collection_iri
@@ -440,7 +473,8 @@ class SwordV2Api:
                 'Could not connect to SWORD v2 server: authorisation failed')
         except sword2.HTTPResponseError as error:
             raise DisseminationError(
-                'Could not connect to SWORD v2 server (status code {})'.format(error.response['status']))
+                'Could not connect to SWORD v2 server (status code {})'.format(
+                    error.response['status']))
 
         # Receipt may not contain useful information
         if request_receipt.code != expected_status:

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -128,7 +128,9 @@ class SwordV2Uploader(Uploader):
         See https://github.com/DSpace/DSpace/blob/main/dspace/config/modules/swordv2-server.cfg
         """
         work_metadata = self.metadata.get('data').get('work')
-        basic_metadata = sword2.Entry(
+        basic_metadata = sword2.Entry()
+        basic_metadata.register_namespace("dc", "http://purl.org/dc/elements/1.1/")
+        basic_metadata.add_fields(
             # swordv2-server.simpledc.abstract
             # swordv2-server.atom.summary
             dc_description_abstract=work_metadata.get('longAbstract'),

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -168,10 +168,6 @@ class SwordV2Uploader(Uploader):
             dcterms_type='text',
             #^should we Include the dcmitype namespace for this?
 
-            # TODO Thoth stores relations/references but not currently retrieved by Thoth Client:
-            # # swordv2-server.simpledc.references
-            # dcterms_relation_references=
-
             # Not appropriate as we may be submitting multiple formats (PDF, XML etc):
             # # swordv2-server.simpledc.extent
             # dcterms_format_extent=
@@ -239,6 +235,13 @@ class SwordV2Uploader(Uploader):
             else:
                 # swordv2-server.simpledc.relation
                 basic_metadata.add_field("dcterms_relation", relation_doi)
+        # Caused error 500 when submitted to DSpace server
+        # for (reference_citation, reference_doi) in [(n.get('unstructuredCitation'), n.get('doi'))
+        #         for n in work_metadata.get('references')]:
+        #     # will always have one or the other (if not both)
+        #     reference = reference_citation if reference_citation else reference_doi
+        #     # swordv2-server.simpledc.references
+        #     basic_metadata.add_field("dcterms_references", reference)
 
         return basic_metadata
 

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -151,8 +151,9 @@ class SwordV2Uploader(Uploader):
             dcterms_date_issued=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.publisher
             dcterms_publisher=self.get_publisher_name(),
-            # swordv2-server.simpledc.coverage
-            dcterms_coverage='open access',
+            # Caused error 500 when submitted to DSpace server
+            # # swordv2-server.simpledc.coverage
+            # dcterms_coverage='open access',
             # swordv2-server.simpledc.spatial
             dcterms_coverage_spatial='global',
             # swordv2-server.simpledc.temporal

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -100,16 +100,19 @@ class SwordV2Uploader(Uploader):
                 self.api.delete_item(create_receipt.edit)
             except DisseminationError as deletion_error:
                 logging.error(
-                    'Failed to delete incomplete item: {}'.format(deletion_error))
+                    'Failed to delete incomplete item: {}'.format(
+                        deletion_error))
             if isinstance(error, DisseminationError):
                 sys.exit(1)
             else:
                 raise
 
         logging.info(
-            # If automatic deposit (no curation) is enabled, `alternate` should show
-            # the front-end URL of the upload (alternatively, use `location` for back-end URL)
-            'Successfully uploaded to SWORD v2 at {}'.format(deposit_receipt.alternate))
+            # If automatic deposit (no curation) is enabled, `alternate`
+            # should show the front-end URL of the upload (alternatively,
+            # use `location` for back-end URL)
+            'Successfully uploaded to SWORD v2 at {}'.format(
+                deposit_receipt.alternate))
 
     def parse_metadata(self):
         """Convert work metadata into SWORD v2 format"""
@@ -324,7 +327,8 @@ class SwordV2Uploader(Uploader):
         """
         Metadata profile based on Jisc Publications Router schema
         (currently articles-only)
-        See https://github.com/jisc-services/Public-Documentation/blob/master/PublicationsRouter/sword-out/DSpace-XML.md
+        See https://github.com/jisc-services/Public-Documentation/blob/master/
+        PublicationsRouter/sword-out/DSpace-XML.md
         """
         work_metadata = self.metadata.get('data').get('work')
         jisc_router_metadata = sword2.Entry(
@@ -353,7 +357,8 @@ class SwordV2Uploader(Uploader):
         for isbn in [
             n.get('isbn').replace(
                 '-',
-                '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
+                '') for n in work_metadata.get('publications') if n.get('isbn')
+                is not None]:
             jisc_router_metadata.add_field(
                 "dcterms_identifier", "isbn: {}".format(isbn))
         for subject in [n.get('subjectCode')
@@ -365,7 +370,8 @@ class SwordV2Uploader(Uploader):
             orcid = contribution.get('contributor').get('orcid')
             affiliations = contribution.get('affiliations')
             first_institution = next((a.get('institution').get(
-                'institutionName') for a in affiliations if affiliations), None)
+                'institutionName') for a in affiliations if affiliations),
+                None)
             contributor_string = contribution.get(
                 'fullName')if first_name is None else "{}, {}".format(
                 contribution.get('lastName'), first_name)

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -298,12 +298,13 @@ class SwordV2Uploader(Uploader):
             ror = funding.get('institution').get('ror')
             doi = funding.get('institution').get('institutionDoi')
             grant_number = funding.get('grantNumber')
+            # Schema states comma-separated but actual Publications Router data is semicolon-separated
             if ror is not None:
-                funding_string += ", ror: {}".format(ror)
+                funding_string += "; ror: {}".format(ror)
             elif doi is not None:
-                funding_string += ", doi: {}".format(doi)
+                funding_string += "; doi: {}".format(doi)
             if grant_number is not None:
-                funding_string += ", Grant(s): {}".format(grant_number)
+                funding_string += "; Grant(s): {}".format(grant_number)
             jisc_router_metadata.add_field("dcterms_description", funding_string)
 
         return jisc_router_metadata

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -128,9 +128,7 @@ class SwordV2Uploader(Uploader):
         See https://github.com/DSpace/DSpace/blob/main/dspace/config/modules/swordv2-server.cfg
         """
         work_metadata = self.metadata.get('data').get('work')
-        basic_metadata = sword2.Entry()
-        basic_metadata.register_namespace("dc", "http://purl.org/dc/elements/1.1/")
-        basic_metadata.add_fields(
+        basic_metadata = sword2.Entry(
             # swordv2-server.simpledc.abstract
             # swordv2-server.atom.summary
             dc_description_abstract=work_metadata.get('longAbstract'),

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -115,7 +115,7 @@ class SwordV2Api:
     def __init__(self, work_id, user_name, user_pass):
         self.work_id = work_id
         self.conn = sword2.Connection(
-            service_document_iri="https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7",
+            service_document_iri="https://copim-b-dev.lib.cam.ac.uk/server/swordv2/servicedocument",
             user_name=user_name,
             user_pass=user_pass,
             # SWORD2 library doesn't handle timeout-related errors gracefully and large files

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -36,11 +36,13 @@ class SwordV2Uploader(Uploader):
         try:
             user_name = self.get_credential_from_env(
                 user_name_string, 'SWORD v2')
-            user_pass = self.get_credential_from_env(user_pass_string, 'SWORD v2')
+            user_pass = self.get_credential_from_env(
+                user_pass_string, 'SWORD v2')
         except DisseminationError as error:
             logging.error(error)
             sys.exit(1)
-        self.api = SwordV2Api(work_id, user_name, user_pass, service_document_iri, collection_iri)
+        self.api = SwordV2Api(work_id, user_name, user_pass,
+                              service_document_iri, collection_iri)
         self.metadata_profile = metadata_profile
 
     def upload_to_platform(self):
@@ -88,7 +90,8 @@ class SwordV2Uploader(Uploader):
             try:
                 self.api.delete_item(create_receipt.edit)
             except DisseminationError as deletion_error:
-                logging.error('Failed to delete incomplete item: {}'.format(deletion_error))
+                logging.error(
+                    'Failed to delete incomplete item: {}'.format(deletion_error))
             if isinstance(error, DisseminationError):
                 sys.exit(1)
             else:
@@ -139,18 +142,22 @@ class SwordV2Uploader(Uploader):
         for contribution in [n for n in work_metadata.get('contributions') if n.get('mainContribution') == True]:
             first_name = contribution.get('firstName')
             orcid = contribution.get('contributor').get('orcid')
-            contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(contribution.get('lastName'), first_name)
+            contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(
+                contribution.get('lastName'), first_name)
             if orcid is not None:
                 contributor_string += ' [orcid: {}]'.format(orcid)
-            cul_pilot_metadata.add_field("dcterms_contributor", contributor_string)
+            cul_pilot_metadata.add_field(
+                "dcterms_contributor", contributor_string)
         for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
             cul_pilot_metadata.add_field("dcterms_subject", subject)
         for isbn in [n.get('isbn').replace(
                 '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
-            cul_pilot_metadata.add_field("dcterms_identifier", "isbn:{}".format(isbn))
+            cul_pilot_metadata.add_field(
+                "dcterms_identifier", "isbn:{}".format(isbn))
         for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
             cul_pilot_metadata.add_field("dcterms_language", language)
-        cul_pilot_metadata.add_field("dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
+        cul_pilot_metadata.add_field(
+            "dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
 
         return cul_pilot_metadata
 
@@ -178,7 +185,8 @@ class SwordV2Uploader(Uploader):
             # swordv2-server.simpledc.created
             # swordv2-server.atom.published
             # swordv2-server.atom.updated
-            dcterms_created="{}T00:00:00Z".format(work_metadata.get('publicationDate')),
+            dcterms_created="{}T00:00:00Z".format(
+                work_metadata.get('publicationDate')),
             # swordv2-server.simpledc.date
             dcterms_date=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.issued
@@ -242,7 +250,8 @@ class SwordV2Uploader(Uploader):
             # Doesn't seem to work; not clear how to represent "dc.contributor.author" in dcterms
             basic_metadata.add_field("dcterms_author", contributor)
         # swordv2-server.simpledc.identifier
-        basic_metadata.add_field("dcterms_identifier", work_metadata.get('doi'))
+        basic_metadata.add_field("dcterms_identifier",
+                                 work_metadata.get('doi'))
         for isbn in [n.get('isbn').replace(
                 '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
             basic_metadata.add_field("dcterms_identifier", isbn)
@@ -253,7 +262,7 @@ class SwordV2Uploader(Uploader):
             # swordv2-server.simpledc.subject
             basic_metadata.add_field("dcterms_subject", subject)
         for (relation_type, relation_doi) in [(n.get('relationType'), n.get('relatedWork').get('doi'))
-                for n in work_metadata.get('relations')]:
+                                              for n in work_metadata.get('relations')]:
             if relation_type == 'IS_PART_OF' or relation_type == 'IS_CHILD_OF':
                 # swordv2-server.simpledc.isPartOf
                 basic_metadata.add_field("dcterms_isPartOf", relation_doi)
@@ -267,12 +276,13 @@ class SwordV2Uploader(Uploader):
                 # swordv2-server.simpledc.relation
                 basic_metadata.add_field("dcterms_relation", relation_doi)
         for (reference_citation, reference_doi) in [(n.get('unstructuredCitation'), n.get('doi'))
-                for n in work_metadata.get('references')]:
+                                                    for n in work_metadata.get('references')]:
             # will always have one or the other (if not both)
             reference = reference_citation if reference_citation else reference_doi
             # swordv2-server.simpledc.references
             basic_metadata.add_field("dcterms_references", reference)
-        basic_metadata.add_field("dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
+        basic_metadata.add_field("dcterms_identifier",
+                                 "thoth-work-id:{}".format(self.work_id))
 
         return basic_metadata
 
@@ -288,8 +298,10 @@ class SwordV2Uploader(Uploader):
             dcterms_abstract=work_metadata.get('longAbstract'),
             dcterms_identifier="doi: {}".format(work_metadata.get('doi')),
             dcterms_issued=work_metadata.get('publicationDate'),
-            dcterms_rights="License for VoR version of this work: {}".format(work_metadata.get('license')),
-            dcterms_description="Publication status: {}".format(work_metadata.get('workStatus')),
+            dcterms_rights="License for VoR version of this work: {}".format(
+                work_metadata.get('license')),
+            dcterms_description="Publication status: {}".format(
+                work_metadata.get('workStatus')),
 
             # Not supported by Thoth:
             # dcterms_bibliographicCitation=
@@ -303,29 +315,37 @@ class SwordV2Uploader(Uploader):
             jisc_router_metadata.add_field("dcterms_language", language)
         for isbn in [n.get('isbn').replace(
                 '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]:
-            jisc_router_metadata.add_field("dcterms_identifier", "isbn: {}".format(isbn))
+            jisc_router_metadata.add_field(
+                "dcterms_identifier", "isbn: {}".format(isbn))
         for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
             jisc_router_metadata.add_field("dcterms_subject", subject)
         for contribution in [n for n in work_metadata.get('contributions') if n.get('mainContribution') == True]:
             first_name = contribution.get('firstName')
             orcid = contribution.get('contributor').get('orcid')
             affiliations = contribution.get('affiliations')
-            first_institution = next((a.get('institution').get('institutionName') for a in affiliations if affiliations), None)
-            contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(contribution.get('lastName'), first_name)
+            first_institution = next((a.get('institution').get(
+                'institutionName') for a in affiliations if affiliations), None)
+            contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(
+                contribution.get('lastName'), first_name)
             if orcid is not None:
                 contributor_string += '; orcid: {}'.format(orcid)
             if first_institution is not None:
                 contributor_string += '; {}'.format(first_institution)
             contribution_type = contribution.get('contributionType')
             if contribution_type == 'AUTHOR':
-                jisc_router_metadata.add_field("dcterms_creator", contributor_string)
+                jisc_router_metadata.add_field(
+                    "dcterms_creator", contributor_string)
             else:
-                jisc_router_metadata.add_field("dcterms_contributor", "{}: {}".format(contribution_type, contributor_string))
+                jisc_router_metadata.add_field("dcterms_contributor", "{}: {}".format(
+                    contribution_type, contributor_string))
         jisc_router_metadata.add_field("dcterms_rights", "Embargo: none")
-        jisc_router_metadata.add_field("dcterms_description", "Work version: VoR")
-        jisc_router_metadata.add_field("dcterms_description", "From {} via Thoth".format(self.get_publisher_name()))
+        jisc_router_metadata.add_field(
+            "dcterms_description", "Work version: VoR")
+        jisc_router_metadata.add_field(
+            "dcterms_description", "From {} via Thoth".format(self.get_publisher_name()))
         for funding in work_metadata.get('fundings'):
-            funding_string = "Funder: {}".format(funding.get('institution').get('institutionName'))
+            funding_string = "Funder: {}".format(
+                funding.get('institution').get('institutionName'))
             ror = funding.get('institution').get('ror')
             doi = funding.get('institution').get('institutionDoi')
             grant_number = funding.get('grantNumber')
@@ -336,8 +356,10 @@ class SwordV2Uploader(Uploader):
                 funding_string += "; doi: {}".format(doi)
             if grant_number is not None:
                 funding_string += "; Grant(s): {}".format(grant_number)
-            jisc_router_metadata.add_field("dcterms_description", funding_string)
-        jisc_router_metadata.add_field("dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
+            jisc_router_metadata.add_field(
+                "dcterms_description", funding_string)
+        jisc_router_metadata.add_field(
+            "dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
 
         return jisc_router_metadata
 
@@ -423,11 +445,14 @@ class SwordV2Api:
         # Receipt may not contain useful information
         if request_receipt.code != expected_status:
             if request_type == RequestType.CREATE_ITEM:
-                raise DisseminationError('Error uploading item data to SWORD v2')
+                raise DisseminationError(
+                    'Error uploading item data to SWORD v2')
             elif request_type == RequestType.UPLOAD_PDF:
-                raise DisseminationError('Error uploading PDF file to SWORD v2')
+                raise DisseminationError(
+                    'Error uploading PDF file to SWORD v2')
             elif request_type == RequestType.UPLOAD_METADATA:
-                raise DisseminationError('Error uploading metadata file to SWORD v2')
+                raise DisseminationError(
+                    'Error uploading metadata file to SWORD v2')
             elif request_type == RequestType.COMPLETE_DEPOSIT:
                 raise DisseminationError('Error publishing item to SWORD v2')
             elif request_type == RequestType.DELETE_ITEM:

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -131,7 +131,7 @@ class SwordV2Uploader(Uploader):
         basic_metadata = sword2.Entry(
             # swordv2-server.simpledc.abstract
             # swordv2-server.atom.summary
-            dcterms_description_abstract=work_metadata.get('longAbstract'),
+            dcterms_abstract=work_metadata.get('longAbstract'),
             # swordv2-server.simpledc.description
             dcterms_description=work_metadata.get('longAbstract'),
             # swordv2-server.simpledc.accessRights
@@ -140,24 +140,24 @@ class SwordV2Uploader(Uploader):
             # swordv2-server.atom.rights
             dcterms_rights=work_metadata.get('license'),
             # swordv2-server.simpledc.available
-            dcterms_date_available=work_metadata.get('publicationDate'),
+            dcterms_available=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.created
             # swordv2-server.atom.published
             # swordv2-server.atom.updated
-            dcterms_date_created=work_metadata.get('publicationDate'),
+            dcterms_created=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.date
             dcterms_date=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.issued
-            dcterms_date_issued=work_metadata.get('publicationDate'),
+            dcterms_issued=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.publisher
             dcterms_publisher=self.get_publisher_name(),
             # Caused error 500 when submitted to DSpace server
             # # swordv2-server.simpledc.coverage
             # dcterms_coverage='open access',
             # swordv2-server.simpledc.spatial
-            dcterms_coverage_spatial='global',
+            dcterms_spatial='global',
             # swordv2-server.simpledc.temporal
-            dcterms_coverage_temporal='all time',
+            dcterms_temporal='all time',
             # swordv2-server.simpledc.title
             # swordv2-server.atom.title
             dcterms_title=work_metadata.get('fullTitle'),
@@ -219,7 +219,8 @@ class SwordV2Uploader(Uploader):
             basic_metadata.add_field("dcterms_contributor", contributor)
             # swordv2-server.simpledc.creator
             # swordv2-server.atom.author
-            basic_metadata.add_field("dcterms_contributor_author", contributor)
+            # Doesn't seem to work; not clear how to represent "dc.contributor.author" in dcterms
+            basic_metadata.add_field("dcterms_author", contributor)
         # swordv2-server.simpledc.identifier
         basic_metadata.add_field("dcterms_identifier", work_metadata.get('doi'))
         for isbn in [n.get('isbn').replace(

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -115,7 +115,7 @@ class SwordV2Api:
     def __init__(self, work_id, user_name, user_pass):
         self.work_id = work_id
         self.conn = sword2.Connection(
-            service_document_iri='https://dspace7-back.lib.cam.ac.uk/server/swordv2/collection/1810/339712',
+            service_document_iri="https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7",
             user_name=user_name,
             user_pass=user_pass,
             # SWORD2 library doesn't handle timeout-related errors gracefully and large files
@@ -196,7 +196,7 @@ class SwordV2Api:
     def send_request(self, request_type, **kwargs):
         if request_type == RequestType.CREATE_ITEM:
             request_receipt = self.conn.create(
-                col_iri='https://dspace7-back.lib.cam.ac.uk/server/swordv2/collection/1810/339712',
+                col_iri="https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/7",
                 in_progress=True,
                 # Required kwargs: metadata_entry
                 **kwargs,

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -141,10 +141,11 @@ class SwordV2Uploader(Uploader):
             dcterms_rights=work_metadata.get('license'),
             # swordv2-server.simpledc.available
             dcterms_available=work_metadata.get('publicationDate'),
-            # swordv2-server.simpledc.created
-            # swordv2-server.atom.published
-            # swordv2-server.atom.updated
-            dcterms_created=work_metadata.get('publicationDate'),
+            # Caused error 500 when submitted to DSpace server
+            # # swordv2-server.simpledc.created
+            # # swordv2-server.atom.published
+            # # swordv2-server.atom.updated
+            # dcterms_created=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.date
             dcterms_date=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.issued

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -142,20 +142,20 @@ class SwordV2Uploader(Uploader):
             dcterms_rights=work_metadata.get('license'),
             # swordv2-server.simpledc.available
             dcterms_available=work_metadata.get('publicationDate'),
-            # Caused error 500 when submitted to DSpace server
-            # # swordv2-server.simpledc.created
-            # # swordv2-server.atom.published
-            # # swordv2-server.atom.updated
-            # dcterms_created=work_metadata.get('publicationDate'),
+            # Needs to be sent in datetime format (otherwise causes error 500),
+            # but is retrieved as `str` so can just append required elements
+            # swordv2-server.simpledc.created
+            # swordv2-server.atom.published
+            # swordv2-server.atom.updated
+            dcterms_created="{}T00:00:00Z".format(work_metadata.get('publicationDate')),
             # swordv2-server.simpledc.date
             dcterms_date=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.issued
             dcterms_issued=work_metadata.get('publicationDate'),
             # swordv2-server.simpledc.publisher
             dcterms_publisher=self.get_publisher_name(),
-            # Caused error 500 when submitted to DSpace server
-            # # swordv2-server.simpledc.coverage
-            # dcterms_coverage='open access',
+            # swordv2-server.simpledc.coverage
+            dcterms_coverage='open access',
             # swordv2-server.simpledc.spatial
             dcterms_spatial='global',
             # swordv2-server.simpledc.temporal
@@ -236,13 +236,12 @@ class SwordV2Uploader(Uploader):
             else:
                 # swordv2-server.simpledc.relation
                 basic_metadata.add_field("dcterms_relation", relation_doi)
-        # Caused error 500 when submitted to DSpace server
-        # for (reference_citation, reference_doi) in [(n.get('unstructuredCitation'), n.get('doi'))
-        #         for n in work_metadata.get('references')]:
-        #     # will always have one or the other (if not both)
-        #     reference = reference_citation if reference_citation else reference_doi
-        #     # swordv2-server.simpledc.references
-        #     basic_metadata.add_field("dcterms_references", reference)
+        for (reference_citation, reference_doi) in [(n.get('unstructuredCitation'), n.get('doi'))
+                for n in work_metadata.get('references')]:
+            # will always have one or the other (if not both)
+            reference = reference_citation if reference_citation else reference_doi
+            # swordv2-server.simpledc.references
+            basic_metadata.add_field("dcterms_references", reference)
 
         return basic_metadata
 

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -139,7 +139,7 @@ class SwordV2Uploader(Uploader):
             dcterms_tableOfContents=work_metadata.get('toc'),
         )
         # Workaround for adding repeatable fields
-        for contribution in [n for n in work_metadata.get('contributions') if n.get('mainContribution') == True]:
+        for contribution in [n for n in work_metadata.get('contributions') if n.get('mainContribution') is True]:
             first_name = contribution.get('firstName')
             orcid = contribution.get('contributor').get('orcid')
             contributor_string = contribution.get('fullName') if first_name is None else "{}, {}".format(
@@ -242,7 +242,7 @@ class SwordV2Uploader(Uploader):
             # dcterms_source=
         )
 
-        for contributor in [n.get('fullName') for n in work_metadata.get('contributions') if n.get('mainContribution') == True]:
+        for contributor in [n.get('fullName') for n in work_metadata.get('contributions') if n.get('mainContribution') is True]:
             # swordv2-server.simpledc.contributor
             basic_metadata.add_field("dcterms_contributor", contributor)
             # swordv2-server.simpledc.creator
@@ -319,7 +319,7 @@ class SwordV2Uploader(Uploader):
                 "dcterms_identifier", "isbn: {}".format(isbn))
         for subject in [n.get('subjectCode') for n in work_metadata.get('subjects')]:
             jisc_router_metadata.add_field("dcterms_subject", subject)
-        for contribution in [n for n in work_metadata.get('contributions') if n.get('mainContribution') == True]:
+        for contribution in [n for n in work_metadata.get('contributions') if n.get('mainContribution') is True]:
             first_name = contribution.get('firstName')
             orcid = contribution.get('contributor').get('orcid')
             affiliations = contribution.get('affiliations')

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -139,6 +139,7 @@ class SwordV2Uploader(Uploader):
             sword_metadata.add_field("dcterms_identifier", "isbn:{}".format(isbn))
         for language in [n.get('languageCode') for n in work_metadata.get('languages')]:
             sword_metadata.add_field("dcterms_language", language)
+        sword_metadata.add_field("dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
 
         return sword_metadata
 
@@ -261,6 +262,7 @@ class SwordV2Uploader(Uploader):
             reference = reference_citation if reference_citation else reference_doi
             # swordv2-server.simpledc.references
             basic_metadata.add_field("dcterms_references", reference)
+        basic_metadata.add_field("dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
 
         return basic_metadata
 
@@ -325,6 +327,7 @@ class SwordV2Uploader(Uploader):
             if grant_number is not None:
                 funding_string += "; Grant(s): {}".format(grant_number)
             jisc_router_metadata.add_field("dcterms_description", funding_string)
+        jisc_router_metadata.add_field("dcterms_identifier", "thoth-work-id:{}".format(self.work_id))
 
         return jisc_router_metadata
 

--- a/uploader.py
+++ b/uploader.py
@@ -173,7 +173,7 @@ class Uploader():
             'data').get('work').get('publications')
         for publication in publications:
             # Required ISBN is under paperback publication
-            if publication.get('publicationType') == 'PDF':
+            if publication.get('publicationType') == 'PAPERBACK':
                 if pb_isbn is None:
                     pb_isbn = publication.get('isbn')
                 else:

--- a/uploader.py
+++ b/uploader.py
@@ -59,20 +59,23 @@ PUB_FORMATS = {
 class Uploader():
     """Generic logic to retrieve and disseminate files and metadata"""
 
-    def __init__(self, work_id, export_url, version):
+    def __init__(self, work_id, export_url, client_url, version):
         """Save argument values and retrieve and store JSON-formatted work metadata"""
         self.work_id = work_id
         self.export_url = export_url
-        self.metadata = self.get_thoth_metadata()
+        self.metadata = self.get_thoth_metadata(client_url)
         self.version = version
 
     def run(self):
         """Execute upload logic specific to the selected platform"""
         self.upload_to_platform()
 
-    def get_thoth_metadata(self):
+    def get_thoth_metadata(self, client_url):
         """Retrieve JSON-formatted work metadata from Thoth GraphQL API via Thoth Client"""
-        thoth = ThothClient()
+        if client_url:
+            thoth = ThothClient(client_url)
+        else:
+            thoth = ThothClient()
         try:
             metadata_string = thoth.work_by_id(self.work_id, raw=True)
         except ThothError:


### PR DESCRIPTION
Main changes:

- extract SWORD2 API connection logic into separate class
- separate out platform-specific logic from SWORD2 base class
- implement concept of "metadata profiles": SWORD2/DSpace support Dublin Core, which is very flexible rather than being a strict standard, so for simplicity/consistency we will maintain a limited set of options for metadata formatting based on existing common schemas (with some leeway for adding customised profiles if deemed worthwhile)