### PR TITLE
Minor updates to CUL, Figshare, Crossref workflows

### DIFF
--- a/config.env.template
+++ b/config.env.template
@@ -13,7 +13,7 @@ so_ftp_pw=
 oapen_ftp_user=
 oapen_ftp_pw=
 
-# University of Cambridge Apollo DSpace 7 test server credentials
+# University of Cambridge Apollo DSpace 7 pilot server credentials
 cam_ds7_user=
 cam_ds7_pw=
 

--- a/crossrefuploader.py
+++ b/crossrefuploader.py
@@ -20,6 +20,12 @@ class CrossrefUploader(Uploader):
         Only the Crossref DOI deposit file is required.
         """
 
+        CR_PREFIX_ENDPOINT = 'https://api.crossref.org/prefixes'
+        CR_DEPOSIT_ENDPOINT = 'https://doi.crossref.org/servlet/deposit'
+        # The deposit API is minimal and will not necessarily return errors if
+        # requests are malformed, so check the response text for confirmation
+        SUCCESS_MSG = 'Your batch submission was successfully received.'
+
         # Check that Crossref credentials have been provided for this publisher
         publisher_id = self.get_publisher_id()
         login_id = self.get_credential_from_env(
@@ -27,18 +33,27 @@ class CrossrefUploader(Uploader):
         login_passwd = self.get_credential_from_env(
             'crossref_pw_' + publisher_id.replace('-', '_'), 'Crossref')
 
-        CROSSREF_ENDPOINT = 'https://doi.crossref.org/servlet/deposit'
-        # The Crossref API is minimal and will not necessarily return errors if
-        # requests are malformed, so check the response text for confirmation
-        SUCCESS_MSG = 'Your batch submission was successfully received.'
-
         metadata_bytes = self.get_formatted_metadata('doideposit::crossref')
+
+        # Check that the provided DOI prefix is a valid Crossref prefix, as
+        # this is not checked by Crossref at point of submission
+        doi = self.metadata.get('data').get('work').get('doi')
+        # DOI must not be None or deposit file request above would have failed
+        # (Thoth database guarantees consistent DOI URL format)
+        doi_prefix = doi.replace('https://doi.org/', '').split('/')[0]
+        doi_rsp = requests.get('{}/{}'.format(CR_PREFIX_ENDPOINT, doi_prefix))
+        if doi_rsp.status_code != 200:
+            logging.error(
+                'Not a valid Crossref DOI prefix: {}'.format(doi_prefix)
+            )
+            sys.exit(1)
+
         # No specifications for filename given in Crossref guide, and it seems
         # not to impact success/failure of upload. Use work ID for simplicity.
         filename = '{}.xml'.format(self.work_id)
 
         crossref_rsp = requests.post(
-            url=CROSSREF_ENDPOINT,
+            url=CR_DEPOSIT_ENDPOINT,
             files={filename: metadata_bytes},
             params={
                 'operation': 'doMDUpload',

--- a/culuploader.py
+++ b/culuploader.py
@@ -13,11 +13,12 @@ class CULUploader(DSpaceUploader):
         user_name_string = 'cam_ds7_user'
         user_pass_string = 'cam_ds7_pw'
         service_document_iri = (
-            'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/servicedocument'
+            'https://api-thoth-arch.lib.cam.ac.uk/server/swordv2/'
+            'servicedocument'
         )
         collection_iri = (
-            'https://copim-b-dev.lib.cam.ac.uk/server/swordv2/collection/1811/'
-            '7'
+            'https://api-thoth-arch.lib.cam.ac.uk/server/swordv2/collection/'
+            '1811/2'
         )
         metadata_profile = MetadataProfile.JISC_ROUTER
         super().__init__(

--- a/fsuploader.py
+++ b/fsuploader.py
@@ -92,6 +92,8 @@ class FigshareUploader(Uploader):
                     metadata_bytes, '{}.json'.format(filename), article_id)
                 # Publish the article.
                 self.api.publish_article(article_id)
+                # Publish project.
+                self.api.publish_project(project_id)
         except DisseminationError as error:
             # Report failure, and remove any partially-created items from Figshare storage.
             logging.error(error)
@@ -102,23 +104,10 @@ class FigshareUploader(Uploader):
             self.api.clean_up(project_id)
             raise
 
-        # Publish project.
-        # Don't do this within the try block for Loughborough repository
-        # as it's configured to require review before publishing -
-        # articles will therefore be "pending" at this stage so
-        # publishing project itself would always fail and trigger cleanup.
-        # (TBD whether this will have any effect or if a manual publication step is required)
-        try:
-            self.api.publish_project(project_id)
-        except DisseminationError as error:
-            # Assume that publishing has failed due to review requirement.
-            # Don't clean up, but warn and continue. TBD how to handle long-term.
-            logging.warning(error)
-
         # The public project URL would be more useful than the project ID, but
-        # the API doesn't return it as part of the workflow (and it won't be created
-        # until the review stage is completed). We could obtain it by calling
-        # the project details endpoint and extracting the "figshare_url" (if any).
+        # the API doesn't return it as part of the workflow. We could obtain it
+        # by calling the project details endpoint and extracting the
+        # "figshare_url" (if any).
         logging.info(
             'Successfully uploaded to Figshare: project ID {}'.format(project_id))
 

--- a/fsuploader.py
+++ b/fsuploader.py
@@ -52,7 +52,13 @@ class FigshareUploader(Uploader):
                 'Cannot upload to Figshare: an item with this Work ID already exists')
             sys.exit(1)
 
+        # If any required metadata is missing, this step will fail, so do it
+        # before attempting large file downloads.
         (project_metadata, article_metadata) = self.parse_metadata()
+
+        # Include full work metadata file in JSON format,
+        # as a supplement to filling out Figshare metadata fields.
+        metadata_bytes = self.get_formatted_metadata('json::thoth')
 
         # Include all available publication files. Don't fail if
         # one is missing, but do fail if none are found at all.
@@ -68,10 +74,6 @@ class FigshareUploader(Uploader):
             logging.error(
                 'Cannot upload to Figshare: no suitable publication files found')
             sys.exit(1)
-
-        # Include full work metadata file in JSON format,
-        # as a supplement to filling out Figshare metadata fields.
-        metadata_bytes = self.get_formatted_metadata('json::thoth')
 
         # Create a project to represent the Work.
         project_id = self.api.create_project(project_metadata)

--- a/iauploader.py
+++ b/iauploader.py
@@ -50,6 +50,7 @@ class IAUploader(Uploader):
             sys.exit(1)
 
         # Convert Thoth work metadata into Internet Archive format
+        # (not expected to fail, as "required" metadata is minimal)
         ia_metadata = self.parse_metadata()
 
         try:

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -428,6 +428,9 @@ class SwordV2Api:
             service_document_iri=service_document_iri,
             user_name=user_name,
             user_pass=user_pass,
+            # We don't make use of history/cache, so turn off to minimise bloat
+            keep_history=False,
+            cache_deposit_receipts=False,
             # SWORD2 library doesn't handle timeout-related errors gracefully
             # and large files (e.g. 50MB) can't be fully uploaded within the
             # 30-second default timeout. Allow lots of leeway. (This otherwise

--- a/swordv2uploader.py
+++ b/swordv2uploader.py
@@ -76,6 +76,7 @@ class SwordV2Uploader(Uploader):
             sys.exit(1)
 
         # Convert Thoth work metadata into SWORD v2 format
+        # (not expected to fail, as "required" metadata is minimal)
         sword_metadata = self.parse_metadata()
 
         try:

--- a/zenodouploader.py
+++ b/zenodouploader.py
@@ -37,6 +37,14 @@ class ZenodoUploader(Uploader):
                 'exists')
             sys.exit(1)
 
+        # If any required metadata is missing, this step will fail, so do it
+        # before attempting large file downloads.
+        zenodo_metadata = self.parse_metadata()
+
+        # Include full work metadata file in JSON format,
+        # as a supplement to filling out Zenodo metadata fields.
+        metadata_bytes = self.get_formatted_metadata('json::thoth')
+
         # Include all available publication files. Don't fail if
         # one is missing, but do fail if none are found at all.
         # (Any paywalled publications will not be retrieved.)
@@ -52,12 +60,7 @@ class ZenodoUploader(Uploader):
                 'Cannot upload to Zenodo: no suitable publication files found')
             sys.exit(1)
 
-        # Include full work metadata file in JSON format,
-        # as a supplement to filling out Zenodo metadata fields.
-        metadata_bytes = self.get_formatted_metadata('json::thoth')
-
         # Create a deposition to represent the Work.
-        zenodo_metadata = self.parse_metadata()
         (deposition_id, api_bucket) = self.api.create_deposition(
             zenodo_metadata)
 


### PR DESCRIPTION
- CUL: update endpoints to point to new live pilot server
- Figshare: remove workaround for manual review requirement (no longer needed)
- Crossref: add DOI prefix check (see https://github.com/thoth-pub/thoth/issues/588)
- Plus minor additional tweaks