### PR TITLE
Add logic for ('manual') FTP dissemination to Project MUSE, JSTOR, EBSCOHost, ProQuest

### DIFF
--- a/.github/workflows/bulk_disseminate.yml
+++ b/.github/workflows/bulk_disseminate.yml
@@ -16,7 +16,7 @@ on:
         type: string
 
 jobs:
-  run-script:
+  obtain-new-ids:
     runs-on: ubuntu-latest
     outputs:
       NEW_IDS: ${{ steps.get-ids.outputs.NEW_IDS }}
@@ -42,10 +42,10 @@ jobs:
           ENV_EXCEPTIONS: ${{ inputs.env_exceptions }}
 
   bulk-disseminate:
-    needs: run-script
-    if: needs.run-script.outputs.NEW_IDS != '[]'
+    needs: obtain-new-ids
+    if: needs.obtain-new-ids.outputs.NEW_IDS != '[]'
     uses: ./.github/workflows/disseminate.yml
     with:
-      work-ids: ${{ needs.run-script.outputs.NEW_IDS }}
+      work-ids: ${{ needs.obtain-new-ids.outputs.NEW_IDS }}
       platform: ${{ inputs.platform }}
     secrets: inherit

--- a/.github/workflows/bulk_disseminate.yml
+++ b/.github/workflows/bulk_disseminate.yml
@@ -44,8 +44,12 @@ jobs:
   bulk-disseminate:
     needs: obtain-new-ids
     if: needs.obtain-new-ids.outputs.NEW_IDS != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        work-id: ${{ fromJSON(needs.run-script.outputs.NEW_IDS) }}
     uses: ./.github/workflows/disseminate.yml
     with:
-      work-ids: ${{ needs.obtain-new-ids.outputs.NEW_IDS }}
+      work-id: ${{ matrix.work-id }}
       platform: ${{ inputs.platform }}
     secrets: inherit

--- a/.github/workflows/disseminate.yml
+++ b/.github/workflows/disseminate.yml
@@ -5,7 +5,7 @@ name: disseminate
 on:
   workflow_call:
     inputs:
-      work-ids:
+      work-id:
         required: true
         type: string
       platform:
@@ -17,10 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: openbookpublishers/thoth-dissemination:latest
-    strategy:
-      fail-fast: false
-      matrix:
-        work-id: ${{ fromJSON(inputs.work-ids) }}
     steps:
       - name: Make all platform credentials available to later steps (with names lowercased)
         uses: oNaiPs/secrets-to-env-action@v1.5
@@ -31,16 +27,16 @@ jobs:
       - name: Run disseminator using Dockerhub image
         run: |
           /disseminator.py \
-            --work ${{ matrix.work-id }} \
+            --work ${{ inputs.work-id }} \
             --platform ${{ inputs.platform }} \
-            > ${{ matrix.work-id }}
+            > ${{ inputs.work-id }}
 
       - name: Upload output to artifact
         uses: actions/upload-artifact@v4
         if: contains(fromJSON('["InternetArchive", "CUL", "Figshare", "Zenodo"]'), inputs.platform)
         with:
-          name: ${{ matrix.work-id }}
-          path: ${{ matrix.work-id }}
+          name: ${{ inputs.work-id }}
+          path: ${{ inputs.work-id }}
           retention-days: 1
           if-no-files-found: ignore
           overwrite: false
@@ -49,10 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: disseminate
     if: contains(fromJSON('["InternetArchive", "CUL", "Figshare", "Zenodo"]'), inputs.platform)
-    strategy:
-      fail-fast: false
-      matrix:
-        work-id: ${{ fromJSON(inputs.work-ids) }}
     steps:
       - name: Checkout
         # This step deletes existing directory contents, so must be done before artifact download
