### PR TITLE
Change filename for upload to be based on PDF ISBN

### DIFF
--- a/museuploader.py
+++ b/museuploader.py
@@ -20,7 +20,7 @@ class MUSEUploader(Uploader):
 
         Content required: PDF and/or EPUB work file plus JPG cover file
         Metadata required: Project MUSE ONIX 3.0 export
-        Naming convention: Use paperback ISBN for all filename roots
+        Naming convention: Use PDF ISBN for all filename roots
         Upload directory: `uploads`
         """
 


### PR DESCRIPTION
The Project MUSE semi-manual workflow has been failing for Works with no ISBN for Paperback Publication, which is used to generate the filename for upload. Project MUSE will accept any ISBN as the filename, so we're switching to PDF ISBN, which should be present in more Works and thus result in fewer failed workflow runs.