### PR TITLE
Feature/remove info logging job summary

### DIFF
--- a/.github/workflows/disseminate.yml
+++ b/.github/workflows/disseminate.yml
@@ -60,10 +60,13 @@ jobs:
             --platform "${{ inputs.platform }}" \
             > "$STDOUT" 2> "$STDERR" || STATUS=$?
           if [ -s "$STDERR" ]; then
-            echo "### Dissemination error for work ID ${{ inputs.work-id }}" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            cat "$STDERR" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
+            ERROR_LOG=$(grep '^ERROR:' "$STDERR")
+            if [ -n "$ERROR_LOG" ]; then
+              echo "### Dissemination error for work ID ${{ inputs.work-id }}" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "$ERROR_LOG" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+            fi
           fi
           exit ${STATUS:-0}
 

--- a/.github/workflows/disseminate.yml
+++ b/.github/workflows/disseminate.yml
@@ -58,7 +58,7 @@ jobs:
           python disseminator.py \
             --work "${{ inputs.work-id }}" \
             --platform "${{ inputs.platform }}" \
-            > "$STDOUT" 2> "$STDERR" || STATUS=$?
+            > >(tee "$STDOUT") 2> >(tee "$STDERR" >&2) || STATUS=$?
           if [ -s "$STDERR" ]; then
             ERROR_LOG=$(grep '^ERROR:' "$STDERR")
             if [ -n "$ERROR_LOG" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to thoth-dissemination will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+  - Only write `ERROR` logging messages to the GitHub Actions Job Summary, removing `INFO` messages so the Job Summaries are easier to read for batch runs of the `manual-disseminate` workflow.
+
 ## [[0.1.30]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v0.1.30) - 2025-08-06
 ### Changed
   - Replaced unmaintained dependency `pysftp` with latest version of `paramiko`


### PR DESCRIPTION
Currently, the Job Summary displays both `INFO` and `ERROR` messages output from running `disseminator.py`. This results in the Job Summary section being long and cluttered with messages from successful runs in the case of a large batch run of the `manual-disseminate` workflow. 

This changes the logic so only `ERROR` messages are output to the Job Summary; successful runs will no longer display a section in the Job Summary.