@@ -61,7 +53,7 @@ jobs:
       - name: Download disseminator output artifact containing location info
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.work-id }}
+          name: ${{ inputs.work-id }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -72,7 +64,7 @@ jobs:
         run: pip install -r requirements_write_locations.txt
 
       - name: Write locations to Thoth using Python script
-        run: python write_locations.py ${{ matrix.work-id }}
+        run: python write_locations.py ${{ inputs.work-id }}
         env:
           THOTH_EMAIL: ${{ secrets.THOTH_EMAIL }}
           THOTH_PWD: ${{ secrets.THOTH_PWD }}

--- a/.github/workflows/manual_disseminate.yml
+++ b/.github/workflows/manual_disseminate.yml
@@ -24,8 +24,12 @@ on:
 
 jobs:
   manual_disseminate:
+    strategy:
+      fail-fast: false
+      matrix:
+        work-id: ${{ fromJSON(github.event.inputs.workIds) }}
     uses: ./.github/workflows/disseminate.yml
     with:
-      work-ids: ${{ github.event.inputs.workIds }}
+      work-id: ${{ matrix.work-id }}
       platform: ${{ github.event.inputs.platform }}
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  - Support for uploading files and metadata to Project MUSE
 
 ## [[0.1.13]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v0.1.13) - 2024-07-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-  - Support for uploading files and metadata to Project MUSE and JSTOR
+  - Support for uploading files and metadata to Project MUSE, JSTOR, EBSCOHost
 
 ## [[0.1.14]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v0.1.14) - 2024-07-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-  - Support for uploading files and metadata to Project MUSE, JSTOR, EBSCOHost
+  - Support for uploading files and metadata to Project MUSE, JSTOR, EBSCOHost, ProQuest (Ebook Central)
 
 ## [[0.1.14]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v0.1.14) - 2024-07-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-  - Support for uploading files and metadata to Project MUSE
+  - Support for uploading files and metadata to Project MUSE and JSTOR
 
 ## [[0.1.14]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v0.1.14) - 2024-07-24
 ### Changed

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ docker run --rm --env-file config.env openbookpublishers/thoth-dissemination:lat
 ### Options
 `--work` = Thoth ID of work to be disseminated
 
-`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`, `ProjectMUSE`, `JSTOR`)
+`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`, `ProjectMUSE`, `JSTOR`, `EBSCOHost`)
 
 See also `--help`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ docker run --rm --env-file config.env openbookpublishers/thoth-dissemination:lat
 ### Options
 `--work` = Thoth ID of work to be disseminated
 
-`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`, `ProjectMUSE`)
+`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`, `ProjectMUSE`, `JSTOR`)
 
 See also `--help`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ docker run --rm --env-file config.env openbookpublishers/thoth-dissemination:lat
 ### Options
 `--work` = Thoth ID of work to be disseminated
 
-`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`)
+`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`, `ProjectMUSE`)
 
 See also `--help`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ docker run --rm --env-file config.env openbookpublishers/thoth-dissemination:lat
 ### Options
 `--work` = Thoth ID of work to be disseminated
 
-`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`, `ProjectMUSE`, `JSTOR`, `EBSCOHost`)
+`--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`, `ProjectMUSE`, `JSTOR`, `EBSCOHost`, `ProQuest`)
 
 See also `--help`.

--- a/config.env.template
+++ b/config.env.template
@@ -17,6 +17,17 @@ oapen_ftp_pw=
 cul_pilot_user=
 cul_pilot_pw=
 
+# Project MUSE FTP server credentials
+# Separate credentials must be provided for each publisher whose works are to be submitted.
+# Each set of credentials must be given in the format below, i.e. with the
+# Thoth publisher ID suffixed (omitting the square brackets).
+# Note that the hyphens (-) in the Thoth publisher ID must be replaced
+# with underscores (_). This is to allow compatibility with GitHub Actions,
+# and make it easier to provide credentials as inline environment variables
+# (as env vars with names containing hyphens require use of `env` program).
+muse_ftp_user_[publisher_id]=
+muse_ftp_pw_[publisher_id]=
+
 # Crossref user credentials
 # Separate credentials must be provided for each publisher whose works are to be submitted.
 # Each set of credentials must be given in the format below, i.e. with the

--- a/config.env.template
+++ b/config.env.template
@@ -23,6 +23,10 @@ cul_pilot_pw=
 jstor_ftp_user=
 jstor_ftp_pw=
 
+# EBSCOHost FTP server credentials
+ebsco_ftp_user=
+ebsco_ftp_pw=
+
 # Project MUSE FTP server credentials
 # Separate credentials must be provided for each publisher whose works are to be submitted.
 # Each set of credentials must be given in the format below, i.e. with the

--- a/config.env.template
+++ b/config.env.template
@@ -17,6 +17,12 @@ oapen_ftp_pw=
 cul_pilot_user=
 cul_pilot_pw=
 
+# JSTOR FTP server credentials
+# TODO not yet not yet confirmed whether credentials will be per-publisher
+# or a single Thoth user
+jstor_ftp_user=
+jstor_ftp_pw=
+
 # Project MUSE FTP server credentials
 # Separate credentials must be provided for each publisher whose works are to be submitted.
 # Each set of credentials must be given in the format below, i.e. with the

--- a/config.env.template
+++ b/config.env.template
@@ -27,6 +27,12 @@ jstor_ftp_pw=
 ebsco_ftp_user=
 ebsco_ftp_pw=
 
+# ProQuest Ebook Central FTP server credentials
+# TODO not yet not yet confirmed whether credentials will be per-publisher
+# or a single Thoth user
+proquest_ftp_user=
+proquest_ftp_pw=
+
 # Project MUSE FTP server credentials
 # Separate credentials must be provided for each publisher whose works are to be submitted.
 # Each set of credentials must be given in the format below, i.e. with the

--- a/disseminator.py
+++ b/disseminator.py
@@ -20,6 +20,7 @@ from culuploader import CULUploader
 from crossrefuploader import CrossrefUploader
 from fsuploader import FigshareUploader
 from zenodouploader import ZenodoUploader
+from museuploader import MUSEUploader
 
 UPLOADERS = {
     "InternetArchive": IAUploader,
@@ -29,6 +30,7 @@ UPLOADERS = {
     "Crossref": CrossrefUploader,
     "Figshare": FigshareUploader,
     "Zenodo": ZenodoUploader,
+    "ProjectMUSE": MUSEUploader,
 }
 
 UPLOADERS_STR = ', '.join("%s" % (key) for (key, _) in UPLOADERS.items())

--- a/disseminator.py
+++ b/disseminator.py
@@ -22,6 +22,7 @@ from fsuploader import FigshareUploader
 from zenodouploader import ZenodoUploader
 from museuploader import MUSEUploader
 from jstoruploader import JSTORUploader
+from ebscouploader import EBSCOUploader
 
 UPLOADERS = {
     "InternetArchive": IAUploader,
@@ -33,6 +34,7 @@ UPLOADERS = {
     "Zenodo": ZenodoUploader,
     "ProjectMUSE": MUSEUploader,
     "JSTOR": JSTORUploader,
+    "EBSCOHost": EBSCOUploader,
 }
 
 UPLOADERS_STR = ', '.join("%s" % (key) for (key, _) in UPLOADERS.items())

--- a/disseminator.py
+++ b/disseminator.py
@@ -21,6 +21,7 @@ from crossrefuploader import CrossrefUploader
 from fsuploader import FigshareUploader
 from zenodouploader import ZenodoUploader
 from museuploader import MUSEUploader
+from jstoruploader import JSTORUploader
 
 UPLOADERS = {
     "InternetArchive": IAUploader,
@@ -31,6 +32,7 @@ UPLOADERS = {
     "Figshare": FigshareUploader,
     "Zenodo": ZenodoUploader,
     "ProjectMUSE": MUSEUploader,
+    "JSTOR": JSTORUploader,
 }
 
 UPLOADERS_STR = ', '.join("%s" % (key) for (key, _) in UPLOADERS.items())

--- a/disseminator.py
+++ b/disseminator.py
@@ -23,6 +23,7 @@ from zenodouploader import ZenodoUploader
 from museuploader import MUSEUploader
 from jstoruploader import JSTORUploader
 from ebscouploader import EBSCOUploader
+from proquestuploader import ProquestUploader
 
 UPLOADERS = {
     "InternetArchive": IAUploader,
@@ -35,6 +36,7 @@ UPLOADERS = {
     "ProjectMUSE": MUSEUploader,
     "JSTOR": JSTORUploader,
     "EBSCOHost": EBSCOUploader,
+    "ProQuest": ProquestUploader,
 }
 
 UPLOADERS_STR = ', '.join("%s" % (key) for (key, _) in UPLOADERS.items())

--- a/ebscouploader.py
+++ b/ebscouploader.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Retrieve and disseminate files and metadata to EBSCOHost
+"""
+
+import logging
+import sys
+import pysftp
+from io import BytesIO
+from errors import DisseminationError
+from uploader import Uploader
+
+
+class EBSCOUploader(Uploader):
+    """Dissemination logic for EBSCOHost"""
+
+    def upload_to_platform(self):
+        """
+        Upload work in required format to EBSCOHost.
+
+        Content required: PDF and/or EPUB work file
+        Metadata required: EBSCOHost ONIX 2.1 export
+        Naming convention: Use "corresponding eISBN" for all filename roots # TODO check
+        Upload directory: TBC # TODO
+        """
+
+        # Check that EBSCOHost credentials have been provided
+        try:
+            username = self.get_credential_from_env('ebsco_ftp_user', 'EBSCOHost')
+            password = self.get_credential_from_env('ebsco_ftp_pw', 'EBSCOHost')
+        except DisseminationError as error:
+            logging.error(error)
+            sys.exit(1)
+
+        # TODO awaiting confirmation whether different ISBNs should be used
+        # for different formats/whether ISBN should be used for metadata file
+        # (this will fail if only EPUB exists - see below)
+        filename = self.get_isbn('PDF')
+
+        metadata_bytes = self.get_formatted_metadata('onix_2.1::ebsco_host')
+        files = [('{}.xml'.format(filename), BytesIO(metadata_bytes))]
+
+        # Can't continue if neither PDF nor EPUB file is present
+        pdf_error = None
+        epub_error = None
+        try:
+            pdf = self.get_publication_details('PDF')
+            files.append(('{}{}'.format(filename, pdf.file_ext), BytesIO(pdf.bytes)))
+        except DisseminationError as error:
+            pdf_error = error
+        try:
+            epub = self.get_publication_details('EPUB')
+            files.append(('{}{}'.format(filename, epub.file_ext), BytesIO(epub.bytes)))
+        except DisseminationError as error:
+            epub_error = error
+        if pdf_error and epub_error:
+            logging.error(pdf_error)
+            logging.error(epub_error)
+            sys.exit(1)
+
+        try:
+            with pysftp.Connection(
+                host='sftp.epnet.com',
+                username=username,
+                password=password,
+            ) as sftp:
+                for file in files:
+                    try:
+                        sftp.putfo(flo=file[1], remotepath=file[0])
+                    except TypeError as error:
+                        logging.error(
+                            'Error uploading to EBSCOHost SFTP server: {}'.format(error))
+                        # Attempt to delete any partially-uploaded items
+                        # (not confirmed whether EBSCOHost system automatically begins
+                        # processing on upload - cf museuploader)
+                        for file in files:
+                            try:
+                                sftp.remove(file[0])
+                            except FileNotFoundError:
+                                pass
+                        sys.exit(1)
+        except pysftp.AuthenticationException as error:
+            logging.error(
+                'Could not connect to EBSCOHost SFTP server: {}'.format(error))
+            sys.exit(1)
+
+        logging.info('Successfully uploaded to EBSCOHost SFTP server')
+
+    def parse_metadata(self):
+        """Convert work metadata into EBSCOHost format"""
+        # Not required for EBSCOHost - only the metadata file is required
+        pass

--- a/fsuploader.py
+++ b/fsuploader.py
@@ -454,7 +454,7 @@ class FigshareApi:
                                              'location'], json_body=metadata)
         except DisseminationError as error:
             raise DisseminationError(
-                'Creating article failed: {}'.format(error))
+                'Creating article failed: {} ({})'.format(error, metadata.get('title')))
         # Derive 'entity_id' from 'location'
         article_id = article_url.split('/')[-1]
         # Figshare default behaviour (confirmed under support ticket #438719)
@@ -495,7 +495,7 @@ class FigshareApi:
             self.issue_request('POST', url, 201)
         except DisseminationError as error:
             raise DisseminationError(
-                'Publishing article failed: {}'.format(error))
+                'Publishing article {} failed: {}'.format(article_id, error))
 
     def clean_up(self, project_id):
         """
@@ -531,7 +531,7 @@ class FigshareApi:
             # Check that the data was processed successfully.
             return self.check_upload_status(file_url)
         except DisseminationError as error:
-            raise DisseminationError('Uploading file failed: {}'.format(error))
+            raise DisseminationError('Uploading file failed: {} ({})'.format(error, file_name))
 
     def initiate_new_upload(self, article_id, file_bytes, file_name):
         """

--- a/jstoruploader.py
+++ b/jstoruploader.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Retrieve and disseminate files and metadata to JSTOR
+"""
+
+import logging
+import sys
+import pysftp
+from io import BytesIO
+from errors import DisseminationError
+from uploader import Uploader
+
+
+class JSTORUploader(Uploader):
+    """Dissemination logic for JSTOR"""
+
+    def upload_to_platform(self):
+        """
+        Upload work in required format to JSTOR.
+
+        Content required: PDF and/or EPUB work file plus JPG cover file
+        Metadata required: JSTOR ONIX 3.0 export
+        Naming convention: Use PDF ISBN for all filename roots
+        Upload directory: per-publisher folder, `books` subfolder
+        """
+
+        # Check that JSTOR credentials have been provided for this publisher
+        # TODO not yet confirmed whether credentials will be per-publisher
+        # or a single Thoth user
+        publisher_id = self.get_publisher_id()
+        try:
+            username = self.get_credential_from_env('jstor_ftp_user', 'JSTOR')
+            password = self.get_credential_from_env('jstor_ftp_pw', 'JSTOR')
+        except DisseminationError as error:
+            logging.error(error)
+            sys.exit(1)
+
+        publisher = self.get_publisher_name()
+        filename = self.get_isbn('PDF')
+        publisher_dir = 'TBD' # TODO
+        collection_dir = 'books'
+
+        metadata_bytes = self.get_formatted_metadata('onix_3.0::jstor')
+        # Only .jpg cover files are supported
+        cover_bytes = self.get_cover_image('jpg')
+        pdf = self.get_publication_details('PDF').bytes
+        files = [
+            ('{}.xml'.format(filename), BytesIO(metadata_bytes)),
+            ('{}.jpg'.format(filename), BytesIO(cover_bytes)),
+            ('{}.pdf'.format(filename), pdf_bytes),
+        ]
+
+        try:
+            with pysftp.Connection(
+                host='ftp.jstor.org',
+                username=username,
+                password=password,
+            ) as sftp:
+                try:
+                    sftp.cwd(publisher_dir)
+                except FileNotFoundError:
+                    logging.error(
+                        'Could not find publisher folder "{}" on JSTOR SFTP server'.format(publisher_dir))
+                    sys.exit(1)
+                try:
+                    sftp.cwd(collection_dir)
+                except FileNotFoundError:
+                    logging.error(
+                        'Could not find collection folder "books" on JSTOR SFTP server')
+                    sys.exit(1)
+                for file in files:
+                    try:
+                        sftp.putfo(flo=file[1], remotepath=file[0])
+                    except TypeError as error:
+                        logging.error(
+                            'Error uploading to JSTOR SFTP server: {}'.format(error))
+                        # Attempt to delete any partially-uploaded items
+                        # (not confirmed whether JSTOR system automatically begins
+                        # processing on upload - cf museuploader)
+                        for file in files:
+                            try:
+                                sftp.remove(file[0])
+                            except FileNotFoundError:
+                                pass
+                        sys.exit(1)
+        except pysftp.AuthenticationException as error:
+            logging.error(
+                'Could not connect to JSTOR SFTP server: {}'.format(error))
+            sys.exit(1)
+
+        logging.info('Successfully uploaded to JSTOR SFTP server')
+
+    def parse_metadata(self):
+        """Convert work metadata into JSTOR format"""
+        # Not required for JSTOR - only the metadata file is required
+        pass

--- a/jstoruploader.py
+++ b/jstoruploader.py
@@ -18,7 +18,7 @@ class JSTORUploader(Uploader):
         """
         Upload work in required format to JSTOR.
 
-        Content required: PDF and/or EPUB work file plus JPG cover file
+        Content required: PDF work file plus JPG cover file
         Metadata required: JSTOR ONIX 3.0 export
         Naming convention: Use PDF ISBN for all filename roots
         Upload directory: per-publisher folder, `books` subfolder

--- a/jstoruploader.py
+++ b/jstoruploader.py
@@ -27,7 +27,6 @@ class JSTORUploader(Uploader):
         # Check that JSTOR credentials have been provided for this publisher
         # TODO not yet confirmed whether credentials will be per-publisher
         # or a single Thoth user
-        publisher_id = self.get_publisher_id()
         try:
             username = self.get_credential_from_env('jstor_ftp_user', 'JSTOR')
             password = self.get_credential_from_env('jstor_ftp_pw', 'JSTOR')
@@ -35,7 +34,6 @@ class JSTORUploader(Uploader):
             logging.error(error)
             sys.exit(1)
 
-        publisher = self.get_publisher_name()
         filename = self.get_isbn('PDF')
         publisher_dir = 'TBD' # TODO
         collection_dir = 'books'

--- a/museuploader.py
+++ b/museuploader.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Retrieve and disseminate files and metadata to Project MUSE
+"""
+
+import logging
+import sys
+import pysftp
+from io import BytesIO
+from errors import DisseminationError
+from uploader import Uploader
+
+
+class MUSEUploader(Uploader):
+    """Dissemination logic for Project MUSE"""
+
+    def upload_to_platform(self):
+        """
+        Upload work in required format to Project MUSE.
+
+        Content required: PDF and/or EPUB work file plus JPG cover file
+        Metadata required: Project MUSE ONIX 3.0 export
+        Naming convention: Use paperback ISBN for all filename roots
+        Upload directory: `uploads`
+        """
+
+        # Check that Project MUSE credentials have been provided for this publisher
+        publisher_id = self.get_publisher_id()
+        try:
+            username = self.get_credential_from_env(
+                'muse_ftp_user_' + publisher_id.replace('-', '_'), 'Project MUSE')
+            password = self.get_credential_from_env(
+                'muse_ftp_pw_' + publisher_id.replace('-', '_'), 'Project MUSE')
+        except DisseminationError as error:
+            logging.error(error)
+            sys.exit(1)
+
+        publisher = self.get_publisher_name()
+        filename = self.get_pb_isbn()
+        root_dir = 'uploads'
+
+        metadata_bytes = self.get_formatted_metadata('onix_3.0::project_muse')
+        # Only .jpg cover files are supported
+        cover_bytes = self.get_cover_image('jpg')
+        files = [
+            ('{}.xml'.format(filename), BytesIO(metadata_bytes)),
+            ('{}.jpg'.format(filename), BytesIO(cover_bytes)),
+        ]
+
+        # Can't continue if neither PDF nor EPUB file is present
+        pdf_error = None
+        epub_error = None
+        try:
+            pdf = self.get_publication_details('PDF')
+            files.append(('{}{}'.format(filename, pdf.file_ext), BytesIO(pdf.bytes)))
+        except DisseminationError as error:
+            pdf_error = error
+        try:
+            epub = self.get_publication_details('EPUB')
+            files.append(('{}{}'.format(filename, epub.file_ext), BytesIO(epub.bytes)))
+        except DisseminationError as error:
+            epub_error = error
+        if pdf_error and epub_error:
+            logging.error(pdf_error)
+            logging.error(epub_error)
+            sys.exit(1)
+
+        try:
+            with pysftp.Connection(
+                host='ftp.press.jhu.edu',
+                username=username,
+                password=password,
+            ) as sftp:
+                try:
+                    sftp.cwd(root_dir)
+                except FileNotFoundError:
+                    logging.error(
+                        'Could not find folder "uploads" on Project MUSE SFTP server')
+                    sys.exit(1)
+                for file in files:
+                    try:
+                        sftp.putfo(flo=file[1], remotepath=file[0])
+                    except TypeError as error:
+                        logging.error(
+                            'Error uploading to Project MUSE SFTP server: {}'.format(error))
+                        # Attempt to delete any partially-uploaded items
+                        # However, note that Project MUSE system automatically begins
+                        # processing on upload, so this may not help
+                        for file in files:
+                            try:
+                                sftp.remove(file[0])
+                            except FileNotFoundError:
+                                pass
+                        sys.exit(1)
+        except pysftp.AuthenticationException as error:
+            logging.error(
+                'Could not connect to Project MUSE SFTP server: {}'.format(error))
+            sys.exit(1)
+
+        logging.info('Successfully uploaded to Project MUSE SFTP server')
+
+    def parse_metadata(self):
+        """Convert work metadata into Project MUSE format"""
+        # Not required for Project MUSE - only the metadata file is required
+        pass

--- a/museuploader.py
+++ b/museuploader.py
@@ -35,7 +35,6 @@ class MUSEUploader(Uploader):
             logging.error(error)
             sys.exit(1)
 
-        publisher = self.get_publisher_name()
         filename = self.get_pb_isbn()
         root_dir = 'uploads'
 

--- a/museuploader.py
+++ b/museuploader.py
@@ -35,7 +35,7 @@ class MUSEUploader(Uploader):
             logging.error(error)
             sys.exit(1)
 
-        filename = self.get_pb_isbn()
+        filename = self.get_isbn('PAPERBACK')
         root_dir = 'uploads'
 
         metadata_bytes = self.get_formatted_metadata('onix_3.0::project_muse')

--- a/obtain_new_ids.py
+++ b/obtain_new_ids.py
@@ -94,7 +94,9 @@ class IDFinder():
         If a list of exceptions has been provided, remove these from the results
         (e.g. works that are ineligible for upload due to not being available as PDFs)
         """
-        if environ.get('ENV_EXCEPTIONS') is not None:
+        # Omitted exceptions may be represented as None if running locally,
+        # or an empty string if passed via GitHub Actions inheritance
+        if environ.get('ENV_EXCEPTIONS'):
             try:
                 exceptions = json.loads(environ.get('ENV_EXCEPTIONS').lower())
                 self.thoth_ids = list(

--- a/proquestuploader.py
+++ b/proquestuploader.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Retrieve and disseminate files and metadata to ProQuest Ebook Central
+"""
+
+import logging
+import sys
+import pysftp
+from datetime import date
+from io import BytesIO
+from errors import DisseminationError
+from uploader import Uploader
+
+
+class ProquestUploader(Uploader):
+    """Dissemination logic for ProQuest Ebook Central"""
+
+    def upload_to_platform(self):
+        """
+        Upload work in required format to ProQuest Ebook Central.
+
+        Content required: PDF and/or EPUB work file plus cover file
+        Metadata required: ProQuest Ebook Central ONIX 2.1 export
+        Naming convention: Use "associated eISBN" for all content filename roots # TODO check
+                           Metadata filename must start with publisher name (no spaces)
+                           and include current date in YYYYMMDD format # TODO check
+        Upload directory: `upload`
+        """
+
+        # Check that ProQuest Ebook Central credentials have been provided
+        # TODO not yet confirmed whether credentials will be per-publisher
+        # or a single Thoth user
+        try:
+            username = self.get_credential_from_env('proquest_ftp_user', 'ProQuest Ebook Central')
+            password = self.get_credential_from_env('proquest_ftp_pw', 'ProQuest Ebook Central')
+        except DisseminationError as error:
+            logging.error(error)
+            sys.exit(1)
+
+        # TODO awaiting confirmation whether different ISBNs should be used
+        # for different formats/whether ISBN should be used for metadata file
+        # (this will fail if only EPUB exists - see below)
+        filename = self.get_isbn('PDF')
+        root_dir = 'upload'
+
+        metadata_bytes = self.get_formatted_metadata('onix_2.1::proquest_ebrary')
+        # TODO unclear whether there are additional filename requirements
+        metadata_filename = '{}_{}_{}.xml'.format(
+            self.get_publisher_name().replace(' ', ''),
+            filename,
+            date.today().isoformat().replace('-', '')
+        )
+
+        cover_bytes = self.get_cover_image()
+        # No restriction on cover file format
+        cover_file_ext = self.get_cover_url().split('.')[-1]
+
+        files = [
+            (metadata_filename, BytesIO(metadata_bytes)),
+            ('{}.{}'.format(filename, cover_file_ext), BytesIO(cover_bytes)),
+        ]
+
+        # Can't continue if neither PDF nor EPUB file is present
+        pdf_error = None
+        epub_error = None
+        try:
+            pdf = self.get_publication_details('PDF')
+            files.append(('{}{}'.format(filename, pdf.file_ext), BytesIO(pdf.bytes)))
+        except DisseminationError as error:
+            pdf_error = error
+        try:
+            epub = self.get_publication_details('EPUB')
+            files.append(('{}{}'.format(filename, epub.file_ext), BytesIO(epub.bytes)))
+        except DisseminationError as error:
+            epub_error = error
+        if pdf_error and epub_error:
+            logging.error(pdf_error)
+            logging.error(epub_error)
+            sys.exit(1)
+
+        try:
+            with pysftp.Connection(
+                host='ftp.ebookcentral.proquest.com',
+                username=username,
+                password=password,
+            ) as sftp:
+                try:
+                    sftp.cwd(collection_dir)
+                except FileNotFoundError:
+                    logging.error(
+                        'Could not find folder "upload" on ProQuest Ebook Central SFTP server')
+                    sys.exit(1)
+                for file in files:
+                    try:
+                        sftp.putfo(flo=file[1], remotepath=file[0])
+                    except TypeError as error:
+                        logging.error(
+                            'Error uploading to ProQuest Ebook Central SFTP server: {}'.format(error))
+                        # Attempt to delete any partially-uploaded items
+                        # However, note that ProQuest Ebook Central system automatically
+                        # begins processing on upload, so this may not help
+                        for file in files:
+                            try:
+                                sftp.remove(file[0])
+                            except FileNotFoundError:
+                                pass
+                        sys.exit(1)
+        except pysftp.AuthenticationException as error:
+            logging.error(
+                'Could not connect to ProQuest Ebook Central SFTP server: {}'.format(error))
+            sys.exit(1)
+
+        logging.info('Successfully uploaded to ProQuest Ebook Central SFTP server')
+
+    def parse_metadata(self):
+        """Convert work metadata into ProQuest Ebook Central format"""
+        # Not required for ProQuest Ebook Central - only the metadata file is required
+        pass

--- a/souploader.py
+++ b/souploader.py
@@ -42,7 +42,7 @@ class SOUploader(Uploader):
             sys.exit(1)
 
         publisher = self.get_publisher_name()
-        filename = self.get_pb_isbn()
+        filename = self.get_isbn('PAPERBACK')
         root_dir = 'UPLOAD_TO_THIS_DIRECTORY'
         collection_dir = 'books'
         new_dir = date.today().isoformat()

--- a/uploader.py
+++ b/uploader.py
@@ -213,27 +213,26 @@ class Uploader():
 
         return cover_url
 
-    def get_pb_isbn(self):
-        """Extract paperback ISBN from work metadata"""
-        pb_isbn = None
+    def get_isbn(self, publication_type):
+        """Extract ISBN of specified type (e.g. 'PAPERBACK') from work metadata"""
+        isbn = None
         publications = self.metadata.get(
             'data').get('work').get('publications')
         for publication in publications:
-            # Required ISBN is under paperback publication
-            if publication.get('publicationType') == 'PAPERBACK':
-                if pb_isbn is None:
-                    pb_isbn = publication.get('isbn')
+            if publication.get('publicationType') == publication_type:
+                if isbn is None:
+                    isbn = publication.get('isbn')
                 else:
                     logging.error(
-                        'Found more than one paperback ISBN - should be unique')
+                        'Found more than one ISBN of type {} - should be unique'.format(publication_type))
                     sys.exit(1)
 
-        if pb_isbn is None:
-            logging.error('No paperback ISBN found for Work')
+        if isbn is None:
+            logging.error('No ISBN of type {} found for Work'.format(publication_type))
             sys.exit(1)
 
         # Remove hyphens from ISBN before returning
-        return pb_isbn.replace('-', '')
+        return isbn.replace('-', '')
 
     def get_publisher_name(self):
         """Extract publisher name from work metadata"""

--- a/uploader.py
+++ b/uploader.py
@@ -215,24 +215,17 @@ class Uploader():
 
     def get_isbn(self, publication_type):
         """Extract ISBN of specified type (e.g. 'PAPERBACK') from work metadata"""
-        isbn = None
-        publications = self.metadata.get(
-            'data').get('work').get('publications')
-        for publication in publications:
-            if publication.get('publicationType') == publication_type:
-                if isbn is None:
-                    isbn = publication.get('isbn')
-                else:
-                    logging.error(
-                        'Found more than one ISBN of type {} - should be unique'.format(publication_type))
-                    sys.exit(1)
-
-        if isbn is None:
+        publications = self.metadata.get('data').get('work').get('publications')
+        # There should be a maximum of one publication per type;
+        # more than one would be a Thoth database error
+        try:
+            isbn = [n['isbn'] for n in publications
+                    if n['publicationType'] == publication_type][0]
+            # Remove hyphens from ISBN before returning
+            return isbn.replace('-', '')
+        except (IndexError, KeyError):
             logging.error('No ISBN of type {} found for Work'.format(publication_type))
             sys.exit(1)
-
-        # Remove hyphens from ISBN before returning
-        return isbn.replace('-', '')
 
     def get_publisher_name(self):
         """Extract publisher name from work metadata"""

--- a/uploader.py
+++ b/uploader.py
@@ -134,15 +134,22 @@ class Uploader():
             logging.error(error)
             sys.exit(1)
 
-    def get_cover_image(self):
+    def get_cover_image(self, required_format=None):
         """
         Retrieve work cover image from URL specified in work metadata
         (required by some platforms)
+        @param required_format: optional string representing file extension of
+                                image type desired by caller (e.g. 'jpg', 'png')
         """
         # Extract cover URL from Thoth metadata
         cover_url = self.get_cover_url()
+        cover_ext = cover_url.split('.')[-1].lower()
 
-        match cover_url.split('.')[-1].lower():
+        if required_format and not required_format == cover_ext:
+            logging.error('Work cover image has format "{}" instead of "{}"'.format(cover_ext, required_format))
+            sys.exit(1)
+
+        match cover_ext:
             case 'jpg':
                 expected_format = 'image/jpeg'
             case 'png':

--- a/zenodouploader.py
+++ b/zenodouploader.py
@@ -7,7 +7,6 @@ import logging
 import sys
 import re
 import requests
-from io import BytesIO
 from errors import DisseminationError
 from uploader import Uploader, PUB_FORMATS, Location
 


### PR DESCRIPTION
Tested against Project MUSE FTP server and EBSCOHost SFTP server; mainline paths working.

Other platforms not yet tested as still awaiting confirmation of some details (e.g. credentials).

Includes some additional minor fixes/improvements, e.g. correct ordering of dependent GitHub Actions jobs.