### PR TITLE
Make Internet Archive dissemination idempotent and schedule update-aware daily runs

### DIFF
--- a/.github/scripts/ia_reconcile_workflow.py
+++ b/.github/scripts/ia_reconcile_workflow.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Validate IA reconciliation workflow inputs and render its Step Summary."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from uuid import UUID
+
+
+LOG_PATH = Path("internet-archive-reconciliation.log")
+CONTEXT_PATH = Path("reconciliation-run-context.json")
+WORK_IDS_PATH = Path("normalised-work-ids.txt")
+REPORT_PATH = Path("internet-archive-reconciliation.json")
+STATUS_PATH = Path("reconciliation-exit-status.txt")
+
+
+def annotation(title, message):
+    """Emit an escaped GitHub error annotation."""
+    safe = (
+        message.replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+    )
+    print(f"::error title={title}::{safe}")
+
+
+def uuid_input(value, label, errors):
+    if not value:
+        return None
+    try:
+        return str(UUID(value))
+    except (AttributeError, ValueError):
+        message = f"{label} is not a valid UUID: {value!r}"
+        errors.append(message)
+        annotation("Malformed UUID", message)
+        return None
+
+
+def integer_input(name, minimum, maximum, errors):
+    raw = os.environ.get(f"INPUT_{name.upper()}", "")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        message = f"{name} must be an integer; received {raw!r}"
+        errors.append(message)
+        annotation(f"Invalid {name}", message)
+        return None
+    if value < minimum or (maximum is not None and value > maximum):
+        bounds = (
+            f"between {minimum} and {maximum}"
+            if maximum is not None
+            else f"at least {minimum}"
+        )
+        message = f"{name} must be {bounds}; received {value}"
+        errors.append(message)
+        annotation(f"Invalid {name}", message)
+        return None
+    return value
+
+
+def validate_inputs(mode):
+    """Normalise input files and fail with annotations for unsafe requests."""
+    LOG_PATH.write_text("", encoding="utf-8")
+    errors = []
+
+    publisher_raw = os.environ.get("INPUT_PUBLISHER_ID", "").strip()
+    publisher_id = uuid_input(publisher_raw, "publisher_id", errors)
+
+    explicit_entries = [
+        entry.strip()
+        for entry in re.split(
+            r"[,\r\n]+", os.environ.get("INPUT_WORK_IDS", "")
+        )
+        if entry.strip()
+    ]
+    explicit_ids = sorted(set(filter(None, (
+        uuid_input(entry, "work_ids entry", errors)
+        for entry in explicit_entries
+    ))))
+
+    limit = integer_input("limit", 1, 200, errors)
+    offset = integer_input("offset", 0, None, errors)
+
+    if not publisher_raw and not explicit_entries:
+        message = "At least one of publisher_id or work_ids must be supplied"
+        errors.append(message)
+        annotation("No selection criteria", message)
+
+    possible_batch = None
+    if limit is not None:
+        possible_batch = (
+            limit + len(explicit_ids)
+            if publisher_raw
+            else len(explicit_ids)
+        )
+        if possible_batch > 200:
+            message = (
+                "The requested batch can select up to "
+                f"{possible_batch} works; the hard limit is 200"
+            )
+            errors.append(message)
+            annotation("Combined batch exceeds 200", message)
+
+    if mode == "apply":
+        if os.environ.get("INPUT_CONFIRM_APPLY") != "APPLY":
+            message = "Apply mode requires confirm_apply to be exactly APPLY"
+            errors.append(message)
+            annotation("Missing apply confirmation", message)
+        if os.environ.get("GITHUB_REF") != "refs/heads/develop":
+            message = (
+                "Apply mode is restricted to refs/heads/develop; received "
+                f"{os.environ.get('GITHUB_REF')!r}"
+            )
+            errors.append(message)
+            annotation("Apply ref restriction", message)
+
+    context = {
+        "artifact_name": os.environ["ARTIFACT_NAME"],
+        "explicit_work_id_count": len(explicit_ids),
+        "github_ref": os.environ.get("GITHUB_REF"),
+        "limit": limit,
+        "mode": mode,
+        "offset": offset,
+        "possible_batch_size": possible_batch,
+        "publisher_id": publisher_id,
+        "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "validation_errors": errors,
+    }
+    CONTEXT_PATH.write_text(
+        json.dumps(context, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    WORK_IDS_PATH.write_text(
+        "".join(f"{work_id}\n" for work_id in explicit_ids),
+        encoding="utf-8",
+    )
+
+    if errors:
+        with LOG_PATH.open("a", encoding="utf-8") as log:
+            for error in errors:
+                log.write(f"VALIDATION ERROR: {error}\n")
+        return 2
+
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as out:
+        out.write(f"publisher_id={publisher_id or ''}\n")
+        out.write(f"explicit_count={len(explicit_ids)}\n")
+        out.write(f"limit={limit}\n")
+        out.write(f"offset={offset}\n")
+    return 0
+
+
+def _load_context():
+    if not CONTEXT_PATH.exists():
+        return {}
+    try:
+        return json.loads(CONTEXT_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _report_lines(context):
+    if not REPORT_PATH.exists():
+        return [
+            "Execution failed before a complete report was generated. "
+            "Review the uploaded stderr log and run context."
+        ]
+
+    try:
+        report = json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+        summary = report["summary"]
+        results = report.get("results") or []
+        lines = [
+            "## Summary counts",
+            "",
+            "| Inspected | Current | Repairable | Ambiguous | Failed | Repaired |",
+            "| ---: | ---: | ---: | ---: | ---: | ---: |",
+            "| {inspected} | {current} | {repairable} | {ambiguous} | "
+            "{failed} | {repaired} |".format(**summary),
+            "",
+            "## Counts by status",
+            "",
+        ]
+        by_status = summary.get("by_status") or {}
+        if by_status:
+            lines.extend(
+                f"- `{status}`: {count}"
+                for status, count in by_status.items()
+            )
+        else:
+            lines.append("- No statuses reported")
+
+        if context.get("mode") == "apply":
+            lines.extend([
+                "",
+                "## Apply actions",
+                "",
+                "- Attempted actions: " + str(sum(
+                    len(result.get("attempted_actions") or [])
+                    for result in results
+                )),
+                "- Applied actions: " + str(sum(
+                    len(result.get("applied_actions") or [])
+                    for result in results
+                )),
+                "- Uncertain actions: " + str(sum(
+                    len(result.get("uncertain_actions") or [])
+                    for result in results
+                )),
+            ])
+        return lines
+    except (KeyError, OSError, TypeError, ValueError) as error:
+        return [
+            "The report exists but could not be parsed for this summary: "
+            f"{error}. Review the uploaded report and log."
+        ]
+
+
+def write_summary():
+    """Write a concise summary without exposing per-work report details."""
+    context = _load_context()
+    lines = [
+        "# Internet Archive reconciliation",
+        "",
+        f"- Mode: {context.get('mode', 'unavailable')}",
+    ]
+    if context.get("publisher_id"):
+        lines.append(f"- Publisher ID: `{context['publisher_id']}`")
+    cli_status = (
+        STATUS_PATH.read_text(encoding="utf-8").strip()
+        if STATUS_PATH.exists()
+        else "unavailable"
+    )
+    artifact_name = (
+        context.get("artifact_name")
+        or os.environ.get("ARTIFACT_NAME", "unavailable")
+    )
+    lines.extend([
+        "- Explicit work IDs: "
+        f"{context.get('explicit_work_id_count', 'unavailable')}",
+        f"- Requested limit: {context.get('limit', 'invalid')}",
+        f"- Requested offset: {context.get('offset', 'invalid')}",
+        f"- CLI exit status: {cli_status}",
+        f"- Artifact: `{artifact_name}`",
+        "",
+    ])
+
+    validation_errors = context.get("validation_errors") or []
+    if validation_errors:
+        lines.extend(["## Validation errors", ""])
+        lines.extend(f"- {error}" for error in validation_errors)
+        lines.append("")
+    lines.extend(_report_lines(context))
+
+    with Path(os.environ["GITHUB_STEP_SUMMARY"]).open(
+        "a", encoding="utf-8"
+    ) as summary_file:
+        summary_file.write("\n".join(lines) + "\n")
+    return 0
+
+
+def parse_arguments(argv=None):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--mode", choices=("dry-run", "apply"), required=True)
+    subparsers.add_parser("summary")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    arguments = parse_arguments(argv)
+    if arguments.command == "validate":
+        return validate_inputs(arguments.mode)
+    return write_summary()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/ia_selection_workflow.py
+++ b/.github/scripts/ia_selection_workflow.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Safe output, summary and final-status handling for scheduled IA selection."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+
+def _read_status(path):
+    try:
+        return int(Path(path).read_text(encoding='utf-8').strip())
+    except (OSError, TypeError, ValueError):
+        return 1
+
+
+def _read_report(path):
+    try:
+        report = json.loads(Path(path).read_text(encoding='utf-8'))
+    except (OSError, TypeError, ValueError):
+        return None
+    return report if isinstance(report, dict) else None
+
+
+def _read_selected_ids(path):
+    try:
+        selected = json.loads(Path(path).read_text(encoding='utf-8'))
+    except (OSError, TypeError, ValueError):
+        return None
+    if not isinstance(selected, list) or not all(
+            isinstance(work_id, str) for work_id in selected):
+        return None
+    return selected
+
+
+def _append_output(name, value):
+    output_path = os.environ.get('GITHUB_OUTPUT')
+    if not output_path:
+        raise RuntimeError('GITHUB_OUTPUT is not set')
+    with open(output_path, 'a', encoding='utf-8') as output:
+        output.write('{}={}\n'.format(name, value))
+
+
+def emit_outputs(args):
+    report = _read_report(args.report)
+    selected = _read_selected_ids(args.selected_ids)
+    status = _read_status(args.status)
+    valid_report = report is not None
+    valid_ids = selected is not None
+
+    if selected is None:
+        selected = []
+    compact_ids = json.dumps(selected, separators=(',', ':'))
+    _append_output('work_ids', compact_ids)
+    _append_output(
+        'selected_count',
+        report.get('selected_count', 0) if valid_report else 0)
+    _append_output(
+        'omitted_count',
+        report.get('omitted_count', 0) if valid_report else 0)
+    _append_output(
+        'truncated',
+        str(bool(report.get('truncated')) if valid_report else False).lower())
+    _append_output('selection_exit_status', status)
+    _append_output('report_valid', str(valid_report).lower())
+    _append_output('ids_valid', str(valid_ids).lower())
+    _append_output('artifact_name', args.artifact_name)
+    return 0
+
+
+def write_summary(args):
+    report = _read_report(args.report)
+    status = _read_status(args.status)
+    summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
+    if not summary_path:
+        raise RuntimeError('GITHUB_STEP_SUMMARY is not set')
+
+    lines = [
+        '## Internet Archive scheduled selection',
+        '',
+        '- Selection exit status: `{}`'.format(status),
+        '- Artifact: `{}`'.format(args.artifact_name),
+    ]
+    if report is None:
+        lines.extend([
+            '- Diagnostics: expected selection report is missing or invalid',
+            '',
+        ])
+    else:
+        window = report.get('window') or {}
+        lines.extend([
+            '- Window start: `{}`'.format(window.get('start', 'unavailable')),
+            '- Window end: `{}`'.format(window.get('end', 'unavailable')),
+            '- Lookback hours: `{}`'.format(
+                window.get('lookback_hours', 'unavailable')),
+            '- Configured publishers: `{}`'.format(
+                len(report.get('publisher_ids') or [])),
+            '- Queried works: `{}`'.format(report.get('queried_count', 0)),
+            '- Eligible works: `{}`'.format(report.get('eligible_count', 0)),
+            '- Selected works: `{}`'.format(report.get('selected_count', 0)),
+            '- Omitted works: `{}`'.format(report.get('omitted_count', 0)),
+            '- Truncated: `{}`'.format(
+                str(bool(report.get('truncated'))).lower()),
+            '',
+            '### Excluded by reason',
+            '',
+        ])
+        excluded_counts = report.get('excluded_counts') or {}
+        if excluded_counts:
+            lines.extend(
+                '- `{}`: {}'.format(reason, excluded_counts[reason])
+                for reason in sorted(excluded_counts)
+            )
+        else:
+            lines.append('- None')
+        lines.append('')
+
+    with open(summary_path, 'a', encoding='utf-8') as summary:
+        summary.write('\n'.join(lines))
+    return 0
+
+
+def selection_guard(args):
+    status = _read_status(args.status)
+    report = _read_report(args.report)
+    selected = _read_selected_ids(args.selected_ids)
+    if status != 0:
+        print(
+            'Selection failed with exit status {}'.format(status),
+            file=sys.stderr)
+        return 1
+    if report is None:
+        print('Selection report is missing or invalid', file=sys.stderr)
+        return 1
+    if selected is None:
+        print('Selected work ID output is missing or invalid', file=sys.stderr)
+        return 1
+    report_ids = [
+        entry.get('work_id') for entry in report.get('selected', [])
+        if isinstance(entry, dict)
+    ]
+    if selected != report_ids:
+        print(
+            'Selected work ID output does not match the report',
+            file=sys.stderr)
+        return 1
+    return 0
+
+
+def final_guard(_args):
+    selection_result = os.environ.get('SELECTION_RESULT', '')
+    dissemination_result = os.environ.get('DISSEMINATION_RESULT', '')
+    selected_count = os.environ.get('SELECTED_COUNT', '0')
+    omitted_count = os.environ.get('OMITTED_COUNT', '0')
+    truncated = os.environ.get('TRUNCATED', 'false').lower() == 'true'
+    artifact_name = os.environ.get('ARTIFACT_NAME', 'ia-selection diagnostics')
+
+    errors = []
+    if selection_result != 'success':
+        errors.append(
+            'selection job result was `{}`'.format(
+                selection_result or 'unavailable'))
+    if selected_count != '0' and dissemination_result != 'success':
+        errors.append(
+            'dissemination job result was `{}`'.format(
+                dissemination_result or 'unavailable'))
+    if selected_count == '0' and dissemination_result not in (
+            'skipped', 'success'):
+        errors.append(
+            'empty selection had unexpected dissemination result `{}`'.format(
+                dissemination_result or 'unavailable'))
+    if truncated:
+        errors.append(
+            '{} eligible works were omitted by the bounded selection'.format(
+                omitted_count))
+
+    summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
+    if summary_path:
+        with open(summary_path, 'a', encoding='utf-8') as summary:
+            summary.write('## Internet Archive final status\n\n')
+            if errors:
+                for error in errors:
+                    summary.write('- Failure: {}\n'.format(error))
+                if truncated:
+                    summary.write(
+                        '- Inspect artifact `{}` and run bounded manual '
+                        'reconciliation or another reviewed bounded operation '
+                        'for omitted works.\n'.format(artifact_name))
+            else:
+                summary.write(
+                    '- Selection and all required dissemination completed '
+                    'without overflow.\n')
+
+    for error in errors:
+        print(error, file=sys.stderr)
+    return 1 if errors else 0
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    outputs = subparsers.add_parser('outputs')
+    outputs.add_argument('--report', required=True)
+    outputs.add_argument('--selected-ids', required=True)
+    outputs.add_argument('--status', required=True)
+    outputs.add_argument('--artifact-name', required=True)
+    outputs.set_defaults(func=emit_outputs)
+
+    summary = subparsers.add_parser('summary')
+    summary.add_argument('--report', required=True)
+    summary.add_argument('--status', required=True)
+    summary.add_argument('--artifact-name', required=True)
+    summary.set_defaults(func=write_summary)
+
+    guard = subparsers.add_parser('selection-guard')
+    guard.add_argument('--report', required=True)
+    guard.add_argument('--selected-ids', required=True)
+    guard.add_argument('--status', required=True)
+    guard.set_defaults(func=selection_guard)
+
+    final = subparsers.add_parser('final-guard')
+    final.set_defaults(func=final_guard)
+    return parser
+
+
+def main(argv=None):
+    args = get_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/disseminate.yml
+++ b/.github/workflows/disseminate.yml
@@ -2,6 +2,10 @@
 # (given as an array of work IDs) from Thoth to the specified platform.
 name: disseminate
 
+concurrency:
+  group: ${{ format('disseminate-{0}-{1}', inputs.platform, inputs.work-id) }}
+  cancel-in-progress: false
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ia_bulk_disseminate.yml
+++ b/.github/workflows/ia_bulk_disseminate.yml
@@ -1,27 +1,151 @@
-# Purpose: upload newly-published works from Thoth to Internet Archive.
-# Uploads all active Thoth works with a publication date within the previous calendar month.
-# Work must have a valid URL supplied as the PDF Publication Canonical Location.
-# IA credentials for a user with write permissions to the Thoth Archiving Network
-# collection (e.g. thoth_pub) must be present as repository secrets
-# named IA_S3_ACCESS (access key) and IA_S3_SECRET (secret key).
+# Select recently updated, IA-eligible works and disseminate a bounded batch.
 name: ia-bulk-disseminate
 
 on:
   schedule:
-    # 'at 04:40 on day-of-month 7'
-    # There might be a delay between a book being published and the publisher
-    # correctly setting its publication date and Active status in Thoth.
-    # Therefore, this action is run a few days after the start of the month,
-    # to minimise situations where e.g. a book which was published on the 31st, but
-    # whose record was not updated until the 1st, is missed out of both months' runs.
-    - cron: '40 4 7 * *'
+    - cron: '40 4 * * *'
   workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: UTC lookback window in hours (maximum 168)
+        required: false
+        type: number
+        default: 30
+      max_works:
+        description: Maximum works to disseminate (hard maximum 200)
+        required: false
+        type: number
+        default: 200
+
+concurrency:
+  group: internet-archive-scheduled-dissemination
+  cancel-in-progress: false
 
 jobs:
-  ia-bulk-disseminate:
-    uses: ./.github/workflows/bulk_disseminate.yml
+  select:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      work_ids: ${{ steps.outputs.outputs.work_ids }}
+      selected_count: ${{ steps.outputs.outputs.selected_count }}
+      omitted_count: ${{ steps.outputs.outputs.omitted_count }}
+      truncated: ${{ steps.outputs.outputs.truncated }}
+      selection_exit_status: ${{ steps.outputs.outputs.selection_exit_status }}
+      artifact_name: ${{ steps.outputs.outputs.artifact_name }}
+    env:
+      ARTIFACT_NAME: ia-selection-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements_obtain_new_ids.txt
+
+      - name: Install selection dependencies
+        run: python -m pip install -r requirements_obtain_new_ids.txt
+
+      - name: Select recently updated eligible works
+        env:
+          ENV_PUBLISHERS: ${{ vars.IA_ENV_PUBLISHERS }}
+          ENV_EXCEPTIONS: ${{ vars.IA_ENV_EXCEPTIONS }}
+        run: |
+          lookback_hours="${{ inputs.lookback_hours }}"
+          max_works="${{ inputs.max_works }}"
+          if [[ -z "$lookback_hours" ]]; then
+            lookback_hours=30
+          fi
+          if [[ -z "$max_works" ]]; then
+            max_works=200
+          fi
+
+          set +e
+          python obtain_new_ids.py \
+            --platform InternetArchive \
+            --lookback-hours "$lookback_hours" \
+            --max-ids "$max_works" \
+            --report internet-archive-selection.json \
+            > selected-work-ids.json \
+            2> >(tee internet-archive-selection.log >&2)
+          status=$?
+          set -e
+          echo "$status" > selection-exit-status.txt
+
+      - name: Expose bounded selection outputs
+        id: outputs
+        if: ${{ always() }}
+        run: >-
+          python3 .github/scripts/ia_selection_workflow.py outputs
+          --report internet-archive-selection.json
+          --selected-ids selected-work-ids.json
+          --status selection-exit-status.txt
+          --artifact-name "$ARTIFACT_NAME"
+
+      - name: Upload selection diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            internet-archive-selection.json
+            internet-archive-selection.log
+          retention-days: 30
+          if-no-files-found: warn
+          overwrite: false
+
+      - name: Write selection summary
+        if: ${{ always() }}
+        run: >-
+          python3 .github/scripts/ia_selection_workflow.py summary
+          --report internet-archive-selection.json
+          --status selection-exit-status.txt
+          --artifact-name "$ARTIFACT_NAME"
+
+      - name: Preserve selection failure status
+        if: ${{ always() }}
+        run: >-
+          python3 .github/scripts/ia_selection_workflow.py selection-guard
+          --report internet-archive-selection.json
+          --selected-ids selected-work-ids.json
+          --status selection-exit-status.txt
+
+  disseminate:
+    needs: select
+    if: ${{ needs.select.outputs.selected_count != '0' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        work-id: ${{ fromJSON(needs.select.outputs.work_ids) }}
+    uses: ./.github/workflows/disseminate.yml
     with:
-      platform: 'InternetArchive'
-      env_publishers: ${{ vars.IA_ENV_PUBLISHERS }}
-      env_exceptions: ${{ vars.IA_ENV_EXCEPTIONS }}
+      platform: InternetArchive
+      work-id: ${{ matrix.work-id }}
     secrets: inherit
+
+  final-status:
+    if: ${{ always() }}
+    needs:
+      - select
+      - disseminate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Evaluate selection, dissemination, and overflow
+        env:
+          SELECTION_RESULT: ${{ needs.select.result }}
+          DISSEMINATION_RESULT: ${{ needs.disseminate.result }}
+          SELECTED_COUNT: ${{ needs.select.outputs.selected_count }}
+          OMITTED_COUNT: ${{ needs.select.outputs.omitted_count }}
+          TRUNCATED: ${{ needs.select.outputs.truncated }}
+          ARTIFACT_NAME: ${{ needs.select.outputs.artifact_name }}
+        run: python3 .github/scripts/ia_selection_workflow.py final-guard

--- a/.github/workflows/ia_reconcile.yml
+++ b/.github/workflows/ia_reconcile.yml
@@ -1,0 +1,221 @@
+# Purpose: manually inspect or repair bounded Internet Archive reconciliation batches.
+# Required reviewers must be configured on the `disseminate` GitHub environment;
+# workflow YAML cannot create environment protection rules.
+name: internet-archive-reconciliation
+run-name: >-
+  IA reconciliation (${{ inputs.apply && 'apply' || 'dry-run' }})
+  for ${{ inputs.publisher_id || 'explicit works' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      publisher_id:
+        description: 'Optional Thoth publisher UUID'
+        required: false
+        type: string
+      work_ids:
+        description: 'Optional comma- or newline-separated Thoth work UUIDs'
+        required: false
+        type: string
+      limit:
+        description: 'Maximum publisher works to select (1-200)'
+        required: true
+        default: 100
+        type: number
+      offset:
+        description: 'Non-negative publisher selection offset'
+        required: true
+        default: 0
+        type: number
+      apply:
+        description: 'Apply safe automatic repairs'
+        required: true
+        default: false
+        type: boolean
+      confirm_apply:
+        description: 'Enter APPLY to confirm apply mode'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    ia-reconciliation-${{
+      inputs.publisher_id != '' &&
+      inputs.publisher_id ||
+      format('explicit-{0}-{1}', github.run_id, github.run_attempt)
+    }}
+  cancel-in-progress: false
+
+jobs:
+  dry-run:
+    if: ${{ inputs.apply == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    env:
+      ARTIFACT_NAME: ia-reconciliation-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate and normalise inputs
+        id: inputs
+        env:
+          INPUT_PUBLISHER_ID: ${{ inputs.publisher_id }}
+          INPUT_WORK_IDS: ${{ inputs.work_ids }}
+          INPUT_LIMIT: ${{ inputs.limit }}
+          INPUT_OFFSET: ${{ inputs.offset }}
+        run: >-
+          python3 .github/scripts/ia_reconcile_workflow.py
+          validate --mode dry-run
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run read-only reconciliation
+        env:
+          PUBLISHER_ID: ${{ steps.inputs.outputs.publisher_id }}
+          LIMIT: ${{ steps.inputs.outputs.limit }}
+          OFFSET: ${{ steps.inputs.outputs.offset }}
+        run: |
+          command=(
+            python reconcile_internet_archive.py
+            --format json
+            --output internet-archive-reconciliation.json
+            --limit "$LIMIT"
+            --offset "$OFFSET"
+          )
+          if [[ -n "$PUBLISHER_ID" ]]; then
+            command+=(--publisher-id "$PUBLISHER_ID")
+          fi
+          while IFS= read -r work_id; do
+            if [[ -n "$work_id" ]]; then
+              command+=(--work-id "$work_id")
+            fi
+          done < normalised-work-ids.txt
+
+          set +e
+          "${command[@]}" \
+            2> >(tee -a internet-archive-reconciliation.log >&2)
+          status=$?
+          set -e
+
+          echo "$status" > reconciliation-exit-status.txt
+          exit "$status"
+
+      - name: Upload reconciliation diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            internet-archive-reconciliation.json
+            internet-archive-reconciliation.log
+            reconciliation-run-context.json
+          retention-days: 30
+          if-no-files-found: error
+          overwrite: false
+
+      - name: Write reconciliation summary
+        if: ${{ always() }}
+        run: python3 .github/scripts/ia_reconcile_workflow.py summary
+
+  apply:
+    if: ${{ inputs.apply == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    environment: disseminate
+    permissions:
+      contents: read
+    env:
+      ARTIFACT_NAME: ia-reconciliation-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate and normalise inputs
+        id: inputs
+        env:
+          INPUT_PUBLISHER_ID: ${{ inputs.publisher_id }}
+          INPUT_WORK_IDS: ${{ inputs.work_ids }}
+          INPUT_LIMIT: ${{ inputs.limit }}
+          INPUT_OFFSET: ${{ inputs.offset }}
+          INPUT_CONFIRM_APPLY: ${{ inputs.confirm_apply }}
+        run: >-
+          python3 .github/scripts/ia_reconcile_workflow.py
+          validate --mode apply
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run protected reconciliation
+        env:
+          PUBLISHER_ID: ${{ steps.inputs.outputs.publisher_id }}
+          LIMIT: ${{ steps.inputs.outputs.limit }}
+          OFFSET: ${{ steps.inputs.outputs.offset }}
+          ia_s3_access: ${{ secrets.IA_S3_ACCESS }}
+          ia_s3_secret: ${{ secrets.IA_S3_SECRET }}
+          THOTH_PAT: ${{ secrets.THOTH_PAT }}
+        run: |
+          command=(
+            python reconcile_internet_archive.py
+            --format json
+            --output internet-archive-reconciliation.json
+            --limit "$LIMIT"
+            --offset "$OFFSET"
+            --apply
+          )
+          if [[ -n "$PUBLISHER_ID" ]]; then
+            command+=(--publisher-id "$PUBLISHER_ID")
+          fi
+          while IFS= read -r work_id; do
+            if [[ -n "$work_id" ]]; then
+              command+=(--work-id "$work_id")
+            fi
+          done < normalised-work-ids.txt
+
+          set +e
+          "${command[@]}" \
+            2> >(tee -a internet-archive-reconciliation.log >&2)
+          status=$?
+          set -e
+
+          echo "$status" > reconciliation-exit-status.txt
+          exit "$status"
+
+      - name: Upload reconciliation diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            internet-archive-reconciliation.json
+            internet-archive-reconciliation.log
+            reconciliation-run-context.json
+          retention-days: 30
+          if-no-files-found: error
+          overwrite: false
+
+      - name: Write reconciliation summary
+        if: ${{ always() }}
+        run: python3 .github/scripts/ia_reconcile_workflow.py summary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m unittest discover -v
+
+      - name: Compile Python sources
+        run: python -m compileall -q .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
   - Send explicit GraphQL nulls when clearing nullable location full-text URLs
+  - Keep reconciliation JSON/JSONL stdout machine-readable during Thoth location mutations while preserving explicit standalone location ID output
+  - Load local `config.env` values before reconciliation apply credential validation without overriding exported environment variables
   - Refuse to create or repair an Internet Archive item unless its missing identifier is explicitly reported as available
   - Block automatic Archive and Thoth mutations when an existing item has missing or incompatible initial-only `mediatype` metadata
   - Stop automatic collection membership patches and report existing items outside the Thoth Archiving Network collection for manual Internet Archive administrator coordination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Set the dissemination service version to the next feature release, 1.5.0
 
 ### Fixed
+  - Refresh and reclassify Internet Archive item ownership immediately before the first repair mutation
   - Send explicit GraphQL nulls when clearing nullable location full-text URLs
   - Keep reconciliation JSON/JSONL stdout machine-readable during Thoth location mutations while preserving explicit standalone location ID output
   - Load local `config.env` values before reconciliation apply credential validation without overriding exported environment variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
   - Send explicit GraphQL nulls when clearing nullable location full-text URLs
+  - Refuse to create or repair an Internet Archive item unless its missing identifier is explicitly reported as available
 
 ## [[1.4.1]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v1.4.1) - 2026-07-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Send explicit GraphQL nulls when clearing nullable location full-text URLs
   - Keep reconciliation JSON/JSONL stdout machine-readable during Thoth location mutations while preserving explicit standalone location ID output
   - Load local `config.env` values before reconciliation apply credential validation without overriding exported environment variables
+  - Reinspect remote state after an Archive repair succeeds but the following Thoth location mutation fails
   - Refuse to create or repair an Internet Archive item unless its missing identifier is explicitly reported as available
   - Block automatic Archive and Thoth mutations when an existing item has missing or incompatible initial-only `mediatype` metadata
   - Stop automatic collection membership patches and report existing items outside the Thoth Archiving Network collection for manual Internet Archive administrator coordination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
   - Made Internet Archive dissemination idempotently converge managed originals and metadata, verify their final remote state in one bounded polling loop, and preserve unrelated Archive data
+  - Distinguished mutable Internet Archive metadata from initial-only `mediatype` state in reconciliation reports
   - Made Thoth location write-back converge create, update, and no-op states while preserving canonical and checksum data
   - Report all reconciliation recommendations separately from safe automatic, attempted, applied, and uncertain actions
   - Set the dissemination service version to the next feature release, 1.5.0
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
   - Send explicit GraphQL nulls when clearing nullable location full-text URLs
   - Refuse to create or repair an Internet Archive item unless its missing identifier is explicitly reported as available
+  - Block automatic Archive and Thoth mutations when an existing item has missing or incompatible initial-only `mediatype` metadata
 
 ## [[1.4.1]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v1.4.1) - 2026-07-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+  - Added a manual, dry-run-by-default Internet Archive reconciliation workflow with bounded input validation, protected `develop`-only apply mode, diagnostic artifacts, and Step Summaries
   - Added a read-only-by-default Internet Archive reconciliation CLI with explicit and publisher selection provenance, deterministic JSON/JSONL reports, and guarded apply mode
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  - Added a read-only-by-default Internet Archive reconciliation CLI with explicit and publisher selection provenance, deterministic JSON/JSONL reports, and guarded apply mode
+
+### Changed
+  - Made Internet Archive dissemination idempotently converge managed originals and metadata, verify their final remote state in one bounded polling loop, and preserve unrelated Archive data
+  - Made Thoth location write-back converge create, update, and no-op states while preserving canonical and checksum data
+  - Report all reconciliation recommendations separately from safe automatic, attempted, applied, and uncertain actions
+  - Set the dissemination service version to the next feature release, 1.5.0
+
+### Fixed
+  - Send explicit GraphQL nulls when clearing nullable location full-text URLs
 
 ## [[1.4.1]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v1.4.1) - 2026-07-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
   - Added a manual, dry-run-by-default Internet Archive reconciliation workflow with bounded input validation, protected `develop`-only apply mode, diagnostic artifacts, and Step Summaries
   - Added a read-only-by-default Internet Archive reconciliation CLI with explicit and publisher selection provenance, deterministic JSON/JSONL reports, and guarded apply mode
+  - Added deterministic scheduled Internet Archive selection reports, 30-day diagnostic artifacts, Step Summaries, and a visible final overflow guard
 
 ### Changed
   - Made Internet Archive dissemination idempotently converge managed originals and metadata, verify their final remote state in one bounded polling loop, and preserve unrelated Archive data
+  - Changed scheduled Internet Archive dissemination from monthly publication-date selection to daily `updatedAtWithRelations` selection using a captured 30-hour UTC window, a 200-work oldest-first cap, and four-way parallelism
+  - Prevent simultaneous ordinary dissemination of the same platform/work pair while allowing different works and platforms to proceed independently
+  - Emit compact valid JSON arrays from all automatic ID finders
   - Distinguished mutable Internet Archive metadata from initial-only `mediatype` and administrator-only collection state in reconciliation reports
   - Made Thoth location write-back converge create, update, and no-op states while preserving canonical and checksum data
   - Report all reconciliation recommendations separately from safe automatic, attempted, applied, and uncertain actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
   - Made Internet Archive dissemination idempotently converge managed originals and metadata, verify their final remote state in one bounded polling loop, and preserve unrelated Archive data
-  - Distinguished mutable Internet Archive metadata from initial-only `mediatype` state in reconciliation reports
+  - Distinguished mutable Internet Archive metadata from initial-only `mediatype` and administrator-only collection state in reconciliation reports
   - Made Thoth location write-back converge create, update, and no-op states while preserving canonical and checksum data
   - Report all reconciliation recommendations separately from safe automatic, attempted, applied, and uncertain actions
   - Set the dissemination service version to the next feature release, 1.5.0
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Send explicit GraphQL nulls when clearing nullable location full-text URLs
   - Refuse to create or repair an Internet Archive item unless its missing identifier is explicitly reported as available
   - Block automatic Archive and Thoth mutations when an existing item has missing or incompatible initial-only `mediatype` metadata
+  - Stop automatic collection membership patches and report existing items outside the Thoth Archiving Network collection for manual Internet Archive administrator coordination
 
 ## [[1.4.1]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v1.4.1) - 2026-07-20
 ### Fixed

--- a/DISTRIBUTION_WORKFLOW.md
+++ b/DISTRIBUTION_WORKFLOW.md
@@ -4,14 +4,20 @@ This document describes the workflow currently implemented in `thoth-disseminati
 
 ## 1) End-to-end architecture
 
-1. A scheduled (or manual) GitHub workflow calls `bulk_disseminate.yml` with:
+1. Most scheduled (or manual) GitHub workflows call `bulk_disseminate.yml` with:
    - `platform`
    - `env_publishers` (JSON list of publisher IDs)
    - `env_exceptions` (JSON list of work IDs to skip)
-2. `bulk_disseminate.yml` runs `obtain_new_ids.py --platform <platform>` to produce a list of work IDs.
-3. It fans out to one `disseminate.yml` run per work ID.
-4. `disseminate.yml` runs `disseminator.py --work <work-id> --platform <platform>`.
-5. Platform uploaders either:
+2. Internet Archive instead uses a dedicated daily
+   `ia_bulk_disseminate.yml` selection/reporting job.
+3. The selector runs `obtain_new_ids.py --platform <platform>` and emits a
+   compact JSON list of work IDs.
+4. The calling workflow fans out to one `disseminate.yml` run per work ID.
+   Scheduled IA uses at most four parallel works.
+5. `disseminate.yml` prevents overlapping ordinary runs for the same
+   platform/work pair.
+6. `disseminate.yml` runs `disseminator.py --work <work-id> --platform <platform>`.
+7. Platform uploaders either:
    - return upload locations (which can be written back to Thoth), or
    - return no locations (and rely on email notifications / later catch-up).
 
@@ -30,6 +36,19 @@ All automatic runs share these rules from `obtain_new_ids.py`:
   - `MonthlyIDFinder`: previous calendar month.
   - `GooglePlayIDFinder`: previous day.
   - `CrossrefIDFinder`: updated within ~last 1.25 hours.
+- `InternetArchiveIDFinder` is deliberately different:
+  - required `IA_ENV_PUBLISHERS` and optional `IA_ENV_EXCEPTIONS` values are
+    validated as JSON UUID arrays;
+  - selection uses `updatedAtWithRelations`, so relation-only changes qualify;
+  - the captured UTC interval is
+    `updatedAtWithRelations > start && updatedAtWithRelations <= end`;
+  - the default 30-hour lookback creates six hours of overlap between daily
+    runs, and the documented hard maximum is 168 hours;
+  - only active IA-supported book-level works with a PDF and a non-empty
+    canonical PDF `fullTextUrl` qualify;
+  - selection performs no PDF/export download and no request to source URLs;
+  - eligible works are ordered by oldest update, then UUID, before the
+    200-work cap.
 
 ## 3) Platform schedule and scope matrix
 
@@ -37,7 +56,7 @@ GitHub Actions schedules run in UTC.
 
 | Platform | Workflow | Cadence | Selector class | High-level scope |
 |---|---|---|---|---|
-| InternetArchive | `ia_bulk_disseminate.yml` | Monthly, day 1 at 00:15 | `InternetArchiveIDFinder` | Active works not already in IA collection |
+| InternetArchive | `ia_bulk_disseminate.yml` | Daily at 04:40 | `InternetArchiveIDFinder` | Active supported works updated in the captured previous 30 hours with a usable canonical PDF source |
 | Crossref | `cr_bulk_disseminate.yml` | Hourly at :45 | `CrossrefIDFinder` | Active + qualifying Forthcoming works updated recently |
 | Figshare | `fs_bulk_disseminate.yml` | Monthly, day 7 at 04:40 | `MonthlyIDFinder` | Previous calendar month, active |
 | Zenodo | `zn_bulk_disseminate.yml` | Monthly, day 7 at 04:40 | `MonthlyIDFinder` | Previous calendar month, active |
@@ -54,16 +73,31 @@ GitHub Actions schedules run in UTC.
 ## 4) Platform-by-platform payload and conditions
 
 ### Internet Archive (`InternetArchive`)
+- Scheduled selection:
+  - Daily at 04:40 UTC with a default 30-hour relation-aware update window
+  - Uses `IA_ENV_PUBLISHERS` and optional `IA_ENV_EXCEPTIONS`
+  - Captures one upper boundary and excludes later updates for the next run
+  - Processes at most 200 works, oldest update first, with four-way parallelism
+  - Uploads a 30-day selection report/log artifact and writes aggregate counts
+    to the Step Summary
+  - Reports every overflow record and fails the final status after the bounded
+    selected batch completes
 - Upload content:
   - Required: PDF publication file
   - Also uploads: `json::thoth` metadata file
   - Uses work ID as IA identifier
 - Preconditions:
   - `ia_s3_access` / `ia_s3_secret`
-  - Identifier must not already exist in IA
-  - PDF canonical location must exist and be downloadable
+  - New identifiers must be explicitly available; owned existing items are
+    updated idempotently
+  - PDF canonical location must exist and be downloadable during dissemination
 - Automatic writeback:
-  - Returns Thoth location (`INTERNET_ARCHIVE`) and is written back by workflow.
+  - Returns Thoth location (`INTERNET_ARCHIVE`) and idempotently creates,
+    updates, or preserves it.
+- Operations:
+  - Unchanged selected works safely no-op.
+  - Use the selection artifact plus bounded manual reconciliation for omitted
+    or ambiguous works.
 
 ### OAPEN (`OAPEN`)
 - Upload content:
@@ -252,11 +286,12 @@ From `disseminate.yml`, email job runs for:
 ## 7) Known implementation caveats in current repo state
 
 1. `muse_bulk_disseminate.yaml` passes `platform: 'MUSE'`, but platform matching in `obtain_new_ids.py` and `disseminator.py` expects `ProjectMUSE`. As coded, scheduled Project MUSE bulk runs will not resolve the platform correctly.
-2. Workflows that call `write_locations.py` set `THOTH_EMAIL` instead of `THOTH_PAT`, but `write_locations.py` requires `THOTH_PAT`. This can prevent automatic location writeback unless `THOTH_PAT` is otherwise present in job env.
-3. `ProQuest` uploader intends PDF-or-EPUB support, but it retrieves PDF ISBN before fallback logic, so EPUB-only records can fail early.
+2. `ProQuest` uploader intends PDF-or-EPUB support, but it retrieves PDF ISBN before fallback logic, so EPUB-only records can fail early.
 
 ## 8) Manual operations
 
 - `manual_disseminate.yml` supports ad-hoc dissemination of explicit work ID arrays to a chosen platform string.
 - `disseminator.py` can also be run directly for one work ID and one platform.
-
+- `reconcile_internet_archive.py` supports bounded read-only inspection and
+  guarded apply repair for explicit works or a publisher selection. Use it to
+  review omitted or ambiguous scheduled-selection records.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,39 @@ docker run --rm --env-file config.env openbookpublishers/thoth-dissemination:lat
 
 See also `--help`.
 
+### Scheduled Internet Archive dissemination
+
+The **ia-bulk-disseminate** workflow runs daily at 04:40 UTC. It selects
+configured-publisher works whose `updatedAtWithRelations` timestamp is within
+one captured UTC window: greater than the start and less than or equal to the
+end. The default 30-hour lookback creates a six-hour overlap between ordinary
+daily runs; manual runs may use a positive lookback up to 168 hours.
+
+Selection requires `IA_ENV_PUBLISHERS` to be a non-empty JSON array of
+publisher UUIDs. `IA_ENV_EXCEPTIONS` is an optional JSON array of work UUIDs
+to exclude. Configured publishers and exceptions are validated and normalised
+before the read-only query runs.
+
+Only active `MONOGRAPH`, `EDITED_BOOK`, `JOURNAL_ISSUE`, `TEXTBOOK`, and
+`BOOK_SET` records with a PDF publication and a non-empty canonical PDF
+`fullTextUrl` are eligible. Selection does not download the PDF, request an
+export, or make a request to the source URL. Eligible records are ordered by
+oldest relation-aware update and then work UUID. At most 200 are selected and
+four different works disseminate concurrently.
+
+Every run writes a concise Step Summary and retains a 30-day
+`ia-selection-<run>-<attempt>` artifact containing the machine-readable report
+and sanitised selection log. If more than 200 works are eligible, all omitted
+records are reported; the bounded selected batch finishes, then the final
+workflow job fails visibly. Inspect the artifact and use bounded manual
+reconciliation or another reviewed bounded operation for omitted or ambiguous
+records.
+
+The reusable dissemination workflow prevents simultaneous ordinary runs for
+the same platform/work pair. Different works and platforms remain independent.
+Because Internet Archive upload and Thoth location write-back are idempotent,
+an unchanged selected work safely converges as a no-op.
+
 ### Reconcile Internet Archive state
 
 Inspect one or more works without write credentials or remote mutations:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ python3 reconcile_internet_archive.py --publisher-id ${publisher_id} --limit 100
 
 Reports are deterministic JSON by default. Use `--format jsonl`, `--output
 <path>`, or `--apply` to select JSONL output, write an artifact, or apply safe
-repairs. Apply mode requires `ia_s3_access`, `ia_s3_secret`, and `THOTH_PAT`.
+repairs. JSON and JSONL stdout contain report data only; operational messages
+and successful location mutation IDs are logged to stderr. With `--output`, the
+report is written only to the requested file and stdout remains empty.
+
+Local CLI runs load `ia_s3_access`, `ia_s3_secret`, and `THOTH_PAT` from
+`./config.env`; already-exported process environment values take precedence.
+Apply mode requires all three credentials, while dry-run requires none. GitHub
+Actions continues to supply write credentials through the protected
+`disseminate` environment rather than a local configuration file.
 
 New Archive items are created with initial `mediatype: texts` metadata and
 membership in the `thoth-archiving-network` collection; final verification

--- a/README.md
+++ b/README.md
@@ -49,3 +49,20 @@ python3 reconcile_internet_archive.py --publisher-id ${publisher_id} --limit 100
 Reports are deterministic JSON by default. Use `--format jsonl`, `--output
 <path>`, or `--apply` to select JSONL output, write an artifact, or apply safe
 repairs. Apply mode requires `ia_s3_access`, `ia_s3_secret`, and `THOTH_PAT`.
+
+The **internet-archive-reconciliation** workflow can also be launched manually
+from the repository's **Actions** tab. Dry-run is the default and receives no
+Archive or Thoth write credentials. Select works with an optional publisher
+UUID, comma- or newline-separated work UUIDs, or both. Blank work entries are
+ignored and duplicates are removed. The workflow rejects batches that could
+exceed 200 works; use 50-100 works for normal runs.
+
+Every run uploads a 30-day diagnostic artifact and writes aggregate counts to
+the GitHub Step Summary, including when validation or reconciliation fails.
+Review a recent dry-run artifact before applying repairs. Apply runs require
+`confirm_apply` to be exactly `APPLY`, must run from `develop`, and wait for
+approval through the protected `disseminate` GitHub environment. Configure
+required reviewers on that environment in repository settings; workflow YAML
+cannot create the protection rule. Apply execution maps only the
+`IA_S3_ACCESS`, `IA_S3_SECRET`, and `THOTH_PAT` write credentials into the
+workflow job.

--- a/README.md
+++ b/README.md
@@ -50,15 +50,18 @@ Reports are deterministic JSON by default. Use `--format jsonl`, `--output
 <path>`, or `--apply` to select JSONL output, write an artifact, or apply safe
 repairs. Apply mode requires `ia_s3_access`, `ia_s3_secret`, and `THOTH_PAT`.
 
-New Archive items are created with the initial-only `mediatype` metadata set to
-`texts`, and final verification confirms that value. If an existing item has a
-missing or incompatible `mediatype`, reconciliation reports a
-`metadata_conflict` with separate immutable metadata details and a manual
-recommendation. Direct dissemination and apply mode do not upload files,
-modify Archive metadata, add ownership markers, or write Thoth locations for
-that work while the conflict remains. Remediation requires manual coordination
-with Internet Archive; the reconciler does not prescribe deleting or
-recreating the item.
+New Archive items are created with initial `mediatype: texts` metadata and
+membership in the `thoth-archiving-network` collection; final verification
+confirms both invariants. `mediatype` is initial-upload-only, while existing
+collection membership can be changed only by Internet Archive administrators.
+If an existing Thoth-owned item has an incompatible `mediatype` or does not
+include the Thoth collection, reconciliation reports a `metadata_conflict`
+with separate initial-only and admin-only details and a manual recommendation.
+Direct dissemination and apply mode do not upload files, modify Archive
+metadata, add ownership markers, or write Thoth locations for that work while
+the conflict remains. Collection remediation requires manual coordination with
+Internet Archive; the reconciler reports but does not mutate these records and
+does not prescribe deleting or recreating the item.
 
 The **internet-archive-reconciliation** workflow can also be launched manually
 from the repository's **Actions** tab. Dry-run is the default and receives no

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Reports are deterministic JSON by default. Use `--format jsonl`, `--output
 <path>`, or `--apply` to select JSONL output, write an artifact, or apply safe
 repairs. Apply mode requires `ia_s3_access`, `ia_s3_secret`, and `THOTH_PAT`.
 
+New Archive items are created with the initial-only `mediatype` metadata set to
+`texts`, and final verification confirms that value. If an existing item has a
+missing or incompatible `mediatype`, reconciliation reports a
+`metadata_conflict` with separate immutable metadata details and a manual
+recommendation. Direct dissemination and apply mode do not upload files,
+modify Archive metadata, add ownership markers, or write Thoth locations for
+that work while the conflict remains. Remediation requires manual coordination
+with Internet Archive; the reconciler does not prescribe deleting or
+recreating the item.
+
 The **internet-archive-reconciliation** workflow can also be launched manually
 from the repository's **Actions** tab. Dry-run is the default and receives no
 Archive or Thoth write credentials. Select works with an optional publisher

--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ docker run --rm --env-file config.env openbookpublishers/thoth-dissemination:lat
 `--platform` = Destination distribution/archiving platform (one of `InternetArchive`, `OAPEN`, `ScienceOpen`, `CUL`, `Crossref`, `Figshare`, `Zenodo`, `ProjectMUSE`, `JSTOR`, `EBSCOHost`, `ProQuest`, `GooglePlay`, `BKCI`)
 
 See also `--help`.
+
+### Reconcile Internet Archive state
+
+Inspect one or more works without write credentials or remote mutations:
+
+```sh
+python3 reconcile_internet_archive.py --work-id ${work_id}
+python3 reconcile_internet_archive.py --publisher-id ${publisher_id} --limit 100
+```
+
+Reports are deterministic JSON by default. Use `--format jsonl`, `--output
+<path>`, or `--apply` to select JSONL output, write an artifact, or apply safe
+repairs. Apply mode requires `ia_s3_access`, `ia_s3_secret`, and `THOTH_PAT`.

--- a/disseminator.py
+++ b/disseminator.py
@@ -13,6 +13,7 @@ import logging
 import sys
 from dotenv import load_dotenv
 from pathlib import Path
+from errors import DisseminationError
 from iauploader import IAUploader
 from oapensworduploader import OAPENSWORDUploader
 from souploader import SOUploader
@@ -76,13 +77,25 @@ def run(work_id, platform, export_url, client_url):
     """Execute a dissemination uploader based on input parameters"""
     logging.info('Beginning upload of {} to {}'.format(work_id, platform))
     try:
-        uploader = UPLOADERS[platform](
-            work_id, export_url, client_url, __version__)
+        uploader_class = UPLOADERS[platform]
     except KeyError:
-        logging.error('{} not supported: platform must be one of {}'.format(
-            platform, UPLOADERS_STR))
-        sys.exit(1)
+        raise DisseminationError(
+            '{} not supported: platform must be one of {}'.format(
+                platform, UPLOADERS_STR))
+    uploader = uploader_class(work_id, export_url, client_url, __version__)
     uploader.run()
+
+
+def main():
+    """Run the CLI and convert reusable uploader errors into a failing status."""
+    arguments = get_arguments()
+    try:
+        run(arguments.work_id, arguments.platform,
+            arguments.export_url, arguments.client_url)
+    except DisseminationError as error:
+        logging.error(error)
+        return 1
+    return 0
 
 
 def get_arguments():
@@ -113,6 +126,4 @@ if __name__ == '__main__':
     # with Docker, --env-file option could be used instead
     dotenv_path = Path('./config.env')
     load_dotenv(dotenv_path=dotenv_path)
-    ARGUMENTS = get_arguments()
-    run(ARGUMENTS.work_id, ARGUMENTS.platform,
-        ARGUMENTS.export_url, ARGUMENTS.client_url)
+    sys.exit(main())

--- a/disseminator.py
+++ b/disseminator.py
@@ -6,14 +6,13 @@ Call custom workflows to retrieve work-related files and metadata
 and upload them in the appropriate format to various platforms.
 """
 
-__version__ = '1.3.2'
-
 import argparse
 import logging
 import sys
 from dotenv import load_dotenv
 from pathlib import Path
 from errors import DisseminationError
+from version import __version__
 from iauploader import IAUploader
 from oapensworduploader import OAPENSWORDUploader
 from souploader import SOUploader

--- a/errors.py
+++ b/errors.py
@@ -15,6 +15,10 @@ class InternetArchiveIdentifierCollisionError(DisseminationError):
     """Refuse to modify an Internet Archive item not known to belong to Thoth."""
 
 
+class InternetArchiveImmutableMetadataError(DisseminationError):
+    """Refuse to mutate an item with incompatible initial-only metadata."""
+
+
 class InternetArchiveVerificationError(DisseminationError):
     """Report an Internet Archive upload which could not be verified in time."""
 

--- a/errors.py
+++ b/errors.py
@@ -9,3 +9,11 @@ class DisseminationError(Exception):
 
     def __init__(self, message):
         super().__init__(message)
+
+
+class InternetArchiveIdentifierCollisionError(DisseminationError):
+    """Refuse to modify an Internet Archive item not known to belong to Thoth."""
+
+
+class InternetArchiveVerificationError(DisseminationError):
+    """Report an Internet Archive upload which could not be verified in time."""

--- a/errors.py
+++ b/errors.py
@@ -17,3 +17,11 @@ class InternetArchiveIdentifierCollisionError(DisseminationError):
 
 class InternetArchiveVerificationError(DisseminationError):
     """Report an Internet Archive upload which could not be verified in time."""
+
+
+class InternetArchiveDesiredStateError(DisseminationError):
+    """Report which source failed while constructing Archive desired state."""
+
+    def __init__(self, source, message):
+        self.source = source
+        super().__init__(message)

--- a/errors.py
+++ b/errors.py
@@ -15,7 +15,12 @@ class InternetArchiveIdentifierCollisionError(DisseminationError):
     """Refuse to modify an Internet Archive item not known to belong to Thoth."""
 
 
-class InternetArchiveImmutableMetadataError(DisseminationError):
+class InternetArchiveRestrictedMetadataError(DisseminationError):
+    """Refuse to mutate Archive metadata unavailable to normal credentials."""
+
+
+class InternetArchiveImmutableMetadataError(
+        InternetArchiveRestrictedMetadataError):
     """Refuse to mutate an item with incompatible initial-only metadata."""
 
 

--- a/iauploader.py
+++ b/iauploader.py
@@ -75,11 +75,6 @@ class IAUploader(Uploader):
 
     def upload_to_platform(self):
         """Create or idempotently update a work in Internet Archive."""
-        access_key = self.get_variable_from_env(
-            'ia_s3_access', 'Internet Archive')
-        secret_key = self.get_variable_from_env(
-            'ia_s3_secret', 'Internet Archive')
-
         identifier = self.work_id
         try:
             item = get_item(identifier)
@@ -97,8 +92,6 @@ class IAUploader(Uploader):
             item,
             desired,
             inspection=inspection,
-            access_key=access_key,
-            secret_key=secret_key,
         )
 
         logging.info(
@@ -348,10 +341,6 @@ class IAUploader(Uploader):
         if inspection['ownership'] == 'collision':
             self._raise_item_collision(inspection['ownership_reason'])
         self._assert_initial_only_metadata_current(item, desired)
-        access_key = access_key or self.get_variable_from_env(
-            'ia_s3_access', 'Internet Archive')
-        secret_key = secret_key or self.get_variable_from_env(
-            'ia_s3_secret', 'Internet Archive')
 
         files_to_upload = [
             name
@@ -362,6 +351,15 @@ class IAUploader(Uploader):
             if not inspection['files'][name]['current']
         ]
         creating_item = not inspection['exists']
+        metadata_update_required = (
+            inspection['exists'] and bool(inspection['metadata_patch'])
+        )
+        if files_to_upload or metadata_update_required:
+            access_key = access_key or self.get_variable_from_env(
+                'ia_s3_access', 'Internet Archive')
+            secret_key = secret_key or self.get_variable_from_env(
+                'ia_s3_secret', 'Internet Archive')
+
         for index, name in enumerate(files_to_upload):
             action = (
                 'upload_pdf_original' if name.endswith('.pdf')
@@ -383,7 +381,7 @@ class IAUploader(Uploader):
             if progress is not None:
                 progress(action, 'completed')
 
-        if inspection['exists'] and inspection['metadata_patch']:
+        if metadata_update_required:
             if progress is not None:
                 progress('update_archive_metadata', 'attempted')
             self._modify_metadata(

--- a/iauploader.py
+++ b/iauploader.py
@@ -73,6 +73,8 @@ class IAUploader(Uploader):
         publication = self.get_publication_details('PDF')
         pdf_bytes = publication.bytes
         ia_metadata = self.parse_metadata()
+        absent_metadata_fields = (
+            self.MANAGED_METADATA_FIELDS - ia_metadata.keys())
 
         file_bytes = {
             '{}.pdf'.format(identifier): pdf_bytes,
@@ -103,7 +105,12 @@ class IAUploader(Uploader):
             self._modify_metadata(
                 item, metadata_patch, access_key, secret_key)
 
-        verified_md5s = self._verify_final_state(item, expected_md5s)
+        verified_md5s = self._verify_final_state(
+            item,
+            expected_md5s,
+            ia_metadata,
+            absent_metadata_fields,
+        )
         landing_page = 'https://archive.org/details/{}'.format(identifier)
         full_text_url = 'https://archive.org/download/{}/{}.pdf'.format(
             identifier, identifier)
@@ -290,6 +297,31 @@ class IAUploader(Uploader):
                 patch[field] = desired_metadata[field]
         return patch
 
+    def _metadata_verification_problems(
+            self, current_metadata, desired_metadata, absent_fields):
+        current_metadata = current_metadata or {}
+        problems = []
+        for field, desired_value in desired_metadata.items():
+            current_value = current_metadata.get(field)
+            if field == 'collection':
+                if self.THOTH_COLLECTION not in self._as_metadata_list(
+                        current_value):
+                    problems.append(
+                        '{} is {!r}, expected to include {!r}'.format(
+                            field, current_value, self.THOTH_COLLECTION))
+            elif not self._metadata_values_equal(
+                    field, current_value, desired_value):
+                problems.append(
+                    '{} is {!r}, expected {!r}'.format(
+                        field, current_value, desired_value))
+
+        for field in sorted(absent_fields):
+            if field in current_metadata:
+                problems.append(
+                    '{} is still present with value {!r}, expected it to be '
+                    'absent'.format(field, current_metadata[field]))
+        return problems
+
     @classmethod
     def _metadata_values_equal(cls, field, current_value, desired_value):
         if field in cls.REPEATABLE_METADATA_FIELDS:
@@ -331,31 +363,51 @@ class IAUploader(Uploader):
             return None
         return value
 
-    def _verify_final_state(self, item, expected_md5s):
-        last_problem = 'item metadata was not available'
+    def _verify_final_state(
+            self, item, expected_md5s, desired_metadata, absent_fields):
+        last_file_problems = ['item file metadata was not available']
+        last_metadata_problems = ['item metadata was not available']
+        last_refresh_problem = None
         for attempt in range(1, self.VERIFICATION_ATTEMPTS + 1):
             try:
                 item.refresh()
                 originals = self._original_files(item.files)
-                problems = []
+                file_problems = []
                 for name, expected_md5 in expected_md5s.items():
                     if name not in originals:
-                        problems.append(
+                        file_problems.append(
                             '{} is missing as an original file'.format(name))
                         continue
                     remote_md5 = self._file_value(originals[name], 'md5')
                     if remote_md5 != expected_md5:
-                        problems.append(
+                        file_problems.append(
                             '{} has MD5 {!r}, expected {!r}'.format(
                                 name, remote_md5, expected_md5))
-                if not problems:
+                metadata_problems = self._metadata_verification_problems(
+                    item.metadata, desired_metadata, absent_fields)
+                last_file_problems = file_problems
+                last_metadata_problems = metadata_problems
+                last_refresh_problem = None
+                if not file_problems and not metadata_problems:
                     return {
                         name: self._file_value(originals[name], 'md5')
                         for name in expected_md5s
                     }
-                last_problem = '; '.join(problems)
             except req_except.RequestException as error:
-                last_problem = 'refresh failed: {}'.format(error)
+                last_refresh_problem = 'refresh failed: {}'.format(error)
+
+            problem_groups = []
+            if last_file_problems:
+                problem_groups.append(
+                    'file discrepancies: {}'.format(
+                        '; '.join(last_file_problems)))
+            if last_metadata_problems:
+                problem_groups.append(
+                    'metadata discrepancies: {}'.format(
+                        '; '.join(last_metadata_problems)))
+            if last_refresh_problem:
+                problem_groups.append(last_refresh_problem)
+            last_problem = '; '.join(problem_groups)
 
             if attempt < self.VERIFICATION_ATTEMPTS:
                 logging.debug(

--- a/iauploader.py
+++ b/iauploader.py
@@ -258,7 +258,7 @@ class IAUploader(Uploader):
 
     def apply_archive_repairs(
             self, item, desired, inspection=None, access_key=None,
-            secret_key=None):
+            secret_key=None, progress=None):
         """Apply only the file and metadata differences found by inspection."""
         access_key = access_key or self.get_variable_from_env(
             'ia_s3_access', 'Internet Archive')
@@ -268,27 +268,47 @@ class IAUploader(Uploader):
         if inspection['ownership'] == 'collision':
             self._raise_item_collision(inspection['ownership_reason'])
 
-        files_to_upload = {
-            name: BytesIO(desired.file_bytes[name])
-            for name, state in inspection['files'].items()
-            if not state['current']
-        }
-        if files_to_upload:
+        files_to_upload = [
+            name
+            for name in (
+                '{}.pdf'.format(desired.identifier),
+                '{}.json'.format(desired.identifier),
+            )
+            if not inspection['files'][name]['current']
+        ]
+        creating_item = not inspection['exists']
+        for index, name in enumerate(files_to_upload):
+            action = (
+                'upload_pdf_original' if name.endswith('.pdf')
+                else 'upload_json_original'
+            )
+            if progress is not None and creating_item and index == 0:
+                progress('create_archive_item', 'attempted')
+            if progress is not None:
+                progress(action, 'attempted')
             self._upload_files(
                 desired.identifier,
-                files_to_upload,
-                desired.metadata if not inspection['exists'] else None,
+                {name: BytesIO(desired.file_bytes[name])},
+                desired.metadata if creating_item and index == 0 else None,
                 access_key,
                 secret_key,
             )
+            if progress is not None and creating_item and index == 0:
+                progress('create_archive_item', 'completed')
+            if progress is not None:
+                progress(action, 'completed')
 
         if inspection['exists'] and inspection['metadata_patch']:
+            if progress is not None:
+                progress('update_archive_metadata', 'attempted')
             self._modify_metadata(
                 item,
                 inspection['metadata_patch'],
                 access_key,
                 secret_key,
             )
+            if progress is not None:
+                progress('update_archive_metadata', 'completed')
 
         return self._verify_final_state(
             item,

--- a/iauploader.py
+++ b/iauploader.py
@@ -17,6 +17,7 @@ from errors import (
     InternetArchiveDesiredStateError,
     InternetArchiveIdentifierCollisionError,
     InternetArchiveImmutableMetadataError,
+    InternetArchiveRestrictedMetadataError,
     InternetArchiveVerificationError,
 )
 from uploader import Uploader, Location
@@ -69,8 +70,14 @@ class IAUploader(Uploader):
     INITIAL_ONLY_METADATA_FIELDS = {
         'mediatype',
     }
+    ADMIN_ONLY_METADATA_FIELDS = {
+        'collection',
+    }
+    NON_AUTOMUTABLE_METADATA_FIELDS = (
+        INITIAL_ONLY_METADATA_FIELDS | ADMIN_ONLY_METADATA_FIELDS
+    )
     MUTABLE_MANAGED_METADATA_FIELDS = (
-        MANAGED_METADATA_FIELDS - INITIAL_ONLY_METADATA_FIELDS
+        MANAGED_METADATA_FIELDS - NON_AUTOMUTABLE_METADATA_FIELDS
     )
 
     def upload_to_platform(self):
@@ -273,7 +280,8 @@ class IAUploader(Uploader):
             originals, desired.expected_md5s)
         metadata_patch = {}
         mutable_metadata_problems = []
-        immutable_metadata_problems = []
+        initial_only_metadata_problems = []
+        admin_only_metadata_problems = []
         if item.exists:
             metadata_patch = self._managed_metadata_patch(
                 item.metadata, desired.metadata)
@@ -283,15 +291,25 @@ class IAUploader(Uploader):
                 desired.absent_metadata_fields,
                 fields=self.MUTABLE_MANAGED_METADATA_FIELDS,
             )
-            immutable_metadata_problems = \
+            initial_only_metadata_problems = \
                 self._metadata_verification_problems(
                     item.metadata,
                     desired.metadata,
                     desired.absent_metadata_fields,
                     fields=self.INITIAL_ONLY_METADATA_FIELDS,
                 )
+            admin_only_metadata_problems = \
+                self._metadata_verification_problems(
+                    item.metadata,
+                    desired.metadata,
+                    desired.absent_metadata_fields,
+                    fields=self.ADMIN_ONLY_METADATA_FIELDS,
+                )
+        restricted_metadata_problems = (
+            initial_only_metadata_problems + admin_only_metadata_problems
+        )
         metadata_problems = (
-            mutable_metadata_problems + immutable_metadata_problems
+            mutable_metadata_problems + restricted_metadata_problems
         )
         return {
             'exists': bool(item.exists),
@@ -303,7 +321,14 @@ class IAUploader(Uploader):
             'metadata_current': bool(item.exists) and not metadata_problems,
             'metadata_problems': metadata_problems,
             'mutable_metadata_problems': mutable_metadata_problems,
-            'immutable_metadata_problems': immutable_metadata_problems,
+            'initial_only_metadata_problems':
+                initial_only_metadata_problems,
+            'admin_only_metadata_problems': admin_only_metadata_problems,
+            'restricted_metadata_problems': restricted_metadata_problems,
+            # Compatibility for existing report consumers: immutable metadata
+            # remains the initial-only subset.
+            'immutable_metadata_problems':
+                initial_only_metadata_problems,
             'metadata_patch': metadata_patch,
         }
 
@@ -333,6 +358,33 @@ class IAUploader(Uploader):
                     desired.identifier, '; '.join(conflicts))
             )
 
+    def _assert_admin_only_metadata_current(self, item, desired):
+        if not item.exists:
+            return
+
+        current_metadata = item.metadata or {}
+        if 'collection' not in desired.metadata:
+            return
+        current_collections = self._as_metadata_list(
+            current_metadata.get('collection'))
+        if self.THOTH_COLLECTION in current_collections:
+            return
+
+        raise InternetArchiveRestrictedMetadataError(
+            'Internet Archive item {} has incompatible collection membership '
+            '{!r}; it must include {!r}. Collection membership changes require '
+            'Internet Archive administrator intervention; no automatic '
+            'mutation was attempted.'.format(
+                desired.identifier,
+                current_collections,
+                self.THOTH_COLLECTION,
+            )
+        )
+
+    def _assert_restricted_metadata_current(self, item, desired):
+        self._assert_initial_only_metadata_current(item, desired)
+        self._assert_admin_only_metadata_current(item, desired)
+
     def apply_archive_repairs(
             self, item, desired, inspection=None, access_key=None,
             secret_key=None, progress=None):
@@ -340,7 +392,7 @@ class IAUploader(Uploader):
         inspection = inspection or self.inspect_item(item, desired)
         if inspection['ownership'] == 'collision':
             self._raise_item_collision(inspection['ownership_reason'])
-        self._assert_initial_only_metadata_current(item, desired)
+        self._assert_restricted_metadata_current(item, desired)
 
         files_to_upload = [
             name
@@ -554,18 +606,6 @@ class IAUploader(Uploader):
 
     def _managed_metadata_patch(self, current_metadata, desired_metadata):
         current_metadata = current_metadata or {}
-        desired_metadata = desired_metadata.copy()
-
-        current_collections = self._as_metadata_list(
-            current_metadata.get('collection'))
-        extra_collections = [
-            collection for collection in current_collections
-            if collection != self.THOTH_COLLECTION
-        ]
-        if extra_collections:
-            desired_metadata['collection'] = current_collections.copy()
-            if self.THOTH_COLLECTION not in current_collections:
-                desired_metadata['collection'].append(self.THOTH_COLLECTION)
 
         patch = {}
         for field in self.MUTABLE_MANAGED_METADATA_FIELDS:

--- a/iauploader.py
+++ b/iauploader.py
@@ -81,12 +81,11 @@ class IAUploader(Uploader):
                 'Error inspecting Internet Archive item {}: {}'.format(
                     identifier, error)) from error
 
-        item_exists = item.exists
-        if item_exists:
-            self._assert_item_owned_by_thoth(item)
+        ownership = self.classify_item_ownership(item)
+        self._assert_item_owned_by_thoth(item, ownership=ownership)
 
         desired = self.build_desired_state()
-        inspection = self.inspect_item(item, desired)
+        inspection = self.inspect_item(item, desired, ownership=ownership)
         verified_md5s = self.apply_archive_repairs(
             item,
             desired,
@@ -196,19 +195,54 @@ class IAUploader(Uploader):
     def classify_item_ownership(self, item):
         """Return an ownership classification shared by inspect and apply paths."""
         if not item.exists:
-            return {'status': 'missing', 'reason': None}
+            try:
+                available = item.identifier_available()
+            except Exception as error:
+                raise DisseminationError(
+                    'Unable to check Internet Archive identifier availability '
+                    'for {} after no public item metadata was available: {}; '
+                    'the item will not be created or modified'.format(
+                        self.work_id, error)
+                ) from error
+            if type(available) is not bool:
+                raise DisseminationError(
+                    'Internet Archive identifier availability returned an '
+                    'invalid response {!r} for {} after no public item '
+                    'metadata was available; the item will not be created or '
+                    'modified'.format(available, self.work_id)
+                )
+            if available:
+                return {
+                    'status': 'missing',
+                    'reason': None,
+                    'identifier_available': True,
+                }
+            return {
+                'status': 'collision',
+                'reason': (
+                    'no public item metadata was available, but the identifier '
+                    'availability API reported the identifier unavailable; the '
+                    'item will not be created or modified'
+                ),
+                'identifier_available': False,
+            }
 
         marker_values = self._as_metadata_list(
             item.metadata.get('thoth-work-id'))
         if marker_values:
             if all(value == self.work_id for value in marker_values):
-                return {'status': 'owned', 'reason': None}
+                return {
+                    'status': 'owned',
+                    'reason': None,
+                    'identifier_available': None,
+                }
             return {
                 'status': 'collision',
                 'reason': (
                     'existing thoth-work-id metadata is {!r}'.format(
                         marker_values)
                 ),
+                'identifier_available': None,
             }
 
         collections = self._as_metadata_list(
@@ -218,6 +252,7 @@ class IAUploader(Uploader):
             return {
                 'status': 'legacy',
                 'reason': 'legacy Thoth collection item has no ownership marker',
+                'identifier_available': None,
             }
 
         return {
@@ -227,11 +262,12 @@ class IAUploader(Uploader):
                 'identifiable legacy member of the {} collection'.format(
                     self.THOTH_COLLECTION)
             ),
+            'identifier_available': None,
         }
 
-    def inspect_item(self, item, desired):
+    def inspect_item(self, item, desired, ownership=None):
         """Compare one Archive item with desired state without mutating it."""
-        ownership = self.classify_item_ownership(item)
+        ownership = ownership or self.classify_item_ownership(item)
         originals = self._original_files(item.files)
         files = self.compare_original_files(
             originals, desired.expected_md5s)
@@ -249,6 +285,7 @@ class IAUploader(Uploader):
             'exists': bool(item.exists),
             'ownership': ownership['status'],
             'ownership_reason': ownership['reason'],
+            'identifier_available': ownership['identifier_available'],
             'legacy': ownership['status'] == 'legacy',
             'files': files,
             'metadata_current': bool(item.exists) and not metadata_problems,
@@ -317,10 +354,10 @@ class IAUploader(Uploader):
             desired.absent_metadata_fields,
         )
 
-    def _assert_item_owned_by_thoth(self, item):
+    def _assert_item_owned_by_thoth(self, item, ownership=None):
         """Raise when an existing identifier cannot safely be linked to Thoth."""
-        ownership = self.classify_item_ownership(item)
-        if ownership['status'] == 'owned':
+        ownership = ownership or self.classify_item_ownership(item)
+        if ownership['status'] in {'owned', 'missing'}:
             return
         if ownership['status'] == 'legacy':
             logging.warning(

--- a/iauploader.py
+++ b/iauploader.py
@@ -16,6 +16,7 @@ from errors import (
     DisseminationError,
     InternetArchiveDesiredStateError,
     InternetArchiveIdentifierCollisionError,
+    InternetArchiveImmutableMetadataError,
     InternetArchiveVerificationError,
 )
 from uploader import Uploader, Location
@@ -65,6 +66,12 @@ class IAUploader(Uploader):
         'thoth-work-id',
         'thoth-dissemination-service',
     }
+    INITIAL_ONLY_METADATA_FIELDS = {
+        'mediatype',
+    }
+    MUTABLE_MANAGED_METADATA_FIELDS = (
+        MANAGED_METADATA_FIELDS - INITIAL_ONLY_METADATA_FIELDS
+    )
 
     def upload_to_platform(self):
         """Create or idempotently update a work in Internet Archive."""
@@ -272,15 +279,27 @@ class IAUploader(Uploader):
         files = self.compare_original_files(
             originals, desired.expected_md5s)
         metadata_patch = {}
-        metadata_problems = []
+        mutable_metadata_problems = []
+        immutable_metadata_problems = []
         if item.exists:
             metadata_patch = self._managed_metadata_patch(
                 item.metadata, desired.metadata)
-            metadata_problems = self._metadata_verification_problems(
+            mutable_metadata_problems = self._metadata_verification_problems(
                 item.metadata,
                 desired.metadata,
                 desired.absent_metadata_fields,
+                fields=self.MUTABLE_MANAGED_METADATA_FIELDS,
             )
+            immutable_metadata_problems = \
+                self._metadata_verification_problems(
+                    item.metadata,
+                    desired.metadata,
+                    desired.absent_metadata_fields,
+                    fields=self.INITIAL_ONLY_METADATA_FIELDS,
+                )
+        metadata_problems = (
+            mutable_metadata_problems + immutable_metadata_problems
+        )
         return {
             'exists': bool(item.exists),
             'ownership': ownership['status'],
@@ -290,20 +309,49 @@ class IAUploader(Uploader):
             'files': files,
             'metadata_current': bool(item.exists) and not metadata_problems,
             'metadata_problems': metadata_problems,
+            'mutable_metadata_problems': mutable_metadata_problems,
+            'immutable_metadata_problems': immutable_metadata_problems,
             'metadata_patch': metadata_patch,
         }
+
+    def _assert_initial_only_metadata_current(self, item, desired):
+        if not item.exists:
+            return
+
+        current_metadata = item.metadata or {}
+        conflicts = []
+        for field in sorted(self.INITIAL_ONLY_METADATA_FIELDS):
+            if field not in desired.metadata:
+                continue
+            current_value = current_metadata.get(field)
+            required_value = desired.metadata[field]
+            if not self._metadata_values_equal(
+                    field, current_value, required_value):
+                conflicts.append(
+                    '{} is {!r}, required {!r}'.format(
+                        field, current_value, required_value)
+                )
+
+        if conflicts:
+            raise InternetArchiveImmutableMetadataError(
+                'Internet Archive item {} has incompatible initial-only '
+                'metadata: {}. These fields can only be set during item '
+                'creation; no automatic mutation was attempted.'.format(
+                    desired.identifier, '; '.join(conflicts))
+            )
 
     def apply_archive_repairs(
             self, item, desired, inspection=None, access_key=None,
             secret_key=None, progress=None):
         """Apply only the file and metadata differences found by inspection."""
+        inspection = inspection or self.inspect_item(item, desired)
+        if inspection['ownership'] == 'collision':
+            self._raise_item_collision(inspection['ownership_reason'])
+        self._assert_initial_only_metadata_current(item, desired)
         access_key = access_key or self.get_variable_from_env(
             'ia_s3_access', 'Internet Archive')
         secret_key = secret_key or self.get_variable_from_env(
             'ia_s3_secret', 'Internet Archive')
-        inspection = inspection or self.inspect_item(item, desired)
-        if inspection['ownership'] == 'collision':
-            self._raise_item_collision(inspection['ownership_reason'])
 
         files_to_upload = [
             name
@@ -361,8 +409,8 @@ class IAUploader(Uploader):
             return
         if ownership['status'] == 'legacy':
             logging.warning(
-                'Internet Archive item %s is a legacy Thoth collection item '
-                'without thoth-work-id metadata; adding the ownership marker',
+                'Internet Archive item %s is an accepted legacy Thoth '
+                'collection item without thoth-work-id metadata',
                 self.work_id)
             return
 
@@ -522,7 +570,7 @@ class IAUploader(Uploader):
                 desired_metadata['collection'].append(self.THOTH_COLLECTION)
 
         patch = {}
-        for field in self.MANAGED_METADATA_FIELDS:
+        for field in self.MUTABLE_MANAGED_METADATA_FIELDS:
             if field not in desired_metadata:
                 if field in current_metadata:
                     patch[field] = 'REMOVE_TAG'
@@ -534,10 +582,14 @@ class IAUploader(Uploader):
         return patch
 
     def _metadata_verification_problems(
-            self, current_metadata, desired_metadata, absent_fields):
+            self, current_metadata, desired_metadata, absent_fields,
+            fields=None):
         current_metadata = current_metadata or {}
+        fields = self.MANAGED_METADATA_FIELDS if fields is None else fields
         problems = []
         for field, desired_value in desired_metadata.items():
+            if field not in fields:
+                continue
             current_value = current_metadata.get(field)
             if field == 'collection':
                 if self.THOTH_COLLECTION not in self._as_metadata_list(
@@ -552,7 +604,7 @@ class IAUploader(Uploader):
                         field, current_value, desired_value))
 
         for field in sorted(absent_fields):
-            if field in current_metadata:
+            if field in fields and field in current_metadata:
                 problems.append(
                     '{} is still present with value {!r}, expected it to be '
                     'absent'.format(field, current_metadata[field]))

--- a/iauploader.py
+++ b/iauploader.py
@@ -407,6 +407,35 @@ class IAUploader(Uploader):
             inspection['exists'] and bool(inspection['metadata_patch'])
         )
         if files_to_upload or metadata_update_required:
+            try:
+                item.refresh()
+            except req_except.RequestException as error:
+                raise DisseminationError(
+                    'Unable to refresh Internet Archive item {} immediately '
+                    'before mutation: {}'.format(
+                        desired.identifier, error)
+                ) from error
+
+            current_ownership = self.classify_item_ownership(item)
+            self._assert_item_owned_by_thoth(
+                item, ownership=current_ownership, warn_legacy=False)
+            inspection = self.inspect_item(
+                item, desired, ownership=current_ownership)
+            self._assert_restricted_metadata_current(item, desired)
+            files_to_upload = [
+                name
+                for name in (
+                    '{}.pdf'.format(desired.identifier),
+                    '{}.json'.format(desired.identifier),
+                )
+                if not inspection['files'][name]['current']
+            ]
+            creating_item = not inspection['exists']
+            metadata_update_required = (
+                inspection['exists'] and bool(inspection['metadata_patch'])
+            )
+
+        if files_to_upload or metadata_update_required:
             access_key = access_key or self.get_variable_from_env(
                 'ia_s3_access', 'Internet Archive')
             secret_key = secret_key or self.get_variable_from_env(
@@ -452,16 +481,18 @@ class IAUploader(Uploader):
             desired.absent_metadata_fields,
         )
 
-    def _assert_item_owned_by_thoth(self, item, ownership=None):
+    def _assert_item_owned_by_thoth(
+            self, item, ownership=None, warn_legacy=True):
         """Raise when an existing identifier cannot safely be linked to Thoth."""
         ownership = ownership or self.classify_item_ownership(item)
         if ownership['status'] in {'owned', 'missing'}:
             return
         if ownership['status'] == 'legacy':
-            logging.warning(
-                'Internet Archive item %s is an accepted legacy Thoth '
-                'collection item without thoth-work-id metadata',
-                self.work_id)
+            if warn_legacy:
+                logging.warning(
+                    'Internet Archive item %s is an accepted legacy Thoth '
+                    'collection item without thoth-work-id metadata',
+                    self.work_id)
             return
 
         self._raise_item_collision(ownership['reason'])

--- a/iauploader.py
+++ b/iauploader.py
@@ -5,6 +5,7 @@ Retrieve and disseminate files and metadata to Internet Archive
 
 import hashlib
 import logging
+from dataclasses import dataclass
 from io import BytesIO
 from time import sleep
 
@@ -13,10 +14,25 @@ from requests import exceptions as req_except
 
 from errors import (
     DisseminationError,
+    InternetArchiveDesiredStateError,
     InternetArchiveIdentifierCollisionError,
     InternetArchiveVerificationError,
 )
 from uploader import Uploader, Location
+
+
+@dataclass(frozen=True)
+class IADesiredState:
+    """Complete Thoth-managed state expected for one Archive item."""
+
+    identifier: str
+    publication_id: str
+    source_url: str
+    file_bytes: dict
+    expected_md5s: dict
+    metadata: dict
+    absent_metadata_fields: frozenset
+    location: Location
 
 
 class IAUploader(Uploader):
@@ -69,102 +85,265 @@ class IAUploader(Uploader):
         if item_exists:
             self._assert_item_owned_by_thoth(item)
 
-        metadata_bytes = self.get_formatted_metadata('json::thoth')
-        publication = self.get_publication_details('PDF')
-        pdf_bytes = publication.bytes
-        ia_metadata = self.parse_metadata()
-        absent_metadata_fields = (
-            self.MANAGED_METADATA_FIELDS - ia_metadata.keys())
+        desired = self.build_desired_state()
+        inspection = self.inspect_item(item, desired)
+        verified_md5s = self.apply_archive_repairs(
+            item,
+            desired,
+            inspection=inspection,
+            access_key=access_key,
+            secret_key=secret_key,
+        )
 
+        logging.info(
+            'Successfully verified Internet Archive item at {}'.format(
+                desired.location.landing_page))
+
+        location = desired.location
+        return [Location(
+            location.publication_id,
+            location.location_platform,
+            location.landing_page,
+            location.full_text_url,
+            verified_md5s['{}.pdf'.format(identifier)],
+            location.checksum_algorithm,
+        )]
+
+    def build_desired_state(self):
+        """Construct Archive and Thoth location state without mutating either."""
+        try:
+            metadata_bytes = self.get_formatted_metadata('json::thoth')
+        except Exception as error:
+            raise InternetArchiveDesiredStateError(
+                'json',
+                'JSON export unavailable for {}: {}'.format(
+                    self.work_id, error),
+            ) from error
+
+        try:
+            publication = self.get_publication_details('PDF')
+        except Exception as error:
+            raise InternetArchiveDesiredStateError(
+                'pdf',
+                'PDF source unavailable for {}: {}'.format(
+                    self.work_id, error),
+            ) from error
+
+        if not isinstance(metadata_bytes, bytes):
+            raise InternetArchiveDesiredStateError(
+                'json',
+                'JSON export unavailable for {}: response was not bytes'.format(
+                    self.work_id),
+            )
+        if not isinstance(publication.bytes, bytes) or not publication.bytes:
+            raise InternetArchiveDesiredStateError(
+                'pdf',
+                'PDF source unavailable for {}: response was empty or not bytes'
+                .format(self.work_id),
+            )
+
+        try:
+            ia_metadata = self.parse_metadata()
+            missing_metadata = [
+                field for field in ('title', 'publisher', 'mediatype',
+                                    'collection', 'thoth-work-id')
+                if field not in ia_metadata
+            ]
+            if missing_metadata:
+                raise ValueError(
+                    'missing required fields {}'.format(
+                        ', '.join(missing_metadata)))
+        except Exception as error:
+            raise InternetArchiveDesiredStateError(
+                'metadata',
+                'Malformed Thoth metadata for {}: {}'.format(
+                    self.work_id, error),
+            ) from error
+
+        identifier = self.work_id
         file_bytes = {
-            '{}.pdf'.format(identifier): pdf_bytes,
+            '{}.pdf'.format(identifier): publication.bytes,
             '{}.json'.format(identifier): metadata_bytes,
         }
         expected_md5s = {
             name: hashlib.md5(contents).hexdigest()
             for name, contents in file_bytes.items()
         }
-        files_to_upload = self._files_requiring_upload(
-            item, file_bytes, expected_md5s)
-
-        metadata_patch = {}
-        if item_exists:
-            metadata_patch = self._managed_metadata_patch(
-                item.metadata, ia_metadata)
-
-        if files_to_upload:
-            self._upload_files(
-                identifier,
-                files_to_upload,
-                ia_metadata if not item_exists else None,
-                access_key,
-                secret_key,
-            )
-
-        if item_exists and metadata_patch:
-            self._modify_metadata(
-                item, metadata_patch, access_key, secret_key)
-
-        verified_md5s = self._verify_final_state(
-            item,
-            expected_md5s,
-            ia_metadata,
-            absent_metadata_fields,
-        )
+        pdf_name = '{}.pdf'.format(identifier)
         landing_page = 'https://archive.org/details/{}'.format(identifier)
-        full_text_url = 'https://archive.org/download/{}/{}.pdf'.format(
-            identifier, identifier)
-
-        logging.info(
-            'Successfully verified Internet Archive item at {}'.format(
-                landing_page))
-
-        return [Location(
+        full_text_url = 'https://archive.org/download/{}/{}'.format(
+            identifier, pdf_name)
+        location = Location(
             publication.id,
             'INTERNET_ARCHIVE',
             landing_page,
             full_text_url,
-            verified_md5s['{}.pdf'.format(identifier)],
+            expected_md5s[pdf_name],
             'MD5',
-        )]
+        )
+        return IADesiredState(
+            identifier=identifier,
+            publication_id=publication.id,
+            source_url=publication.source_url,
+            file_bytes=file_bytes,
+            expected_md5s=expected_md5s,
+            metadata=ia_metadata,
+            absent_metadata_fields=frozenset(
+                self.MANAGED_METADATA_FIELDS - ia_metadata.keys()),
+            location=location,
+        )
 
-    def _assert_item_owned_by_thoth(self, item):
-        """Raise when an existing identifier cannot safely be linked to Thoth."""
+    def classify_item_ownership(self, item):
+        """Return an ownership classification shared by inspect and apply paths."""
+        if not item.exists:
+            return {'status': 'missing', 'reason': None}
+
         marker_values = self._as_metadata_list(
             item.metadata.get('thoth-work-id'))
         if marker_values:
             if all(value == self.work_id for value in marker_values):
-                return
-            raise InternetArchiveIdentifierCollisionError(
-                'Internet Archive identifier collision for {}: existing '
-                'thoth-work-id metadata is {!r}; refusing to modify the item'
-                .format(self.work_id, marker_values))
+                return {'status': 'owned', 'reason': None}
+            return {
+                'status': 'collision',
+                'reason': (
+                    'existing thoth-work-id metadata is {!r}'.format(
+                        marker_values)
+                ),
+            }
 
         collections = self._as_metadata_list(
             item.metadata.get('collection'))
         if (item.identifier == self.work_id
                 and self.THOTH_COLLECTION in collections):
+            return {
+                'status': 'legacy',
+                'reason': 'legacy Thoth collection item has no ownership marker',
+            }
+
+        return {
+            'status': 'collision',
+            'reason': (
+                'item has no matching thoth-work-id metadata and is not an '
+                'identifiable legacy member of the {} collection'.format(
+                    self.THOTH_COLLECTION)
+            ),
+        }
+
+    def inspect_item(self, item, desired):
+        """Compare one Archive item with desired state without mutating it."""
+        ownership = self.classify_item_ownership(item)
+        originals = self._original_files(item.files)
+        files = self.compare_original_files(
+            originals, desired.expected_md5s)
+        metadata_patch = {}
+        metadata_problems = []
+        if item.exists:
+            metadata_patch = self._managed_metadata_patch(
+                item.metadata, desired.metadata)
+            metadata_problems = self._metadata_verification_problems(
+                item.metadata,
+                desired.metadata,
+                desired.absent_metadata_fields,
+            )
+        return {
+            'exists': bool(item.exists),
+            'ownership': ownership['status'],
+            'ownership_reason': ownership['reason'],
+            'legacy': ownership['status'] == 'legacy',
+            'files': files,
+            'metadata_current': bool(item.exists) and not metadata_problems,
+            'metadata_problems': metadata_problems,
+            'metadata_patch': metadata_patch,
+        }
+
+    def apply_archive_repairs(
+            self, item, desired, inspection=None, access_key=None,
+            secret_key=None):
+        """Apply only the file and metadata differences found by inspection."""
+        access_key = access_key or self.get_variable_from_env(
+            'ia_s3_access', 'Internet Archive')
+        secret_key = secret_key or self.get_variable_from_env(
+            'ia_s3_secret', 'Internet Archive')
+        inspection = inspection or self.inspect_item(item, desired)
+        if inspection['ownership'] == 'collision':
+            self._raise_item_collision(inspection['ownership_reason'])
+
+        files_to_upload = {
+            name: BytesIO(desired.file_bytes[name])
+            for name, state in inspection['files'].items()
+            if not state['current']
+        }
+        if files_to_upload:
+            self._upload_files(
+                desired.identifier,
+                files_to_upload,
+                desired.metadata if not inspection['exists'] else None,
+                access_key,
+                secret_key,
+            )
+
+        if inspection['exists'] and inspection['metadata_patch']:
+            self._modify_metadata(
+                item,
+                inspection['metadata_patch'],
+                access_key,
+                secret_key,
+            )
+
+        return self._verify_final_state(
+            item,
+            desired.expected_md5s,
+            desired.metadata,
+            desired.absent_metadata_fields,
+        )
+
+    def _assert_item_owned_by_thoth(self, item):
+        """Raise when an existing identifier cannot safely be linked to Thoth."""
+        ownership = self.classify_item_ownership(item)
+        if ownership['status'] == 'owned':
+            return
+        if ownership['status'] == 'legacy':
             logging.warning(
                 'Internet Archive item %s is a legacy Thoth collection item '
                 'without thoth-work-id metadata; adding the ownership marker',
                 self.work_id)
             return
 
+        self._raise_item_collision(ownership['reason'])
+
+    def _raise_item_collision(self, reason):
         raise InternetArchiveIdentifierCollisionError(
-            'Internet Archive identifier collision for {}: the existing item '
-            'has no matching thoth-work-id metadata and is not an identifiable '
-            'legacy member of the {} collection; refusing to modify it'.format(
-                self.work_id, self.THOTH_COLLECTION))
+            'Internet Archive identifier collision for {}: {}; refusing to '
+            'modify the item'.format(self.work_id, reason))
 
     @classmethod
     def _files_requiring_upload(cls, item, file_bytes, expected_md5s):
-        originals = cls._original_files(item.files)
+        comparisons = cls.compare_original_files(
+            cls._original_files(item.files), expected_md5s)
         return {
             name: BytesIO(contents)
             for name, contents in file_bytes.items()
-            if name not in originals
-            or cls._file_value(originals[name], 'md5') != expected_md5s[name]
+            if not comparisons[name]['current']
         }
+
+    @classmethod
+    def compare_original_files(cls, originals, expected_md5s):
+        """Return deterministic managed-original comparisons by filename."""
+        comparisons = {}
+        for name in sorted(expected_md5s):
+            file_metadata = originals.get(name)
+            remote_md5 = None if file_metadata is None else cls._file_value(
+                file_metadata, 'md5')
+            comparisons[name] = {
+                'present': file_metadata is not None,
+                'remote_md5': remote_md5,
+                'expected_md5': expected_md5s[name],
+                'current': (
+                    file_metadata is not None
+                    and remote_md5 == expected_md5s[name]
+                ),
+            }
+        return comparisons
 
     @staticmethod
     def _file_value(file_metadata, key):

--- a/iauploader.py
+++ b/iauploader.py
@@ -3,183 +3,431 @@
 Retrieve and disseminate files and metadata to Internet Archive
 """
 
+import hashlib
 import logging
-import sys
-from internetarchive import get_item, upload, exceptions as ia_except, File
 from io import BytesIO
 from time import sleep
+
+from internetarchive import get_item, upload, exceptions as ia_except
 from requests import exceptions as req_except
-from errors import DisseminationError
+
+from errors import (
+    DisseminationError,
+    InternetArchiveIdentifierCollisionError,
+    InternetArchiveVerificationError,
+)
 from uploader import Uploader, Location
 
 
 class IAUploader(Uploader):
-    """Dissemination logic for Internet Archive"""
+    """Dissemination logic for Internet Archive."""
+
+    THOTH_COLLECTION = 'thoth-archiving-network'
+    VERIFICATION_ATTEMPTS = 10
+    VERIFICATION_SLEEP_SECONDS = 20
+    REPEATABLE_METADATA_FIELDS = {
+        'collection', 'creator', 'isbn', 'subject', 'language', 'issn'
+    }
+    MANAGED_METADATA_FIELDS = {
+        'collection',
+        'title',
+        'publisher',
+        'creator',
+        'date',
+        'description',
+        'imagecount',
+        'isbn',
+        'lccn',
+        'licenseurl',
+        'mediatype',
+        'oclc-id',
+        'source',
+        'subject',
+        'language',
+        'issn',
+        'volume',
+        'thoth-work-id',
+        'thoth-dissemination-service',
+    }
 
     def upload_to_platform(self):
-        """Upload work in required format to Internet Archive"""
+        """Create or idempotently update a work in Internet Archive."""
+        access_key = self.get_variable_from_env(
+            'ia_s3_access', 'Internet Archive')
+        secret_key = self.get_variable_from_env(
+            'ia_s3_secret', 'Internet Archive')
 
-        # Fast-fail if credentials for upload are missing
+        identifier = self.work_id
         try:
-            access_key = self.get_variable_from_env(
-                'ia_s3_access', 'Internet Archive')
-            secret_key = self.get_variable_from_env(
-                'ia_s3_secret', 'Internet Archive')
-        except DisseminationError as error:
-            logging.error(error)
-            sys.exit(1)
+            item = get_item(identifier)
+        except req_except.RequestException as error:
+            raise DisseminationError(
+                'Error inspecting Internet Archive item {}: {}'.format(
+                    identifier, error)) from error
 
-        # Use Thoth ID as unique identifier (URL will be in format `archive.org/details/[identifier]`)
-        filename = self.work_id
+        item_exists = item.exists
+        if item_exists:
+            self._assert_item_owned_by_thoth(item)
 
-        # Ensure that this identifier is available in the Archive
-        # (this will also check that the identifier is in a valid format,
-        # although all Thoth IDs should be acceptable)
-        if not get_item(filename).identifier_available():
-            logging.error(
-                'Cannot upload to Internet Archive: an item with this identifier already exists')
-            sys.exit(1)
-
-        # Include full work metadata file in JSON format,
-        # as a supplement to filling out Internet Archive metadata fields
         metadata_bytes = self.get_formatted_metadata('json::thoth')
-        # Can't continue if no PDF file is present
-        try:
-            publication = self.get_publication_details('PDF')
-            pdf_bytes = publication.bytes
-        except DisseminationError as error:
-            logging.error(error)
-            sys.exit(1)
-
-        # Convert Thoth work metadata into Internet Archive format
-        # (not expected to fail, as "required" metadata is minimal)
+        publication = self.get_publication_details('PDF')
+        pdf_bytes = publication.bytes
         ia_metadata = self.parse_metadata()
 
+        file_bytes = {
+            '{}.pdf'.format(identifier): pdf_bytes,
+            '{}.json'.format(identifier): metadata_bytes,
+        }
+        expected_md5s = {
+            name: hashlib.md5(contents).hexdigest()
+            for name, contents in file_bytes.items()
+        }
+        files_to_upload = self._files_requiring_upload(
+            item, file_bytes, expected_md5s)
+
+        metadata_patch = {}
+        if item_exists:
+            metadata_patch = self._managed_metadata_patch(
+                item.metadata, ia_metadata)
+
+        if files_to_upload:
+            self._upload_files(
+                identifier,
+                files_to_upload,
+                ia_metadata if not item_exists else None,
+                access_key,
+                secret_key,
+            )
+
+        if item_exists and metadata_patch:
+            self._modify_metadata(
+                item, metadata_patch, access_key, secret_key)
+
+        verified_md5s = self._verify_final_state(item, expected_md5s)
+        landing_page = 'https://archive.org/details/{}'.format(identifier)
+        full_text_url = 'https://archive.org/download/{}/{}.pdf'.format(
+            identifier, identifier)
+
+        logging.info(
+            'Successfully verified Internet Archive item at {}'.format(
+                landing_page))
+
+        return [Location(
+            publication.id,
+            'INTERNET_ARCHIVE',
+            landing_page,
+            full_text_url,
+            verified_md5s['{}.pdf'.format(identifier)],
+            'MD5',
+        )]
+
+    def _assert_item_owned_by_thoth(self, item):
+        """Raise when an existing identifier cannot safely be linked to Thoth."""
+        marker_values = self._as_metadata_list(
+            item.metadata.get('thoth-work-id'))
+        if marker_values:
+            if all(value == self.work_id for value in marker_values):
+                return
+            raise InternetArchiveIdentifierCollisionError(
+                'Internet Archive identifier collision for {}: existing '
+                'thoth-work-id metadata is {!r}; refusing to modify the item'
+                .format(self.work_id, marker_values))
+
+        collections = self._as_metadata_list(
+            item.metadata.get('collection'))
+        if (item.identifier == self.work_id
+                and self.THOTH_COLLECTION in collections):
+            logging.warning(
+                'Internet Archive item %s is a legacy Thoth collection item '
+                'without thoth-work-id metadata; adding the ownership marker',
+                self.work_id)
+            return
+
+        raise InternetArchiveIdentifierCollisionError(
+            'Internet Archive identifier collision for {}: the existing item '
+            'has no matching thoth-work-id metadata and is not an identifiable '
+            'legacy member of the {} collection; refusing to modify it'.format(
+                self.work_id, self.THOTH_COLLECTION))
+
+    @classmethod
+    def _files_requiring_upload(cls, item, file_bytes, expected_md5s):
+        originals = cls._original_files(item.files)
+        return {
+            name: BytesIO(contents)
+            for name, contents in file_bytes.items()
+            if name not in originals
+            or cls._file_value(originals[name], 'md5') != expected_md5s[name]
+        }
+
+    @staticmethod
+    def _file_value(file_metadata, key):
+        if isinstance(file_metadata, dict):
+            return file_metadata.get(key)
+        return getattr(file_metadata, key, None)
+
+    @classmethod
+    def _original_files(cls, files):
+        originals = {}
+        for file_metadata in files or []:
+            if cls._file_value(file_metadata, 'source') != 'original':
+                continue
+            name = cls._file_value(file_metadata, 'name')
+            if name is not None:
+                originals[name] = file_metadata
+        return originals
+
+    def _upload_files(self, identifier, files, metadata, access_key, secret_key):
         try:
             responses = upload(
-                identifier=filename,
-                files={
-                    '{}.pdf'.format(filename): BytesIO(pdf_bytes),
-                    '{}.json'.format(filename): BytesIO(metadata_bytes),
-                },
-                metadata=ia_metadata,
+                identifier=identifier,
+                files=files,
+                metadata=metadata,
                 access_key=access_key,
                 secret_key=secret_key,
+                queue_derive=True,
                 retries=2,
                 retries_sleep=30,
                 verify=True,
+                checksum=True,
             )
-        # Empty access_key and/or secret_key triggers an AuthenticationError.
-        # Incorrect access_key and/or secret_key triggers an HTTPError.
-        except ia_except.AuthenticationError:
-            # The fast-fail above ought to prevent us from hitting this
-            logging.error(
-                'Error uploading to Internet Archive: credentials missing')
-            sys.exit(1)
-        except req_except.HTTPError:
-            # internetarchive module outputs its own ERROR log before we catch this exception,
-            # so no need to repeat the error text. As a future enhancement,
-            # we could filter out these third-party logs (along with the INFO logs
-            # which are output during the upload process) and update this message.
-            logging.error(
-                'Error uploading to Internet Archive: credentials may be incorrect')
-            sys.exit(1)
+        except ia_except.AuthenticationError as error:
+            raise DisseminationError(
+                'Error uploading to Internet Archive: credentials missing') \
+                from error
+        except (ia_except.InvalidChecksumError,
+                ia_except.ItemLocateError) as error:
+            raise DisseminationError(
+                'Internet Archive file upload failed for {}: {}'.format(
+                    identifier, error)) from error
+        except req_except.HTTPError as error:
+            raise DisseminationError(
+                'Internet Archive file upload failed for {}: {}'.format(
+                    identifier, error)) from error
+        except req_except.RequestException as error:
+            raise DisseminationError(
+                'Internet Archive file upload request failed for {}: {}'.format(
+                    identifier, error)) from error
 
-        if len(responses) < 1:
-            logging.error(
-                'Error uploading to Internet Archive: no response received from server')
-            sys.exit(1)
+        if not responses:
+            raise DisseminationError(
+                'Error uploading to Internet Archive: no response received '
+                'for requested files')
 
         for response in responses:
-            if response.status_code != 200:
-                logging.error(
-                    'Error uploading to Internet Archive: {}'.format(response.text))
-                sys.exit(1)
+            self._validate_response(
+                response, 'Internet Archive file upload', allow_empty=True)
 
-        landing_page = 'https://archive.org/details/{}'.format(filename)
-        full_text_url = 'https://archive.org/download/{}/{}.pdf'.format(filename, filename)
-        location_platform = 'INTERNET_ARCHIVE'
-        checksum_algorithm = 'MD5'
+    def _modify_metadata(self, item, metadata_patch, access_key, secret_key):
+        try:
+            response = item.modify_metadata(
+                metadata_patch,
+                access_key=access_key,
+                secret_key=secret_key,
+                refresh=False,
+            )
+        except ia_except.AuthenticationError as error:
+            raise DisseminationError(
+                'Error updating Internet Archive metadata: credentials missing') \
+                from error
+        except (ia_except.ItemLocateError,
+                req_except.RequestException) as error:
+            raise DisseminationError(
+                'Internet Archive metadata update failed for {}: {}'.format(
+                    self.work_id, error)) from error
 
-        logging.info('Successfully uploaded to Internet Archive at {}'.format(landing_page))
+        self._validate_response(
+            response, 'Internet Archive metadata update', allow_empty=False)
 
-        # Return details of created upload to be entered as a Thoth Location
-        # It may take some time for the upload to be processed and a checksum to be returned
-        # (test example: approx 80 seconds for 50MB file)
-        # Checksum fetch will silently fail if not found
-        upload_md5 = None
-        attempt = 1
-        while attempt <= 10:
-            sleep(20)
-            upload_md5 = File(get_item(filename), '{}.pdf'.format(filename)).md5
-            if upload_md5 == None:
-                logging.debug('No checksum returned for file (attempt {})'.format(attempt))
-                attempt += 1
-            else:
-                logging.debug('File checksum returned on attempt {}'.format(attempt))
-                break
+    @staticmethod
+    def _validate_response(response, action, allow_empty):
+        status_code = getattr(response, 'status_code', None)
+        if status_code is None:
+            if allow_empty:
+                return
+            raise DisseminationError(
+                '{} failed: no HTTP status was returned'.format(action))
 
-        if upload_md5 is None:
-            logging.warning('Unable to retrieve Internet Archive checksum for uploaded file')
-            checksum_algorithm = None
+        if not 200 <= status_code < 300:
+            response_text = getattr(response, 'text', '')
+            raise DisseminationError(
+                '{} failed with HTTP status {}: {}'.format(
+                    action, status_code, response_text))
 
-        return [Location(publication.id, location_platform, landing_page,
-                         full_text_url, upload_md5, checksum_algorithm)]
+        try:
+            response_body = response.json()
+        except (AttributeError, ValueError):
+            response_body = {}
+        if isinstance(response_body, dict) \
+                and response_body.get('success') is False:
+            raise DisseminationError(
+                '{} failed: {}'.format(
+                    action, response_body.get('error', response_body)))
+
+    def _managed_metadata_patch(self, current_metadata, desired_metadata):
+        current_metadata = current_metadata or {}
+        desired_metadata = desired_metadata.copy()
+
+        current_collections = self._as_metadata_list(
+            current_metadata.get('collection'))
+        extra_collections = [
+            collection for collection in current_collections
+            if collection != self.THOTH_COLLECTION
+        ]
+        if extra_collections:
+            desired_metadata['collection'] = current_collections.copy()
+            if self.THOTH_COLLECTION not in current_collections:
+                desired_metadata['collection'].append(self.THOTH_COLLECTION)
+
+        patch = {}
+        for field in self.MANAGED_METADATA_FIELDS:
+            if field not in desired_metadata:
+                if field in current_metadata:
+                    patch[field] = 'REMOVE_TAG'
+                continue
+            if not self._metadata_values_equal(
+                    field, current_metadata.get(field),
+                    desired_metadata[field]):
+                patch[field] = desired_metadata[field]
+        return patch
+
+    @classmethod
+    def _metadata_values_equal(cls, field, current_value, desired_value):
+        if field in cls.REPEATABLE_METADATA_FIELDS:
+            return cls._as_metadata_list(current_value) \
+                == cls._as_metadata_list(desired_value)
+        if field == 'thoth-work-id':
+            return cls._as_metadata_list(current_value) \
+                == cls._as_metadata_list(desired_value)
+        return cls._clean_metadata_value(current_value) \
+            == cls._clean_metadata_value(desired_value)
+
+    @classmethod
+    def _as_metadata_list(cls, value):
+        if isinstance(value, (list, tuple, set)):
+            values = value
+        elif value is None:
+            values = []
+        else:
+            values = [value]
+        return [
+            cleaned for cleaned in (
+                cls._clean_metadata_value(entry) for entry in values)
+            if cleaned is not None
+        ]
+
+    @classmethod
+    def _clean_metadata_value(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, (list, tuple, set)):
+            cleaned_values = [
+                cleaned for cleaned in (
+                    cls._clean_metadata_value(entry) for entry in value)
+                if cleaned is not None
+            ]
+            return cleaned_values or None
+        if isinstance(value, str) \
+                and (not value.strip() or value == 'None'):
+            return None
+        return value
+
+    def _verify_final_state(self, item, expected_md5s):
+        last_problem = 'item metadata was not available'
+        for attempt in range(1, self.VERIFICATION_ATTEMPTS + 1):
+            try:
+                item.refresh()
+                originals = self._original_files(item.files)
+                problems = []
+                for name, expected_md5 in expected_md5s.items():
+                    if name not in originals:
+                        problems.append(
+                            '{} is missing as an original file'.format(name))
+                        continue
+                    remote_md5 = self._file_value(originals[name], 'md5')
+                    if remote_md5 != expected_md5:
+                        problems.append(
+                            '{} has MD5 {!r}, expected {!r}'.format(
+                                name, remote_md5, expected_md5))
+                if not problems:
+                    return {
+                        name: self._file_value(originals[name], 'md5')
+                        for name in expected_md5s
+                    }
+                last_problem = '; '.join(problems)
+            except req_except.RequestException as error:
+                last_problem = 'refresh failed: {}'.format(error)
+
+            if attempt < self.VERIFICATION_ATTEMPTS:
+                logging.debug(
+                    'Internet Archive verification incomplete on attempt %s: %s',
+                    attempt, last_problem)
+                sleep(self.VERIFICATION_SLEEP_SECONDS)
+
+        raise InternetArchiveVerificationError(
+            'Timed out verifying Internet Archive item {} after {} attempts: {}'
+            .format(self.work_id, self.VERIFICATION_ATTEMPTS, last_problem))
 
     def parse_metadata(self):
-        """Convert work metadata into Internet Archive format"""
-        work_metadata = self.metadata.get('data').get('work')
-        # Repeatable fields such as 'creator', 'isbn', 'subject'
-        # can be set by submitting a list of values
-        creators = [n.get('fullName')
-                    for n in work_metadata.get('contributions')
-                    if n.get('mainContribution') is True]
-        # IA metadata schema suggests hyphens should be omitted,
-        # although including them does not cause any errors
-        isbns = [n.get('isbn').replace(
-            '-', '') for n in work_metadata.get('publications') if n.get('isbn') is not None]
-        # We may want to mark BIC, BISAC, Thema etc subject codes as such;
-        # IA doesn't set a standard so representations vary across the archive
-        subjects = [n.get('subjectCode')
-                    for n in work_metadata.get('subjects')]
-        languages = [n.get('languageCode')
-                     for n in work_metadata.get('languages')]
-        issns = [n.get('series').get(key) for n in work_metadata.get(
-            'issues') for key in ['issnPrint', 'issnDigital']]
-        # IA only accepts a single volume number
-        volume = next(iter([str(n.get('issueOrdinal'))
-                      for n in work_metadata.get('issues')]), None)
+        """Convert work metadata into Internet Archive format."""
+        work_metadata = self.metadata.get('data', {}).get('work', {})
+        contributions = work_metadata.get('contributions') or []
+        publications = work_metadata.get('publications') or []
+        subjects_metadata = work_metadata.get('subjects') or []
+        languages_metadata = work_metadata.get('languages') or []
+        issues = work_metadata.get('issues') or []
+
+        creators = [
+            contribution.get('fullName')
+            for contribution in contributions
+            if contribution.get('mainContribution') is True
+        ]
+        isbns = [
+            publication.get('isbn').replace('-', '')
+            for publication in publications
+            if publication.get('isbn') is not None
+        ]
+        subjects = [
+            subject.get('subjectCode') for subject in subjects_metadata
+        ]
+        languages = [
+            language.get('languageCode') for language in languages_metadata
+        ]
+        issns = [
+            (issue.get('series') or {}).get(key)
+            for issue in issues
+            for key in ['issnPrint', 'issnDigital']
+        ]
+        volume = next(iter([
+            str(issue.get('issueOrdinal'))
+            for issue in issues
+            if issue.get('issueOrdinal') is not None
+        ]), None)
+        page_count = work_metadata.get('pageCount')
+
         ia_metadata = {
-            # All fields are non-mandatory
-            # Any None values or empty lists are ignored by IA on ingest
-            'collection': 'thoth-archiving-network',
+            'collection': self.THOTH_COLLECTION,
             'title': work_metadata.get('fullTitle'),
             'publisher': self.get_publisher_name(),
             'creator': creators,
-            # IA requires date in YYYY-MM-DD format, as output by Thoth
             'date': work_metadata.get('publicationDate'),
             'description': work_metadata.get('longAbstract'),
-            # Field name is misleading; displayed in IA as 'Pages'
-            'imagecount': str(work_metadata.get('pageCount')),
+            'imagecount': None if page_count is None else str(page_count),
             'isbn': isbns,
             'lccn': work_metadata.get('lccn'),
             'licenseurl': work_metadata.get('license'),
             'mediatype': 'texts',
             'oclc-id': work_metadata.get('oclc'),
-            # IA has no dedicated DOI field but 'source' is
-            # "[u]sed to signify where a piece of media originated"
             'source': work_metadata.get('doi'),
-            # https://help.archive.org/help/uploading-a-basic-guide/ requests no more than
-            # 10 subject tags, but additional tags appear to be accepted without error
             'subject': subjects,
             'language': languages,
             'issn': issns,
             'volume': volume,
-            # Custom field: this data should already be included in the formatted
-            # metadata file, but including it here may be beneficial for searching
             'thoth-work-id': self.work_id,
-            # Custom field helping future users determine what logic was used to create an upload
             'thoth-dissemination-service': self.version,
         }
 
-        return ia_metadata
+        return {
+            field: cleaned
+            for field, value in ia_metadata.items()
+            if (cleaned := self._clean_metadata_value(value)) is not None
+        }

--- a/internet_archive_policy.py
+++ b/internet_archive_policy.py
@@ -1,0 +1,12 @@
+"""Import-safe Internet Archive scheduled-selection policy."""
+
+
+SUPPORTED_WORK_TYPES = (
+    'MONOGRAPH',
+    'EDITED_BOOK',
+    'JOURNAL_ISSUE',
+    'TEXTBOOK',
+    'BOOK_SET',
+)
+
+ACTIVE_WORK_STATUSES = ('ACTIVE',)

--- a/obtain_new_ids.py
+++ b/obtain_new_ids.py
@@ -2,8 +2,9 @@
 """
 Acquire a list of work IDs to be disseminated.
 Purpose: automatic dissemination at regular intervals of specified works from selected publishers.
-For dissemination to Internet Archive, (Loughborough) Figshare, Zenodo, CUL and Google Play:
-find newly-published works for upload.
+For dissemination to (Loughborough) Figshare, Zenodo, CUL and Google Play:
+find newly-published works for upload. Internet Archive selection is based on
+recent relation-aware updates and usable canonical PDF sources.
 For dissemination to Crossref: find newly-updated works for metadata deposit (including update).
 Based on `iabulkupload/obtain_work_ids.py`.
 """
@@ -13,10 +14,79 @@ from thothlibrary import errors
 import argparse
 import json
 import logging
+import math
 from datetime import datetime, timedelta, UTC
 from os import environ
+from pathlib import Path
 import sys
-from thothapi import get_thoth_client
+from uuid import UUID
+
+from internet_archive_policy import SUPPORTED_WORK_TYPES
+from thothapi import (
+    get_internet_archive_selection_works,
+    get_thoth_client,
+)
+
+
+DEFAULT_IA_LOOKBACK_HOURS = 30
+MAX_IA_LOOKBACK_HOURS = 168
+DEFAULT_IA_MAX_IDS = 200
+MAX_IA_MAX_IDS = 200
+IA_QUERY_PAGE_SIZE = 100
+
+
+class InternetArchiveSelectionError(RuntimeError):
+    """Internet Archive selection could not complete safely."""
+
+
+def canonical_utc_timestamp(value):
+    """Render a timezone-aware datetime as canonical UTC ISO 8601."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError('timestamp is timezone-naive')
+    return value.astimezone(UTC).isoformat().replace('+00:00', 'Z')
+
+
+def parse_api_timestamp(value):
+    """Parse an API timestamp without guessing a missing timezone."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError('timestamp is missing')
+    normalised = value.strip()
+    if normalised.endswith(('Z', 'z')):
+        normalised = normalised[:-1] + '+00:00'
+    parsed = datetime.fromisoformat(normalised)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError('timestamp is timezone-naive')
+    return parsed.astimezone(UTC)
+
+
+def lookback_hours_type(value):
+    """Argparse validator for the bounded IA overlap window."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as error:
+        raise argparse.ArgumentTypeError(
+            'lookback hours must be a number') from error
+    if not math.isfinite(number) or number <= 0:
+        raise argparse.ArgumentTypeError(
+            'lookback hours must be a positive finite number')
+    if number > MAX_IA_LOOKBACK_HOURS:
+        raise argparse.ArgumentTypeError(
+            'lookback hours may not exceed {}'.format(
+                MAX_IA_LOOKBACK_HOURS))
+    return int(number) if number.is_integer() else number
+
+
+def max_ids_type(value):
+    """Argparse validator for the IA matrix hard cap."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as error:
+        raise argparse.ArgumentTypeError(
+            'max IDs must be an integer') from error
+    if number < 1 or number > MAX_IA_MAX_IDS:
+        raise argparse.ArgumentTypeError(
+            'max IDs must be between 1 and {}'.format(MAX_IA_MAX_IDS))
+    return number
 
 
 class IDFinder():
@@ -43,7 +113,7 @@ class IDFinder():
         self.remove_exceptions()
         self.post_process()
         logging.info('List of IDs found: {}'.format(self.thoth_ids))
-        print(self.thoth_ids)
+        print(json.dumps(self.thoth_ids, separators=(',', ':')))
 
     def get_publishers(self):
         """"Retrieve IDs for all publishers whose works should be included"""
@@ -190,6 +260,302 @@ class MonthlyIDFinder(IDFinder):
         previous_month_start = previous_month_end.replace(day=1)
 
         self.get_thoth_ids_iteratively(previous_month_start, previous_month_end)
+
+
+class InternetArchiveIDFinder(IDFinder):
+    """Select recently updated IA-eligible works without retrieving sources."""
+
+    def __init__(
+            self, lookback_hours=DEFAULT_IA_LOOKBACK_HOURS,
+            max_ids=DEFAULT_IA_MAX_IDS, report_path=None, now_provider=None,
+            thoth=None):
+        if thoth is None:
+            super().__init__()
+        else:
+            self.thoth = thoth
+            self.thoth_ids = []
+        self.lookback_hours = lookback_hours
+        self.max_ids = max_ids
+        self.report_path = Path(report_path) if report_path else None
+        self.now_provider = now_provider or (lambda: datetime.now(UTC))
+        self.publisher_ids = []
+        self.exception_ids = []
+        self.report = None
+        self.window_start = None
+        self.window_end = None
+
+    @staticmethod
+    def _normalise_uuid_list(raw_value, variable_name, required):
+        if raw_value is None or raw_value == '':
+            if required:
+                raise InternetArchiveSelectionError(
+                    '{} must be a non-empty JSON array'.format(variable_name))
+            return []
+        try:
+            values = json.loads(raw_value)
+        except (TypeError, ValueError) as error:
+            raise InternetArchiveSelectionError(
+                '{} must be a JSON array'.format(variable_name)) from error
+        if not isinstance(values, list) or (required and not values):
+            qualifier = 'non-empty ' if required else ''
+            raise InternetArchiveSelectionError(
+                '{} must be a {}JSON array'.format(variable_name, qualifier))
+
+        normalised = []
+        for value in values:
+            if not isinstance(value, str):
+                raise InternetArchiveSelectionError(
+                    '{} contains a non-string UUID'.format(variable_name))
+            try:
+                normalised.append(str(UUID(value)))
+            except (ValueError, AttributeError) as error:
+                raise InternetArchiveSelectionError(
+                    '{} contains malformed UUID {}'.format(
+                        variable_name, value)
+                ) from error
+        return sorted(set(normalised))
+
+    def get_publishers(self):
+        """Validate, normalise and confirm every configured publisher."""
+        self.publisher_ids = self._normalise_uuid_list(
+            environ.get('ENV_PUBLISHERS'), 'ENV_PUBLISHERS', required=True)
+        for publisher_id in self.publisher_ids:
+            try:
+                publisher = self.thoth.publisher(publisher_id=publisher_id)
+            except Exception as error:
+                raise InternetArchiveSelectionError(
+                    'Publisher {} could not be confirmed'.format(
+                        publisher_id)
+                ) from error
+            if publisher is None:
+                raise InternetArchiveSelectionError(
+                    'Publisher {} was not found'.format(publisher_id))
+
+    def get_exceptions(self):
+        """Validate and normalise the optional configured work exceptions."""
+        self.exception_ids = self._normalise_uuid_list(
+            environ.get('ENV_EXCEPTIONS'), 'ENV_EXCEPTIONS', required=False)
+
+    @staticmethod
+    def _work_value(work, key, default=None):
+        if isinstance(work, dict):
+            return work.get(key, default)
+        return getattr(work, key, default)
+
+    @classmethod
+    def _exclusion(cls, work, reason, timestamp=None):
+        work_id = cls._work_value(work, 'workId')
+        raw_timestamp = cls._work_value(work, 'updatedAtWithRelations')
+        return {
+            'work_id': None if work_id is None else str(work_id),
+            'updated_at_with_relations': (
+                canonical_utc_timestamp(timestamp)
+                if timestamp is not None
+                else raw_timestamp
+            ),
+            'reason': reason,
+        }
+
+    @classmethod
+    def _source_exclusion_reason(cls, work):
+        publications = cls._work_value(work, 'publications', []) or []
+        pdf_publications = [
+            publication for publication in publications
+            if cls._work_value(publication, 'publicationType') == 'PDF'
+        ]
+        if not pdf_publications:
+            return 'no_pdf_publication'
+
+        locations = cls._work_value(
+            pdf_publications[0], 'locations', []) or []
+        canonical_locations = [
+            location for location in locations
+            if cls._work_value(location, 'canonical') is True
+        ]
+        if not canonical_locations:
+            return 'no_canonical_pdf_location'
+        if not any(
+                isinstance(cls._work_value(location, 'fullTextUrl'), str)
+                and cls._work_value(location, 'fullTextUrl').strip()
+                for location in canonical_locations):
+            return 'canonical_pdf_location_missing_full_text_url'
+        return None
+
+    @staticmethod
+    def _excluded_sort_key(entry):
+        timestamp = entry.get('updated_at_with_relations')
+        try:
+            timestamp_key = parse_api_timestamp(timestamp)
+        except (TypeError, ValueError):
+            timestamp_key = datetime.max.replace(tzinfo=UTC)
+        return (
+            timestamp_key,
+            entry.get('work_id') or '',
+            entry.get('reason') or '',
+            '' if timestamp is None else str(timestamp),
+        )
+
+    def _write_report(self, report):
+        if self.report_path is None:
+            return
+        self.report_path.parent.mkdir(parents=True, exist_ok=True)
+        serialised = json.dumps(
+            report, indent=2, sort_keys=True, ensure_ascii=True) + '\n'
+        self.report_path.write_text(serialised, encoding='utf-8')
+
+    def _base_report(self, generated_at):
+        return {
+            'platform': 'InternetArchive',
+            'generated_at': canonical_utc_timestamp(generated_at),
+            'window': {
+                'start': canonical_utc_timestamp(self.window_start),
+                'end': canonical_utc_timestamp(self.window_end),
+                'lookback_hours': self.lookback_hours,
+            },
+            'publisher_ids': self.publisher_ids,
+            'exception_ids': self.exception_ids,
+            'queried_count': 0,
+            'eligible_count': 0,
+            'selected_count': 0,
+            'omitted_count': 0,
+            'truncated': False,
+            'selection_limit': self.max_ids,
+            'selected': [],
+            'omitted': [],
+            'excluded_counts': {},
+            'excluded': [],
+        }
+
+    def write_failure_report(self, error):
+        """Write a sanitised report for configuration/query failures."""
+        if self.window_end is None:
+            now = self.now_provider()
+            if now.tzinfo is None or now.utcoffset() is None:
+                now = datetime.now(UTC)
+            self.window_end = now.astimezone(UTC)
+            self.window_start = self.window_end - timedelta(
+                hours=self.lookback_hours)
+        report = self._base_report(self.window_end)
+        report['error'] = '{}: {}'.format(type(error).__name__, str(error))
+        report['status'] = 'failed'
+        self.report = report
+        self._write_report(report)
+
+    def select(self):
+        """Build the deterministic selected, omitted and excluded records."""
+        captured_now = self.now_provider()
+        if captured_now.tzinfo is None or captured_now.utcoffset() is None:
+            raise InternetArchiveSelectionError(
+                'Current time must be timezone-aware')
+        self.window_end = captured_now.astimezone(UTC)
+        self.window_start = self.window_end - timedelta(
+            hours=self.lookback_hours)
+
+        self.get_publishers()
+        self.get_exceptions()
+        report = self._base_report(self.window_end)
+        works = get_internet_archive_selection_works(
+            self.thoth,
+            self.publisher_ids,
+            SUPPORTED_WORK_TYPES,
+            canonical_utc_timestamp(self.window_start),
+            page_size=IA_QUERY_PAGE_SIZE,
+        )
+        report['queried_count'] = len(works)
+
+        newest_by_work_id = {}
+        excluded = []
+        for work in works:
+            work_id = self._work_value(work, 'workId')
+            raw_timestamp = self._work_value(
+                work, 'updatedAtWithRelations')
+            if raw_timestamp is None or raw_timestamp == '':
+                excluded.append(self._exclusion(
+                    work, 'missing_update_timestamp'))
+                continue
+            try:
+                timestamp = parse_api_timestamp(raw_timestamp)
+            except (TypeError, ValueError):
+                excluded.append(self._exclusion(
+                    work, 'malformed_update_timestamp'))
+                continue
+            if work_id is None:
+                excluded.append(self._exclusion(
+                    work, 'missing_work_id', timestamp))
+                continue
+            work_id = str(work_id)
+            current = newest_by_work_id.get(work_id)
+            if current is None or timestamp > current[0]:
+                newest_by_work_id[work_id] = (timestamp, work)
+
+        eligible = []
+        exception_ids = set(self.exception_ids)
+        for work_id, (timestamp, work) in newest_by_work_id.items():
+            reason = None
+            if timestamp <= self.window_start:
+                reason = 'outside_window'
+            elif timestamp > self.window_end:
+                reason = 'after_window_end'
+            elif work_id in exception_ids:
+                reason = 'configured_exception'
+            elif self._work_value(work, 'workStatus') != 'ACTIVE':
+                reason = 'inactive'
+            elif self._work_value(work, 'workType') not in SUPPORTED_WORK_TYPES:
+                reason = 'unsupported_work_type'
+            else:
+                reason = self._source_exclusion_reason(work)
+
+            if reason is not None:
+                excluded.append(self._exclusion(work, reason, timestamp))
+                continue
+            eligible.append({
+                'work_id': work_id,
+                'updated_at_with_relations': canonical_utc_timestamp(timestamp),
+                '_timestamp': timestamp,
+            })
+
+        eligible.sort(key=lambda entry: (
+            entry['_timestamp'], entry['work_id']))
+        selected = eligible[:self.max_ids]
+        omitted = eligible[self.max_ids:]
+        for entry in selected + omitted:
+            entry.pop('_timestamp')
+
+        excluded.sort(key=self._excluded_sort_key)
+        excluded_counts = {}
+        for entry in excluded:
+            reason = entry['reason']
+            excluded_counts[reason] = excluded_counts.get(reason, 0) + 1
+
+        report.update({
+            'eligible_count': len(eligible),
+            'selected_count': len(selected),
+            'omitted_count': len(omitted),
+            'truncated': bool(omitted),
+            'selected': selected,
+            'omitted': omitted,
+            'excluded_counts': dict(sorted(excluded_counts.items())),
+            'excluded': excluded,
+        })
+        self.thoth_ids = [entry['work_id'] for entry in selected]
+        self.report = report
+        return report
+
+    def run(self):
+        """Select, report, then emit only the compact JSON work-ID array."""
+        report = self.select()
+        self._write_report(report)
+        if report['truncated']:
+            logging.warning(
+                '%s eligible works exceeded the %s-work limit; %s omitted. '
+                'Inspect the selection artifact and use bounded manual '
+                'reconciliation or another reviewed bounded operation.',
+                report['eligible_count'],
+                report['selection_limit'],
+                report['omitted_count'],
+            )
+        logging.info('List of IDs found: %s', self.thoth_ids)
+        print(json.dumps(self.thoth_ids, separators=(',', ':')))
 
 
 class WeeklyIDFinder(IDFinder):
@@ -353,48 +719,104 @@ class OapenLocationsIDFinder(IDFinder):
         self.thoth_ids = oapen_location_required
 
 
-def get_arguments():
+def get_arguments(argv=None):
     """Simple argument parsing"""
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform")
     parser.add_argument("--locations", action=argparse.BooleanOptionalAction)
-    args = parser.parse_args()
+    parser.add_argument(
+        '--lookback-hours',
+        type=lookback_hours_type,
+        default=DEFAULT_IA_LOOKBACK_HOURS,
+        help='IA UTC lookback window (positive hours, maximum 168; default 30)',
+    )
+    parser.add_argument(
+        '--max-ids',
+        type=max_ids_type,
+        default=DEFAULT_IA_MAX_IDS,
+        help='IA selection limit (1-200; default 200)',
+    )
+    parser.add_argument(
+        '--report',
+        help='write the Internet Archive selection report to this path',
+    )
+    args = parser.parse_args(argv)
     return args
+
+
+def get_id_finder(args, now_provider=None, thoth=None):
+    """Map parsed CLI arguments to the platform-specific finder."""
+    platform = args.platform
+    if args.locations:
+        if platform == 'OAPEN':
+            return OapenLocationsIDFinder()
+        raise InternetArchiveSelectionError(
+            'Locations option is only supported for OAPEN')
+
+    finder_classes = {
+        'Crossref': CrossrefIDFinder,
+        'GooglePlay': GooglePlayIDFinder,
+        'OAPEN': WeeklyIDFinder,
+        'EBSCOHost': WeeklyIDFinder,
+        'JSTOR': WeeklyIDFinder,
+        'ProjectMUSE': WeeklyIDFinder,
+        'ProQuest': WeeklyIDFinder,
+        'Figshare': MonthlyIDFinder,
+        'Zenodo': MonthlyIDFinder,
+        'CUL': MonthlyIDFinder,
+        'BKCI': BKCIIDFinder,
+    }
+    if platform == 'InternetArchive':
+        return InternetArchiveIDFinder(
+            lookback_hours=args.lookback_hours,
+            max_ids=args.max_ids,
+            report_path=args.report,
+            now_provider=now_provider,
+            thoth=thoth,
+        )
+    finder_class = finder_classes.get(platform)
+    if finder_class is None:
+        raise InternetArchiveSelectionError(
+            'Platform must be one of InternetArchive, Crossref, Figshare, '
+            'Zenodo, CUL, GooglePlay, BKCI, OAPEN, EBSCOHost, JSTOR, '
+            'ProjectMUSE or ProQuest')
+    return finder_class()
+
+
+def main(argv=None, now_provider=None, thoth=None):
+    """Run selection and return a process status."""
+    args = get_arguments(argv)
+    finder = None
+    try:
+        finder = get_id_finder(args, now_provider=now_provider, thoth=thoth)
+        finder.run()
+    except InternetArchiveSelectionError as error:
+        if isinstance(finder, InternetArchiveIDFinder):
+            try:
+                finder.write_failure_report(error)
+            except Exception as report_error:
+                logging.error(
+                    'Unable to write Internet Archive failure report: %s',
+                    report_error)
+        logging.error('%s', error)
+        return 1
+    except Exception as error:
+        if isinstance(finder, InternetArchiveIDFinder):
+            try:
+                finder.write_failure_report(error)
+            except Exception as report_error:
+                logging.error(
+                    'Unable to write Internet Archive failure report: %s',
+                    report_error)
+            logging.error(
+                'Internet Archive selection failed: %s: %s',
+                type(error).__name__, error)
+            return 1
+        raise
+    return 0
 
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO,
                         format='%(levelname)s:%(asctime)s: %(message)s')
-
-    args = get_arguments()
-    platform = args.platform
-    locations = args.locations
-
-    if locations:
-        match platform:
-            case 'OAPEN':
-                id_finder = OapenLocationsIDFinder()
-            case _:
-                logging.error(
-                    'Locations option is only supported for OAPEN')
-                sys.exit(1)
-    else:
-        match platform:
-            case 'Crossref':
-                id_finder = CrossrefIDFinder()
-            case 'GooglePlay':
-                id_finder = GooglePlayIDFinder()
-            case 'OAPEN' | 'EBSCOHost' | 'JSTOR' | 'ProjectMUSE' | 'ProQuest':
-                id_finder = WeeklyIDFinder()
-            case 'Figshare' | 'Zenodo' | 'CUL' | 'InternetArchive':
-                id_finder = MonthlyIDFinder()
-            case 'BKCI':
-                id_finder = BKCIIDFinder()
-            case _:
-                logging.error(
-                    'Platform must be one of InternetArchive, Crossref, Figshare, '
-                    'Zenodo, CUL, GooglePlay, BKCI, OAPEN, EBSCOHost, JSTOR, '
-                    'ProjectMUSE or ProQuest')
-                sys.exit(1)
-
-    id_finder.run()
+    sys.exit(main())

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -257,6 +257,7 @@ def _archive_report(item, desired, inspection):
         'exists': inspection['exists'],
         'ownership': inspection['ownership'],
         'ownership_reason': inspection['ownership_reason'],
+        'identifier_available': inspection['identifier_available'],
         'accepted_legacy_item': inspection['legacy'],
         'warnings': (
             ['legacy_item_missing_ownership_marker']
@@ -309,6 +310,7 @@ def _archive_inventory_report(item, uploader):
         'exists': bool(item.exists),
         'ownership': ownership['status'],
         'ownership_reason': ownership['reason'],
+        'identifier_available': ownership['identifier_available'],
         'accepted_legacy_item': ownership['status'] == 'legacy',
         'warnings': (
             ['legacy_item_missing_ownership_marker']
@@ -583,12 +585,12 @@ class InternetArchiveReconciler:
                 item, uploader)
             context['item'] = item
             result['internet_archive'] = archive_report
-            if not item.exists:
-                issues.append('item_missing')
-                actions.append('create_archive_item')
-            elif ownership['status'] == 'collision':
+            if ownership['status'] == 'collision':
                 issues.append('identifier_collision')
                 actions.append('resolve_identifier_collision')
+            elif not item.exists:
+                issues.append('item_missing')
+                actions.append('create_archive_item')
         except Exception as error:
             issues.append('archive_request_failed')
             errors.append('Internet Archive request failed: {}'.format(error))
@@ -637,16 +639,16 @@ class InternetArchiveReconciler:
                     'collection item without an ownership marker',
                     desired.identifier,
                 )
-            if not inspection['exists']:
+            if inspection['ownership'] == 'collision':
+                issues.append('identifier_collision')
+                actions.append('resolve_identifier_collision')
+            elif not inspection['exists']:
                 issues.append('item_missing')
                 actions.extend([
                     'create_archive_item',
                     'upload_pdf_original',
                     'upload_json_original',
                 ])
-            elif inspection['ownership'] == 'collision':
-                issues.append('identifier_collision')
-                actions.append('resolve_identifier_collision')
             else:
                 pdf_name = '{}.pdf'.format(desired.identifier)
                 json_name = '{}.json'.format(desired.identifier)

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -1,0 +1,842 @@
+#!/usr/bin/env python3
+"""Inspect and optionally reconcile Internet Archive dissemination state."""
+
+import argparse
+from copy import deepcopy
+import json
+import logging
+from os import environ
+from pathlib import Path
+import sys
+from uuid import UUID
+
+from internetarchive import get_item
+from thothlibrary import ThothError
+
+from errors import (
+    DisseminationError,
+    InternetArchiveDesiredStateError,
+    InternetArchiveVerificationError,
+)
+from iauploader import IAUploader
+from thothapi import get_thoth_client
+from uploader import Uploader
+from version import __version__
+from write_locations import (
+    DuplicateLocationsError,
+    LocationInput,
+    decide_location_action,
+    retrieve_existing_locations,
+    upsert_location,
+)
+
+
+DEFAULT_LIMIT = 100
+DEFAULT_EXPORT_URL = 'https://export.thoth.pub'
+SUPPORTED_WORK_TYPES = (
+    'MONOGRAPH',
+    'EDITED_BOOK',
+    'JOURNAL_ISSUE',
+    'TEXTBOOK',
+    'BOOK_SET',
+)
+ACTIVE_WORK_STATUSES = ('ACTIVE',)
+ARCHIVE_ACTIONS = {
+    'create_archive_item',
+    'upload_pdf_original',
+    'upload_json_original',
+    'update_archive_metadata',
+}
+LOCATION_ACTIONS = {
+    'create_thoth_location',
+    'update_thoth_location',
+}
+
+ISSUE_ORDER = (
+    'work_not_found',
+    'thoth_work_lookup_failed',
+    'ineligible_status',
+    'unsupported_work_type',
+    'no_pdf_publication',
+    'no_pdf_source',
+    'pdf_source_unavailable',
+    'json_export_unavailable',
+    'malformed_metadata',
+    'archive_request_failed',
+    'identifier_collision',
+    'item_missing',
+    'missing_pdf_original',
+    'missing_json_original',
+    'stale_pdf_original',
+    'stale_json_original',
+    'archive_metadata_stale',
+    'thoth_location_lookup_failed',
+    'location_missing',
+    'location_stale',
+    'duplicate_locations',
+    'archive_mutation_failed',
+    'thoth_location_mutation_failed',
+    'verification_failed',
+)
+
+ACTION_ORDER = (
+    'resolve_identifier_collision',
+    'restore_pdf_source',
+    'restore_json_export',
+    'fix_work_eligibility',
+    'create_archive_item',
+    'upload_pdf_original',
+    'upload_json_original',
+    'update_archive_metadata',
+    'create_thoth_location',
+    'update_thoth_location',
+    'resolve_duplicate_locations',
+)
+
+STATUS_ORDER = (
+    'identifier_collision',
+    'error',
+    'source_unavailable',
+    'duplicate_locations',
+    'item_missing',
+    'item_incomplete',
+    'files_stale',
+    'metadata_stale',
+    'location_missing',
+    'location_stale',
+    'ineligible',
+    'current',
+)
+
+ISSUE_STATUS = {
+    'work_not_found': 'error',
+    'thoth_work_lookup_failed': 'error',
+    'ineligible_status': 'ineligible',
+    'unsupported_work_type': 'ineligible',
+    'no_pdf_publication': 'ineligible',
+    'no_pdf_source': 'ineligible',
+    'pdf_source_unavailable': 'source_unavailable',
+    'json_export_unavailable': 'source_unavailable',
+    'malformed_metadata': 'error',
+    'archive_request_failed': 'error',
+    'identifier_collision': 'identifier_collision',
+    'item_missing': 'item_missing',
+    'missing_pdf_original': 'item_incomplete',
+    'missing_json_original': 'item_incomplete',
+    'stale_pdf_original': 'files_stale',
+    'stale_json_original': 'files_stale',
+    'archive_metadata_stale': 'metadata_stale',
+    'thoth_location_lookup_failed': 'error',
+    'location_missing': 'location_missing',
+    'location_stale': 'location_stale',
+    'duplicate_locations': 'duplicate_locations',
+    'archive_mutation_failed': 'error',
+    'thoth_location_mutation_failed': 'error',
+    'verification_failed': 'error',
+}
+
+
+class ReconciliationConfigurationError(RuntimeError):
+    """The requested batch cannot be configured safely."""
+
+
+class WorkLookupError(RuntimeError):
+    """One requested Thoth work could not be loaded."""
+
+
+def _value(value, key, default=None):
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _ordered_unique(values, ordering):
+    order = {value: index for index, value in enumerate(ordering)}
+    return sorted(
+        set(values),
+        key=lambda value: (order.get(value, len(order)), value),
+    )
+
+
+def _status_for_issues(issues):
+    statuses = {ISSUE_STATUS.get(issue, 'error') for issue in issues}
+    if not statuses:
+        return 'current'
+    return next(status for status in STATUS_ORDER if status in statuses)
+
+
+def _base_result(work_id):
+    return {
+        'work_id': work_id,
+        'publisher_id': None,
+        'title': None,
+        'publication_id': None,
+        'pdf_source_url': None,
+        'eligible': False,
+        'status': 'error',
+        'issues': [],
+        'recommended_actions': [],
+        'applied_actions': [],
+        'internet_archive': None,
+        'thoth_location': None,
+        'error': None,
+    }
+
+
+def _location_input(location):
+    return LocationInput(
+        publication_id=location.publication_id,
+        location_platform=location.location_platform,
+        landing_page=location.landing_page,
+        full_text_url=location.full_text_url,
+        checksum=location.checksum,
+        checksum_algorithm=location.checksum_algorithm,
+    )
+
+
+def _location_report(locations, location_input, plan=None):
+    matches = [
+        location for location in locations
+        if location['locationPlatform'] == location_input.location_platform
+    ]
+    return {
+        'count': len(matches),
+        'state': (
+            'duplicate' if len(matches) > 1
+            else 'missing' if not matches
+            else 'current' if plan is not None and plan.action == 'noop'
+            else 'stale'
+        ),
+        'location_id': matches[0]['locationId'] if len(matches) == 1 else None,
+        'canonical': matches[0]['canonical'] if len(matches) == 1 else None,
+        'locations': [
+            {
+                'location_id': location['locationId'],
+                'publication_id': location['publicationId'],
+                'platform': location['locationPlatform'],
+                'landing_page': location['landingPage'],
+                'full_text_url': location['fullTextUrl'],
+                'canonical': location['canonical'],
+                'checksum': location['checksum'],
+                'checksum_algorithm': location['checksumAlgorithm'],
+            }
+            for location in matches
+        ],
+        'other_platform_location_count': len(locations) - len(matches),
+        'expected': {
+            'platform': location_input.location_platform,
+            'landing_page': location_input.landing_page,
+            'full_text_url': location_input.full_text_url,
+            'checksum': location_input.checksum,
+            'checksum_algorithm': location_input.checksum_algorithm,
+        },
+    }
+
+
+def _archive_report(item, desired, inspection):
+    expected_names = set(desired.expected_md5s)
+    originals = IAUploader._original_files(item.files)
+    unmanaged_originals = sorted(set(originals) - expected_names)
+    all_file_names = {
+        IAUploader._file_value(file_metadata, 'name')
+        for file_metadata in item.files or []
+    }
+    all_file_names.discard(None)
+    unmanaged_metadata = sorted(
+        set((item.metadata or {}).keys()) - IAUploader.MANAGED_METADATA_FIELDS
+    )
+    return {
+        'identifier': desired.identifier,
+        'exists': inspection['exists'],
+        'ownership': inspection['ownership'],
+        'ownership_reason': inspection['ownership_reason'],
+        'accepted_legacy_item': inspection['legacy'],
+        'warnings': (
+            ['legacy_item_missing_ownership_marker']
+            if inspection['legacy'] else []
+        ),
+        'files': inspection['files'],
+        'metadata': {
+            'current': inspection['metadata_current'],
+            'problems': inspection['metadata_problems'],
+            'patch_fields': sorted(inspection['metadata_patch']),
+        },
+        'unrelated': {
+            'files': sorted(all_file_names - expected_names),
+            'original_files': unmanaged_originals,
+            'metadata_fields': unmanaged_metadata,
+            'collections': [
+                collection
+                for collection in IAUploader._as_metadata_list(
+                    (item.metadata or {}).get('collection'))
+                if collection != IAUploader.THOTH_COLLECTION
+            ],
+        },
+        'expected': {
+            'pdf_filename': '{}.pdf'.format(desired.identifier),
+            'json_filename': '{}.json'.format(desired.identifier),
+            'pdf_md5': desired.expected_md5s[
+                '{}.pdf'.format(desired.identifier)],
+            'json_md5': desired.expected_md5s[
+                '{}.json'.format(desired.identifier)],
+            'managed_metadata': desired.metadata,
+            'absent_managed_metadata_fields': sorted(
+                desired.absent_metadata_fields),
+            'landing_page': desired.location.landing_page,
+            'full_text_url': desired.location.full_text_url,
+        },
+    }
+
+
+class InternetArchiveReconciler:
+    """Coordinate read-only inspection and guarded idempotent repairs."""
+
+    def __init__(self, thoth=None, export_url=DEFAULT_EXPORT_URL):
+        self.thoth = thoth or get_thoth_client()
+        self.export_url = export_url.rstrip('/')
+
+    def publisher_work_ids(self, publisher_id, limit, offset):
+        """Return a stable eligible publisher slice without downloading files."""
+        try:
+            publisher = self.thoth.publisher(publisher_id=publisher_id)
+        except Exception as error:
+            raise ReconciliationConfigurationError(
+                'Publisher {} was not found: {}'.format(publisher_id, error)
+            ) from error
+        if publisher is None:
+            raise ReconciliationConfigurationError(
+                'Publisher {} was not found'.format(publisher_id)
+            )
+
+        page_size = 100
+        page_offset = 0
+        work_ids = []
+        while True:
+            try:
+                page = self.thoth.works(
+                    limit=page_size,
+                    offset=page_offset,
+                    publishers=json.dumps([publisher_id]),
+                    work_statuses='[{}]'.format(
+                        ', '.join(ACTIVE_WORK_STATUSES)),
+                    work_types='[{}]'.format(', '.join(SUPPORTED_WORK_TYPES)),
+                )
+            except Exception as error:
+                raise ReconciliationConfigurationError(
+                    'Unable to select works for publisher {}: {}'.format(
+                        publisher_id, error)
+                ) from error
+
+            for work in page:
+                publications = _value(work, 'publications', []) or []
+                if any(
+                        _value(publication, 'publicationType') == 'PDF'
+                        for publication in publications):
+                    work_ids.append(str(_value(work, 'workId')))
+            if len(page) < page_size:
+                break
+            page_offset += page_size
+
+        return sorted(set(work_ids))[offset:offset + limit]
+
+    def select_work_ids(
+            self, publisher_id=None, explicit_work_ids=None,
+            limit=DEFAULT_LIMIT, offset=0):
+        selected = set(explicit_work_ids or [])
+        if publisher_id is not None:
+            selected.update(
+                self.publisher_work_ids(publisher_id, limit, offset))
+        return sorted(selected)
+
+    def _load_work_metadata(self, work_id):
+        try:
+            raw = self.thoth.work_by_id(work_id=work_id, raw=True)
+        except ThothError as error:
+            error_text = str(error)
+            if any(marker in error_text.lower() for marker in (
+                    'not found', 'no record was found', 'could not find')):
+                raise WorkLookupError('work not found') from error
+            raise WorkLookupError(
+                'Thoth GraphQL lookup failed: {}'.format(error_text)
+            ) from error
+        except Exception as error:
+            raise WorkLookupError(str(error)) from error
+
+        try:
+            payload = json.loads(raw) if isinstance(raw, str) else raw
+            work = payload['data']['work']
+        except (KeyError, TypeError, ValueError) as error:
+            raise WorkLookupError(
+                'Thoth returned malformed work metadata: {}'.format(error)
+            ) from error
+        if work is None:
+            raise WorkLookupError('work not found')
+        Uploader.normalise_work_metadata(payload)
+        return payload
+
+    def _uploader(self, work_id, metadata):
+        uploader = IAUploader.__new__(IAUploader)
+        uploader.work_id = work_id
+        uploader.export_url = self.export_url
+        uploader.version = __version__
+        uploader.metadata = metadata
+        return uploader
+
+    @staticmethod
+    def _eligibility_issues(work):
+        issues = []
+        if work.get('workStatus') not in ACTIVE_WORK_STATUSES:
+            issues.append('ineligible_status')
+        if work.get('workType') not in SUPPORTED_WORK_TYPES:
+            issues.append('unsupported_work_type')
+        publications = work.get('publications') or []
+        if not any(
+                publication.get('publicationType') == 'PDF'
+                for publication in publications):
+            issues.append('no_pdf_publication')
+        return issues
+
+    def inspect_work(self, work_id):
+        """Build desired state, then inspect both remote systems read-only."""
+        result = _base_result(work_id)
+        context = {}
+        try:
+            metadata = self._load_work_metadata(work_id)
+        except WorkLookupError as error:
+            issue = (
+                'work_not_found' if str(error) == 'work not found'
+                else 'thoth_work_lookup_failed'
+            )
+            result['issues'] = [issue]
+            result['status'] = _status_for_issues(result['issues'])
+            result['error'] = str(error)
+            return result, context
+
+        work = metadata['data']['work']
+        uploader = self._uploader(work_id, metadata)
+        publisher = ((work.get('imprint') or {}).get('publisher') or {})
+        result.update({
+            'publisher_id': publisher.get('publisherId'),
+            'title': work.get('title') or work.get('fullTitle'),
+        })
+        eligibility_issues = self._eligibility_issues(work)
+        if eligibility_issues:
+            result['issues'] = _ordered_unique(
+                eligibility_issues, ISSUE_ORDER)
+            result['recommended_actions'] = ['fix_work_eligibility']
+            result['status'] = _status_for_issues(result['issues'])
+            return result, context
+
+        try:
+            source = uploader.get_publication_source('PDF')
+        except Exception as error:
+            result['issues'] = ['no_pdf_source']
+            result['recommended_actions'] = ['fix_work_eligibility']
+            result['status'] = 'ineligible'
+            result['error'] = str(error)
+            return result, context
+
+        result.update({
+            'publication_id': source.id,
+            'pdf_source_url': source.url,
+            'eligible': True,
+        })
+        try:
+            desired = uploader.build_desired_state()
+        except InternetArchiveDesiredStateError as error:
+            issue = {
+                'pdf': 'pdf_source_unavailable',
+                'json': 'json_export_unavailable',
+                'metadata': 'malformed_metadata',
+            }.get(error.source, 'malformed_metadata')
+            result['issues'] = [issue]
+            result['recommended_actions'] = [{
+                'pdf_source_unavailable': 'restore_pdf_source',
+                'json_export_unavailable': 'restore_json_export',
+                'malformed_metadata': 'fix_work_eligibility',
+            }[issue]]
+            result['status'] = _status_for_issues(result['issues'])
+            result['error'] = str(error)
+            return result, context
+
+        context.update({'uploader': uploader, 'desired': desired})
+        result = self._inspect_remote(result, uploader, desired, context)
+        return result, context
+
+    def _inspect_remote(self, initial_result, uploader, desired, context):
+        result = deepcopy(initial_result)
+        issues = []
+        actions = []
+        errors = []
+        result['internet_archive'] = None
+        result['thoth_location'] = None
+
+        try:
+            item = get_item(desired.identifier)
+            inspection = uploader.inspect_item(item, desired)
+            context.update({'item': item, 'archive_inspection': inspection})
+            result['internet_archive'] = _archive_report(
+                item, desired, inspection)
+            if inspection['legacy']:
+                logging.warning(
+                    'Internet Archive item %s is an accepted legacy Thoth '
+                    'collection item without an ownership marker',
+                    desired.identifier,
+                )
+            if not inspection['exists']:
+                issues.append('item_missing')
+                actions.append('create_archive_item')
+            elif inspection['ownership'] == 'collision':
+                issues.append('identifier_collision')
+                actions.append('resolve_identifier_collision')
+            else:
+                pdf_name = '{}.pdf'.format(desired.identifier)
+                json_name = '{}.json'.format(desired.identifier)
+                for name, missing_issue, stale_issue, action in (
+                    (pdf_name, 'missing_pdf_original', 'stale_pdf_original',
+                     'upload_pdf_original'),
+                    (json_name, 'missing_json_original', 'stale_json_original',
+                     'upload_json_original'),
+                ):
+                    state = inspection['files'][name]
+                    if not state['present']:
+                        issues.append(missing_issue)
+                        actions.append(action)
+                    elif not state['current']:
+                        issues.append(stale_issue)
+                        actions.append(action)
+                if not inspection['metadata_current']:
+                    issues.append('archive_metadata_stale')
+                    actions.append('update_archive_metadata')
+        except Exception as error:
+            issues.append('archive_request_failed')
+            errors.append('Internet Archive request failed: {}'.format(error))
+
+        location_input = _location_input(desired.location)
+        context['location_input'] = location_input
+        try:
+            locations = retrieve_existing_locations(
+                self.thoth, desired.publication_id)
+            try:
+                plan = decide_location_action(location_input, locations)
+            except DuplicateLocationsError:
+                plan = None
+                issues.append('duplicate_locations')
+                actions.append('resolve_duplicate_locations')
+            context.update({'locations': locations, 'location_plan': plan})
+            result['thoth_location'] = _location_report(
+                locations, location_input, plan)
+            if plan is not None and plan.action == 'create':
+                issues.append('location_missing')
+                actions.append('create_thoth_location')
+            elif plan is not None and plan.action == 'update':
+                issues.append('location_stale')
+                actions.append('update_thoth_location')
+        except Exception as error:
+            issues.append('thoth_location_lookup_failed')
+            errors.append('Thoth location lookup failed: {}'.format(error))
+
+        issues = _ordered_unique(issues, ISSUE_ORDER)
+        actions = _ordered_unique(actions, ACTION_ORDER)
+        if 'identifier_collision' in issues:
+            actions = ['resolve_identifier_collision']
+        elif 'duplicate_locations' in issues:
+            actions = ['resolve_duplicate_locations']
+        result['issues'] = issues
+        result['recommended_actions'] = actions
+        result['status'] = _status_for_issues(issues)
+        result['error'] = '; '.join(errors) if errors else None
+        return result
+
+    @staticmethod
+    def _safe_to_apply(result):
+        return (
+            result['eligible']
+            and result['error'] is None
+            and 'identifier_collision' not in result['issues']
+            and 'duplicate_locations' not in result['issues']
+            and bool(
+                set(result['recommended_actions'])
+                & (ARCHIVE_ACTIONS | LOCATION_ACTIONS)
+            )
+        )
+
+    def reconcile_one(self, work_id, apply=False, credentials=None):
+        before, context = self.inspect_work(work_id)
+        if not apply or not self._safe_to_apply(before):
+            return before
+
+        applied_actions = []
+        try:
+            archive_actions = [
+                action for action in before['recommended_actions']
+                if action in ARCHIVE_ACTIONS
+            ]
+            if archive_actions:
+                context['uploader'].apply_archive_repairs(
+                    context['item'],
+                    context['desired'],
+                    inspection=context['archive_inspection'],
+                    access_key=credentials['ia_s3_access'],
+                    secret_key=credentials['ia_s3_secret'],
+                )
+                applied_actions.extend(archive_actions)
+
+            location_actions = [
+                action for action in before['recommended_actions']
+                if action in LOCATION_ACTIONS
+            ]
+            if location_actions:
+                upsert_location(self.thoth, context['location_input'])
+                applied_actions.extend(location_actions)
+        except InternetArchiveVerificationError as error:
+            return self._failed_apply_result(
+                before, applied_actions, 'verification_failed', str(error))
+        except DisseminationError as error:
+            return self._failed_apply_result(
+                before, applied_actions, 'archive_mutation_failed', str(error))
+        except Exception as error:
+            issue = (
+                'thoth_location_mutation_failed'
+                if any(
+                    action in LOCATION_ACTIONS
+                    for action in before['recommended_actions'])
+                and all(action in applied_actions for action in archive_actions)
+                else 'archive_mutation_failed'
+            )
+            return self._failed_apply_result(
+                before, applied_actions, issue, str(error))
+
+        verification_base = deepcopy(before)
+        verification_base.update({
+            'issues': [],
+            'recommended_actions': [],
+            'applied_actions': [],
+            'internet_archive': None,
+            'thoth_location': None,
+            'error': None,
+        })
+        verification_context = {
+            'uploader': context['uploader'],
+            'desired': context['desired'],
+        }
+        final = self._inspect_remote(
+            verification_base,
+            context['uploader'],
+            context['desired'],
+            verification_context,
+        )
+        final['before'] = before
+        final['applied_actions'] = _ordered_unique(
+            applied_actions, ACTION_ORDER)
+        if final['status'] != 'current':
+            final['issues'] = _ordered_unique(
+                final['issues'] + ['verification_failed'], ISSUE_ORDER)
+            final['status'] = 'error'
+            message = 'Final verification did not converge to current state'
+            final['error'] = (
+                '{}; {}'.format(final['error'], message)
+                if final['error'] else message
+            )
+        return final
+
+    @staticmethod
+    def _failed_apply_result(before, applied_actions, issue, error):
+        result = deepcopy(before)
+        result['before'] = before
+        result['issues'] = _ordered_unique(
+            result['issues'] + [issue], ISSUE_ORDER)
+        result['status'] = 'error'
+        result['applied_actions'] = _ordered_unique(
+            applied_actions, ACTION_ORDER)
+        result['error'] = error
+        return result
+
+    def reconcile(self, work_ids, apply=False, credentials=None):
+        results = []
+        for work_id in work_ids:
+            logging.info('Inspecting Internet Archive state for %s', work_id)
+            try:
+                result = self.reconcile_one(
+                    work_id, apply=apply, credentials=credentials)
+            except Exception as error:
+                result = _base_result(work_id)
+                result.update({
+                    'status': 'error',
+                    'issues': ['thoth_work_lookup_failed'],
+                    'error': 'Unexpected reconciliation failure: {}'.format(
+                        error),
+                })
+            results.append(result)
+        return results
+
+
+def validate_apply_credentials(environment=None):
+    values = environ if environment is None else environment
+    required = ('ia_s3_access', 'ia_s3_secret', 'THOTH_PAT')
+    missing = [name for name in required if not values.get(name)]
+    if missing:
+        raise ReconciliationConfigurationError(
+            'Apply mode requires: {}'.format(', '.join(missing)))
+    return {name: values[name] for name in required}
+
+
+def summarise(results):
+    ambiguous_statuses = {'identifier_collision', 'duplicate_locations'}
+    failed_statuses = {'error', 'source_unavailable', 'ineligible'}
+    return {
+        'inspected': len(results),
+        'current': sum(result['status'] == 'current' for result in results),
+        'repairable': sum(
+            result['eligible']
+            and result['status'] not in ambiguous_statuses | failed_statuses
+            and bool(
+                set(result['recommended_actions'])
+                & (ARCHIVE_ACTIONS | LOCATION_ACTIONS)
+            )
+            for result in results
+        ),
+        'ambiguous': sum(
+            result['status'] in ambiguous_statuses for result in results),
+        'failed': sum(
+            result['status'] in failed_statuses for result in results),
+        'repaired': sum(
+            result['status'] == 'current' and bool(result['applied_actions'])
+            for result in results
+        ),
+        'by_status': {
+            status: sum(result['status'] == status for result in results)
+            for status in STATUS_ORDER
+            if any(result['status'] == status for result in results)
+        },
+    }
+
+
+def _redact(value, secrets):
+    if isinstance(value, dict):
+        return {key: _redact(item, secrets) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact(item, secrets) for item in value]
+    if isinstance(value, str):
+        redacted = value
+        for secret in secrets:
+            if secret:
+                redacted = redacted.replace(secret, '[REDACTED]')
+        return redacted
+    return value
+
+
+def render_report(results, output_format='json', secrets=()):
+    safe_results = _redact(results, secrets)
+    summary = summarise(safe_results)
+    if output_format == 'json':
+        return json.dumps(
+            {'results': safe_results, 'summary': summary},
+            indent=2,
+            sort_keys=True,
+        ) + '\n'
+    lines = [
+        json.dumps(result, sort_keys=True, separators=(',', ':'))
+        for result in safe_results
+    ]
+    lines.append(json.dumps(
+        {'summary': summary}, sort_keys=True, separators=(',', ':')))
+    return '\n'.join(lines) + '\n'
+
+
+def write_report(report, output=None):
+    if output is None:
+        sys.stdout.write(report)
+        return
+    Path(output).write_text(report, encoding='utf-8')
+
+
+def uuid_value(value):
+    try:
+        return str(UUID(value))
+    except (ValueError, AttributeError) as error:
+        raise argparse.ArgumentTypeError(
+            '{} is not a valid UUID'.format(value)) from error
+
+
+def positive_integer(value):
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError('must be an integer') from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError('must be at least 1')
+    return parsed
+
+
+def nonnegative_integer(value):
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError('must be an integer') from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError('must be at least 0')
+    return parsed
+
+
+def parse_arguments(argv=None):
+    parser = argparse.ArgumentParser(
+        description='Inspect and safely reconcile Internet Archive state')
+    parser.add_argument('--publisher-id', type=uuid_value)
+    parser.add_argument('--work-id', action='append', type=uuid_value,
+                        default=[])
+    parser.add_argument('--limit', type=positive_integer,
+                        default=DEFAULT_LIMIT)
+    parser.add_argument('--offset', type=nonnegative_integer, default=0)
+    parser.add_argument('--output')
+    parser.add_argument('--format', choices=('json', 'jsonl'), default='json')
+    parser.add_argument('--apply', action='store_true')
+    arguments = parser.parse_args(argv)
+    if arguments.publisher_id is None and not arguments.work_id:
+        parser.error('at least one --publisher-id or --work-id is required')
+    return arguments
+
+
+def main(argv=None):
+    arguments = parse_arguments(argv)
+    credentials = None
+    try:
+        if arguments.apply:
+            credentials = validate_apply_credentials()
+        reconciler = InternetArchiveReconciler()
+        if arguments.apply:
+            reconciler.thoth.set_token(credentials['THOTH_PAT'])
+        work_ids = reconciler.select_work_ids(
+            publisher_id=arguments.publisher_id,
+            explicit_work_ids=arguments.work_id,
+            limit=arguments.limit,
+            offset=arguments.offset,
+        )
+        results = reconciler.reconcile(
+            work_ids, apply=arguments.apply, credentials=credentials)
+        secret_values = [
+            environ.get(name)
+            for name in ('ia_s3_access', 'ia_s3_secret', 'THOTH_PAT')
+        ]
+        write_report(
+            render_report(results, arguments.format, secret_values),
+            arguments.output,
+        )
+    except (ReconciliationConfigurationError, OSError) as error:
+        logging.error('%s', error)
+        return 2
+
+    summary = summarise(results)
+    if arguments.apply:
+        return 1 if any(
+            result['status'] != 'current' for result in results) else 0
+    return 1 if summary['failed'] else 0
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s:%(asctime)s: %(message)s',
+    )
+    logging.getLogger('urllib3').setLevel(logging.INFO)
+    sys.exit(main())

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import sys
 from uuid import UUID
 
+from dotenv import load_dotenv
 from internetarchive import get_item
 from thothlibrary import ThothError
 
@@ -869,6 +870,7 @@ class InternetArchiveReconciler:
                     self.thoth,
                     context['location_input'],
                     progress=record_progress,
+                    emit_location_id=False,
                 )
                 # A successful alternate implementation without progress
                 # callbacks still indicates a mutation when it returns an ID.
@@ -977,6 +979,11 @@ def validate_apply_credentials(environment=None):
         raise ReconciliationConfigurationError(
             'Apply mode requires: {}'.format(', '.join(missing)))
     return {name: values[name] for name in required}
+
+
+def load_local_environment(path=Path('./config.env')):
+    """Load local CLI configuration without overriding process values."""
+    load_dotenv(dotenv_path=path, override=False)
 
 
 def summarise(results):
@@ -1102,6 +1109,7 @@ def main(argv=None):
     arguments = parse_arguments(argv)
     credentials = None
     try:
+        load_local_environment()
         if arguments.apply:
             credentials = validate_apply_credentials()
         reconciler = InternetArchiveReconciler()

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -881,34 +881,24 @@ class InternetArchiveReconciler:
                         if action not in applied_actions:
                             applied_actions.append(action)
         except Exception as error:
+            failure_base = before
+            failure_error = str(error)
+            if any(
+                    action in ARCHIVE_ACTIONS
+                    for action in applied_actions):
+                try:
+                    failure_base = self._inspect_after_apply(before, context)
+                except Exception as inspection_error:
+                    failure_error = (
+                        '{}; post-apply reinspection failed: {}'.format(
+                            failure_error, inspection_error)
+                    )
             return self._failed_apply_result(
-                before, attempted_actions, applied_actions,
+                failure_base, attempted_actions, applied_actions,
                 uncertain_actions, 'thoth_location_mutation_failed',
-                str(error))
+                failure_error, before=before)
 
-        verification_base = deepcopy(before)
-        verification_base.update({
-            'issues': [],
-            'recommended_actions': [],
-            'auto_applicable_actions': [],
-            'attempted_actions': [],
-            'applied_actions': [],
-            'uncertain_actions': [],
-            'internet_archive': None,
-            'thoth_location': None,
-            'error': None,
-        })
-        verification_context = {
-            'uploader': context['uploader'],
-            'desired': context['desired'],
-            'item': context['item'],
-        }
-        final = self._inspect_remote(
-            verification_base,
-            context['uploader'],
-            context['desired'],
-            verification_context,
-        )
+        final = self._inspect_after_apply(before, context)
         final['before'] = before
         final['attempted_actions'] = _ordered_unique(
             attempted_actions, ACTION_ORDER)
@@ -927,12 +917,37 @@ class InternetArchiveReconciler:
             )
         return final
 
+    def _inspect_after_apply(self, before, context):
+        verification_base = deepcopy(before)
+        verification_base.update({
+            'issues': [],
+            'recommended_actions': [],
+            'auto_applicable_actions': [],
+            'attempted_actions': [],
+            'applied_actions': [],
+            'uncertain_actions': [],
+            'internet_archive': None,
+            'thoth_location': None,
+            'error': None,
+        })
+        verification_context = {
+            'uploader': context['uploader'],
+            'desired': context['desired'],
+            'item': context['item'],
+        }
+        return self._inspect_remote(
+            verification_base,
+            context['uploader'],
+            context['desired'],
+            verification_context,
+        )
+
     @staticmethod
     def _failed_apply_result(
-            before, attempted_actions, applied_actions, uncertain_actions,
-            issue, error):
-        result = deepcopy(before)
-        result['before'] = before
+            base, attempted_actions, applied_actions, uncertain_actions,
+            issue, error, before=None):
+        result = deepcopy(base)
+        result['before'] = base if before is None else before
         result['issues'] = _ordered_unique(
             result['issues'] + [issue], ISSUE_ORDER)
         result['status'] = 'error'

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -303,9 +303,9 @@ def _archive_report(item, desired, inspection):
     }
 
 
-def _archive_inventory_report(item, uploader):
+def _archive_inventory_report(item, uploader, ownership=None):
     """Report safely discoverable Archive state without desired source state."""
-    ownership = uploader.classify_item_ownership(item)
+    ownership = ownership or uploader.classify_item_ownership(item)
     all_files = sorted(filter(None, (
         IAUploader._file_value(file_metadata, 'name')
         for file_metadata in item.files or []
@@ -491,7 +491,7 @@ class InternetArchiveReconciler:
         return issues
 
     def inspect_work(self, work_id, selection=None):
-        """Build desired state, then inspect both remote systems read-only."""
+        """Preflight Archive ownership, then inspect source and remote state."""
         result = _base_result(work_id)
         if selection is not None:
             result['selection'] = {
@@ -518,18 +518,34 @@ class InternetArchiveReconciler:
 
         work = metadata['data']['work']
         uploader = self._uploader(work_id, metadata)
+        context['uploader'] = uploader
         publisher = ((work.get('imprint') or {}).get('publisher') or {})
+        pdf_publication = next((
+            publication for publication in work.get('publications') or []
+            if publication.get('publicationType') == 'PDF'
+        ), None)
         result.update({
             'publisher_id': publisher.get('publisherId'),
             'title': work.get('title') or work.get('fullTitle'),
+            'publication_id': (
+                pdf_publication.get('publicationId')
+                if pdf_publication is not None else None
+            ),
         })
         eligibility_issues = self._eligibility_issues(work)
         result['issues'] = _ordered_unique(eligibility_issues, ISSUE_ORDER)
+        result['eligible'] = not eligibility_issues
         if eligibility_issues:
             result['recommended_actions'] = ['fix_work_eligibility']
+
+        result = self._preflight_archive(result, uploader, context)
+        if {'archive_request_failed', 'identifier_collision'}.intersection(
+                result['issues']):
+            return self._inspect_discoverable_state(
+                result, uploader, context), context
         if eligibility_issues and not result['selection']['explicit']:
-            result['status'] = _status_for_issues(result['issues'])
-            return result, context
+            return self._inspect_discoverable_state(
+                result, uploader, context), context
 
         try:
             source = uploader.get_publication_source('PDF')
@@ -541,19 +557,12 @@ class InternetArchiveReconciler:
                 ACTION_ORDER,
             )
             result['error'] = str(error)
-            pdf_publication = next((
-                publication for publication in work.get('publications') or []
-                if publication.get('publicationType') == 'PDF'
-            ), None)
-            if pdf_publication is not None:
-                result['publication_id'] = pdf_publication.get('publicationId')
             return self._inspect_discoverable_state(
                 result, uploader, context), context
 
         result.update({
             'publication_id': source.id,
             'pdf_source_url': source.url,
-            'eligible': not eligibility_issues,
         })
         try:
             desired = uploader.build_desired_state()
@@ -575,32 +584,58 @@ class InternetArchiveReconciler:
             return self._inspect_discoverable_state(
                 result, uploader, context), context
 
-        context.update({'uploader': uploader, 'desired': desired})
+        context['desired'] = desired
         result = self._inspect_remote(result, uploader, desired, context)
         return result, context
 
-    def _inspect_discoverable_state(self, initial_result, uploader, context):
-        """Inspect ownership and observed locations without expected state."""
+    def _preflight_archive(self, initial_result, uploader, context):
+        """Retrieve and classify one Archive item before source requests."""
         result = deepcopy(initial_result)
         issues = list(result['issues'])
         actions = list(result['recommended_actions'])
         errors = [result['error']] if result['error'] else []
+        context['archive_preflight_complete'] = True
 
         try:
             item = get_item(uploader.work_id)
-            archive_report, ownership = _archive_inventory_report(
-                item, uploader)
-            context['item'] = item
+            ownership = uploader.classify_item_ownership(item)
+            archive_report, _ = _archive_inventory_report(
+                item, uploader, ownership=ownership)
+            context.update({
+                'item': item,
+                'archive_ownership': ownership,
+            })
             result['internet_archive'] = archive_report
             if ownership['status'] == 'collision':
                 issues.append('identifier_collision')
                 actions.append('resolve_identifier_collision')
-            elif not item.exists:
-                issues.append('item_missing')
-                actions.append('create_archive_item')
         except Exception as error:
             issues.append('archive_request_failed')
             errors.append('Internet Archive request failed: {}'.format(error))
+
+        result['issues'] = _ordered_unique(issues, ISSUE_ORDER)
+        result['recommended_actions'] = _ordered_unique(actions, ACTION_ORDER)
+        result['status'] = _status_for_issues(result['issues'])
+        result['error'] = '; '.join(_ordered_unique(errors, ())) or None
+        return result
+
+    def _inspect_discoverable_state(self, initial_result, uploader, context):
+        """Inspect ownership and observed locations without expected state."""
+        result = deepcopy(initial_result)
+        if not context.get('archive_preflight_complete'):
+            result = self._preflight_archive(result, uploader, context)
+        issues = list(result['issues'])
+        actions = list(result['recommended_actions'])
+        errors = [result['error']] if result['error'] else []
+
+        ownership = context.get('archive_ownership')
+        if ownership is not None:
+            if ownership['status'] == 'collision':
+                issues.append('identifier_collision')
+                actions.append('resolve_identifier_collision')
+            elif ownership['status'] == 'missing':
+                issues.append('item_missing')
+                actions.append('create_archive_item')
 
         if result['publication_id'] is not None:
             try:
@@ -631,13 +666,21 @@ class InternetArchiveReconciler:
         issues = list(result['issues'])
         actions = list(result['recommended_actions'])
         errors = [result['error']] if result['error'] else []
-        result['internet_archive'] = None
+        result['internet_archive'] = initial_result.get('internet_archive')
         result['thoth_location'] = None
 
         try:
-            item = get_item(desired.identifier)
-            inspection = uploader.inspect_item(item, desired)
-            context.update({'item': item, 'archive_inspection': inspection})
+            item = context.get('item')
+            if item is None:
+                item = get_item(desired.identifier)
+                context['item'] = item
+            ownership = context.get('archive_ownership')
+            if ownership is None:
+                ownership = uploader.classify_item_ownership(item)
+                context['archive_ownership'] = ownership
+            inspection = uploader.inspect_item(
+                item, desired, ownership=ownership)
+            context['archive_inspection'] = inspection
             result['internet_archive'] = _archive_report(
                 item, desired, inspection)
             if inspection['legacy']:
@@ -841,6 +884,7 @@ class InternetArchiveReconciler:
         verification_context = {
             'uploader': context['uploader'],
             'desired': context['desired'],
+            'item': context['item'],
         }
         final = self._inspect_remote(
             verification_base,

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -20,6 +20,7 @@ from errors import (
     InternetArchiveVerificationError,
 )
 from iauploader import IAUploader
+from internet_archive_policy import ACTIVE_WORK_STATUSES, SUPPORTED_WORK_TYPES
 from thothapi import get_thoth_client
 from uploader import Uploader
 from version import __version__
@@ -34,14 +35,6 @@ from write_locations import (
 
 DEFAULT_LIMIT = 100
 DEFAULT_EXPORT_URL = 'https://export.thoth.pub'
-SUPPORTED_WORK_TYPES = (
-    'MONOGRAPH',
-    'EDITED_BOOK',
-    'JOURNAL_ISSUE',
-    'TEXTBOOK',
-    'BOOK_SET',
-)
-ACTIVE_WORK_STATUSES = ('ACTIVE',)
 ARCHIVE_ACTIONS = {
     'create_archive_item',
     'upload_pdf_original',

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -168,6 +168,10 @@ def _status_for_issues(issues):
 def _base_result(work_id):
     return {
         'work_id': work_id,
+        'selection': {
+            'explicit': True,
+            'publisher': False,
+        },
         'publisher_id': None,
         'title': None,
         'publication_id': None,
@@ -176,7 +180,10 @@ def _base_result(work_id):
         'status': 'error',
         'issues': [],
         'recommended_actions': [],
+        'auto_applicable_actions': [],
+        'attempted_actions': [],
         'applied_actions': [],
+        'uncertain_actions': [],
         'internet_archive': None,
         'thoth_location': None,
         'error': None,
@@ -195,10 +202,10 @@ def _location_input(location):
 
 
 def _location_report(locations, location_input, plan=None):
-    matches = [
+    matches = sorted([
         location for location in locations
         if location['locationPlatform'] == location_input.location_platform
-    ]
+    ], key=lambda location: location['locationId'])
     return {
         'count': len(matches),
         'state': (
@@ -265,12 +272,12 @@ def _archive_report(item, desired, inspection):
             'files': sorted(all_file_names - expected_names),
             'original_files': unmanaged_originals,
             'metadata_fields': unmanaged_metadata,
-            'collections': [
+            'collections': sorted([
                 collection
                 for collection in IAUploader._as_metadata_list(
                     (item.metadata or {}).get('collection'))
                 if collection != IAUploader.THOTH_COLLECTION
-            ],
+            ]),
         },
         'expected': {
             'pdf_filename': '{}.pdf'.format(desired.identifier),
@@ -288,12 +295,81 @@ def _archive_report(item, desired, inspection):
     }
 
 
+def _archive_inventory_report(item, uploader):
+    """Report safely discoverable Archive state without desired source state."""
+    ownership = uploader.classify_item_ownership(item)
+    all_files = sorted(filter(None, (
+        IAUploader._file_value(file_metadata, 'name')
+        for file_metadata in item.files or []
+    )))
+    originals = sorted(IAUploader._original_files(item.files))
+    metadata = item.metadata or {}
+    return {
+        'identifier': uploader.work_id,
+        'exists': bool(item.exists),
+        'ownership': ownership['status'],
+        'ownership_reason': ownership['reason'],
+        'accepted_legacy_item': ownership['status'] == 'legacy',
+        'warnings': (
+            ['legacy_item_missing_ownership_marker']
+            if ownership['status'] == 'legacy' else []
+        ),
+        'files': {
+            'all_names': all_files,
+            'original_names': originals,
+        },
+        'metadata': None,
+        'unrelated': {
+            'files': all_files,
+            'original_files': originals,
+            'metadata_fields': sorted(metadata),
+            'collections': sorted(
+                IAUploader._as_metadata_list(metadata.get('collection'))),
+        },
+        'expected': None,
+    }, ownership
+
+
+def _location_inventory_report(locations):
+    """Report observed IA locations when desired source state is unavailable."""
+    matches = sorted([
+        location for location in locations
+        if location['locationPlatform'] == 'INTERNET_ARCHIVE'
+    ], key=lambda location: location['locationId'])
+    return {
+        'count': len(matches),
+        'state': (
+            'duplicate' if len(matches) > 1
+            else 'missing' if not matches
+            else 'observed'
+        ),
+        'location_id': matches[0]['locationId'] if len(matches) == 1 else None,
+        'canonical': matches[0]['canonical'] if len(matches) == 1 else None,
+        'locations': [
+            {
+                'location_id': location['locationId'],
+                'publication_id': location['publicationId'],
+                'platform': location['locationPlatform'],
+                'landing_page': location['landingPage'],
+                'full_text_url': location['fullTextUrl'],
+                'canonical': location['canonical'],
+                'checksum': location['checksum'],
+                'checksum_algorithm': location['checksumAlgorithm'],
+            }
+            for location in matches
+        ],
+        'other_platform_location_count': len(locations) - len(matches),
+        'expected': None,
+    }
+
+
 class InternetArchiveReconciler:
     """Coordinate read-only inspection and guarded idempotent repairs."""
 
     def __init__(self, thoth=None, export_url=DEFAULT_EXPORT_URL):
         self.thoth = thoth or get_thoth_client()
         self.export_url = export_url.rstrip('/')
+        self.selection_by_work_id = {}
 
     def publisher_work_ids(self, publisher_id, limit, offset):
         """Return a stable eligible publisher slice without downloading files."""
@@ -342,10 +418,19 @@ class InternetArchiveReconciler:
     def select_work_ids(
             self, publisher_id=None, explicit_work_ids=None,
             limit=DEFAULT_LIMIT, offset=0):
-        selected = set(explicit_work_ids or [])
+        explicit = set(explicit_work_ids or [])
+        publisher = set()
         if publisher_id is not None:
-            selected.update(
+            publisher.update(
                 self.publisher_work_ids(publisher_id, limit, offset))
+        selected = explicit | publisher
+        self.selection_by_work_id = {
+            work_id: {
+                'explicit': work_id in explicit,
+                'publisher': work_id in publisher,
+            }
+            for work_id in selected
+        }
         return sorted(selected)
 
     def _load_work_metadata(self, work_id):
@@ -396,9 +481,14 @@ class InternetArchiveReconciler:
             issues.append('no_pdf_publication')
         return issues
 
-    def inspect_work(self, work_id):
+    def inspect_work(self, work_id, selection=None):
         """Build desired state, then inspect both remote systems read-only."""
         result = _base_result(work_id)
+        if selection is not None:
+            result['selection'] = {
+                'explicit': bool(selection.get('explicit')),
+                'publisher': bool(selection.get('publisher')),
+            }
         context = {}
         try:
             metadata = self._load_work_metadata(work_id)
@@ -410,6 +500,11 @@ class InternetArchiveReconciler:
             result['issues'] = [issue]
             result['status'] = _status_for_issues(result['issues'])
             result['error'] = str(error)
+            if result['selection']['explicit']:
+                uploader = self._uploader(
+                    work_id, {'data': {'work': {}}})
+                return self._inspect_discoverable_state(
+                    result, uploader, context), context
             return result, context
 
         work = metadata['data']['work']
@@ -420,26 +515,36 @@ class InternetArchiveReconciler:
             'title': work.get('title') or work.get('fullTitle'),
         })
         eligibility_issues = self._eligibility_issues(work)
+        result['issues'] = _ordered_unique(eligibility_issues, ISSUE_ORDER)
         if eligibility_issues:
-            result['issues'] = _ordered_unique(
-                eligibility_issues, ISSUE_ORDER)
             result['recommended_actions'] = ['fix_work_eligibility']
+        if eligibility_issues and not result['selection']['explicit']:
             result['status'] = _status_for_issues(result['issues'])
             return result, context
 
         try:
             source = uploader.get_publication_source('PDF')
         except Exception as error:
-            result['issues'] = ['no_pdf_source']
-            result['recommended_actions'] = ['fix_work_eligibility']
-            result['status'] = 'ineligible'
+            result['issues'] = _ordered_unique(
+                result['issues'] + ['no_pdf_source'], ISSUE_ORDER)
+            result['recommended_actions'] = _ordered_unique(
+                result['recommended_actions'] + ['fix_work_eligibility'],
+                ACTION_ORDER,
+            )
             result['error'] = str(error)
-            return result, context
+            pdf_publication = next((
+                publication for publication in work.get('publications') or []
+                if publication.get('publicationType') == 'PDF'
+            ), None)
+            if pdf_publication is not None:
+                result['publication_id'] = pdf_publication.get('publicationId')
+            return self._inspect_discoverable_state(
+                result, uploader, context), context
 
         result.update({
             'publication_id': source.id,
             'pdf_source_url': source.url,
-            'eligible': True,
+            'eligible': not eligibility_issues,
         })
         try:
             desired = uploader.build_desired_state()
@@ -449,25 +554,74 @@ class InternetArchiveReconciler:
                 'json': 'json_export_unavailable',
                 'metadata': 'malformed_metadata',
             }.get(error.source, 'malformed_metadata')
-            result['issues'] = [issue]
-            result['recommended_actions'] = [{
+            result['issues'] = _ordered_unique(
+                result['issues'] + [issue], ISSUE_ORDER)
+            result['recommended_actions'] = _ordered_unique(
+                result['recommended_actions'] + [{
                 'pdf_source_unavailable': 'restore_pdf_source',
                 'json_export_unavailable': 'restore_json_export',
                 'malformed_metadata': 'fix_work_eligibility',
-            }[issue]]
-            result['status'] = _status_for_issues(result['issues'])
+                }[issue]], ACTION_ORDER)
             result['error'] = str(error)
-            return result, context
+            return self._inspect_discoverable_state(
+                result, uploader, context), context
 
         context.update({'uploader': uploader, 'desired': desired})
         result = self._inspect_remote(result, uploader, desired, context)
         return result, context
 
+    def _inspect_discoverable_state(self, initial_result, uploader, context):
+        """Inspect ownership and observed locations without expected state."""
+        result = deepcopy(initial_result)
+        issues = list(result['issues'])
+        actions = list(result['recommended_actions'])
+        errors = [result['error']] if result['error'] else []
+
+        try:
+            item = get_item(uploader.work_id)
+            archive_report, ownership = _archive_inventory_report(
+                item, uploader)
+            context['item'] = item
+            result['internet_archive'] = archive_report
+            if not item.exists:
+                issues.append('item_missing')
+                actions.append('create_archive_item')
+            elif ownership['status'] == 'collision':
+                issues.append('identifier_collision')
+                actions.append('resolve_identifier_collision')
+        except Exception as error:
+            issues.append('archive_request_failed')
+            errors.append('Internet Archive request failed: {}'.format(error))
+
+        if result['publication_id'] is not None:
+            try:
+                locations = retrieve_existing_locations(
+                    self.thoth, result['publication_id'])
+                context['locations'] = locations
+                result['thoth_location'] = _location_inventory_report(locations)
+                count = result['thoth_location']['count']
+                if count == 0:
+                    issues.append('location_missing')
+                    actions.append('create_thoth_location')
+                elif count > 1:
+                    issues.append('duplicate_locations')
+                    actions.append('resolve_duplicate_locations')
+            except Exception as error:
+                issues.append('thoth_location_lookup_failed')
+                errors.append('Thoth location lookup failed: {}'.format(error))
+
+        result['issues'] = _ordered_unique(issues, ISSUE_ORDER)
+        result['recommended_actions'] = _ordered_unique(actions, ACTION_ORDER)
+        result['auto_applicable_actions'] = []
+        result['status'] = _status_for_issues(result['issues'])
+        result['error'] = '; '.join(_ordered_unique(errors, ())) or None
+        return result
+
     def _inspect_remote(self, initial_result, uploader, desired, context):
         result = deepcopy(initial_result)
-        issues = []
-        actions = []
-        errors = []
+        issues = list(result['issues'])
+        actions = list(result['recommended_actions'])
+        errors = [result['error']] if result['error'] else []
         result['internet_archive'] = None
         result['thoth_location'] = None
 
@@ -485,7 +639,11 @@ class InternetArchiveReconciler:
                 )
             if not inspection['exists']:
                 issues.append('item_missing')
-                actions.append('create_archive_item')
+                actions.extend([
+                    'create_archive_item',
+                    'upload_pdf_original',
+                    'upload_json_original',
+                ])
             elif inspection['ownership'] == 'collision':
                 issues.append('identifier_collision')
                 actions.append('resolve_identifier_collision')
@@ -538,38 +696,58 @@ class InternetArchiveReconciler:
 
         issues = _ordered_unique(issues, ISSUE_ORDER)
         actions = _ordered_unique(actions, ACTION_ORDER)
-        if 'identifier_collision' in issues:
-            actions = ['resolve_identifier_collision']
-        elif 'duplicate_locations' in issues:
-            actions = ['resolve_duplicate_locations']
         result['issues'] = issues
         result['recommended_actions'] = actions
         result['status'] = _status_for_issues(issues)
-        result['error'] = '; '.join(errors) if errors else None
+        result['error'] = '; '.join(_ordered_unique(errors, ())) or None
+        result['auto_applicable_actions'] = self._auto_applicable_actions(
+            result)
         return result
 
     @staticmethod
-    def _safe_to_apply(result):
-        return (
-            result['eligible']
-            and result['error'] is None
-            and 'identifier_collision' not in result['issues']
-            and 'duplicate_locations' not in result['issues']
-            and bool(
-                set(result['recommended_actions'])
-                & (ARCHIVE_ACTIONS | LOCATION_ACTIONS)
-            )
-        )
+    def _auto_applicable_actions(result):
+        blocking_issues = {
+            'work_not_found',
+            'thoth_work_lookup_failed',
+            'pdf_source_unavailable',
+            'json_export_unavailable',
+            'malformed_metadata',
+            'archive_request_failed',
+            'identifier_collision',
+            'thoth_location_lookup_failed',
+            'duplicate_locations',
+        }
+        if (not result['eligible'] or result['error'] is not None
+                or blocking_issues.intersection(result['issues'])):
+            return []
+        return _ordered_unique([
+            action for action in result['recommended_actions']
+            if action in ARCHIVE_ACTIONS | LOCATION_ACTIONS
+        ], ACTION_ORDER)
 
-    def reconcile_one(self, work_id, apply=False, credentials=None):
-        before, context = self.inspect_work(work_id)
+    @staticmethod
+    def _safe_to_apply(result):
+        return bool(result['auto_applicable_actions'])
+
+    def reconcile_one(
+            self, work_id, apply=False, credentials=None, selection=None):
+        before, context = self.inspect_work(work_id, selection=selection)
         if not apply or not self._safe_to_apply(before):
             return before
 
+        attempted_actions = []
         applied_actions = []
+        uncertain_actions = []
+
+        def record_progress(action, state):
+            if state == 'attempted':
+                attempted_actions.append(action)
+            elif state == 'completed':
+                applied_actions.append(action)
+
         try:
             archive_actions = [
-                action for action in before['recommended_actions']
+                action for action in before['auto_applicable_actions']
                 if action in ARCHIVE_ACTIONS
             ]
             if archive_actions:
@@ -579,39 +757,78 @@ class InternetArchiveReconciler:
                     inspection=context['archive_inspection'],
                     access_key=credentials['ia_s3_access'],
                     secret_key=credentials['ia_s3_secret'],
+                    progress=record_progress,
                 )
-                applied_actions.extend(archive_actions)
+                # Preserve compatibility with test doubles or alternate
+                # uploaders that return success without progress callbacks.
+                for action in archive_actions:
+                    if action not in attempted_actions:
+                        attempted_actions.append(action)
+                    if action not in applied_actions:
+                        applied_actions.append(action)
 
             location_actions = [
-                action for action in before['recommended_actions']
+                action for action in before['auto_applicable_actions']
                 if action in LOCATION_ACTIONS
             ]
             if location_actions:
-                upsert_location(self.thoth, context['location_input'])
-                applied_actions.extend(location_actions)
+                location_result = upsert_location(
+                    self.thoth,
+                    context['location_input'],
+                    progress=record_progress,
+                )
+                # A successful alternate implementation without progress
+                # callbacks still indicates a mutation when it returns an ID.
+                if location_result is not None:
+                    for action in location_actions:
+                        if action not in attempted_actions:
+                            attempted_actions.append(action)
+                        if action not in applied_actions:
+                            applied_actions.append(action)
         except InternetArchiveVerificationError as error:
+            uncertain_actions = [
+                action for action in applied_actions
+                if action in ARCHIVE_ACTIONS
+            ]
+            applied_actions = [
+                action for action in applied_actions
+                if action not in uncertain_actions
+            ]
             return self._failed_apply_result(
-                before, applied_actions, 'verification_failed', str(error))
+                before, attempted_actions, applied_actions,
+                uncertain_actions, 'verification_failed', str(error))
         except DisseminationError as error:
             return self._failed_apply_result(
-                before, applied_actions, 'archive_mutation_failed', str(error))
+                before, attempted_actions, applied_actions,
+                uncertain_actions, 'archive_mutation_failed', str(error))
         except Exception as error:
+            selected_location_actions = [
+                action for action in before['auto_applicable_actions']
+                if action in LOCATION_ACTIONS
+            ]
+            if selected_location_actions and not any(
+                    action in attempted_actions
+                    for action in selected_location_actions):
+                attempted_actions.extend(selected_location_actions)
             issue = (
                 'thoth_location_mutation_failed'
                 if any(
                     action in LOCATION_ACTIONS
-                    for action in before['recommended_actions'])
-                and all(action in applied_actions for action in archive_actions)
+                    for action in attempted_actions)
                 else 'archive_mutation_failed'
             )
             return self._failed_apply_result(
-                before, applied_actions, issue, str(error))
+                before, attempted_actions, applied_actions,
+                uncertain_actions, issue, str(error))
 
         verification_base = deepcopy(before)
         verification_base.update({
             'issues': [],
             'recommended_actions': [],
+            'auto_applicable_actions': [],
+            'attempted_actions': [],
             'applied_actions': [],
+            'uncertain_actions': [],
             'internet_archive': None,
             'thoth_location': None,
             'error': None,
@@ -627,8 +844,12 @@ class InternetArchiveReconciler:
             verification_context,
         )
         final['before'] = before
+        final['attempted_actions'] = _ordered_unique(
+            attempted_actions, ACTION_ORDER)
         final['applied_actions'] = _ordered_unique(
             applied_actions, ACTION_ORDER)
+        final['uncertain_actions'] = _ordered_unique(
+            uncertain_actions, ACTION_ORDER)
         if final['status'] != 'current':
             final['issues'] = _ordered_unique(
                 final['issues'] + ['verification_failed'], ISSUE_ORDER)
@@ -641,14 +862,20 @@ class InternetArchiveReconciler:
         return final
 
     @staticmethod
-    def _failed_apply_result(before, applied_actions, issue, error):
+    def _failed_apply_result(
+            before, attempted_actions, applied_actions, uncertain_actions,
+            issue, error):
         result = deepcopy(before)
         result['before'] = before
         result['issues'] = _ordered_unique(
             result['issues'] + [issue], ISSUE_ORDER)
         result['status'] = 'error'
+        result['attempted_actions'] = _ordered_unique(
+            attempted_actions, ACTION_ORDER)
         result['applied_actions'] = _ordered_unique(
             applied_actions, ACTION_ORDER)
+        result['uncertain_actions'] = _ordered_unique(
+            uncertain_actions, ACTION_ORDER)
         result['error'] = error
         return result
 
@@ -658,9 +885,16 @@ class InternetArchiveReconciler:
             logging.info('Inspecting Internet Archive state for %s', work_id)
             try:
                 result = self.reconcile_one(
-                    work_id, apply=apply, credentials=credentials)
+                    work_id,
+                    apply=apply,
+                    credentials=credentials,
+                    selection=self.selection_by_work_id.get(work_id),
+                )
             except Exception as error:
                 result = _base_result(work_id)
+                selection = self.selection_by_work_id.get(work_id)
+                if selection is not None:
+                    result['selection'] = selection
                 result.update({
                     'status': 'error',
                     'issues': ['thoth_work_lookup_failed'],
@@ -690,16 +924,15 @@ def summarise(results):
         'repairable': sum(
             result['eligible']
             and result['status'] not in ambiguous_statuses | failed_statuses
-            and bool(
-                set(result['recommended_actions'])
-                & (ARCHIVE_ACTIONS | LOCATION_ACTIONS)
-            )
+            and bool(result['auto_applicable_actions'])
             for result in results
         ),
         'ambiguous': sum(
-            result['status'] in ambiguous_statuses for result in results),
+            result['eligible'] and result['status'] in ambiguous_statuses
+            for result in results),
         'failed': sum(
-            result['status'] in failed_statuses for result in results),
+            not result['eligible'] or result['status'] in failed_statuses
+            for result in results),
         'repaired': sum(
             result['status'] == 'current' and bool(result['applied_actions'])
             for result in results

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -69,6 +69,7 @@ ISSUE_ORDER = (
     'missing_json_original',
     'stale_pdf_original',
     'stale_json_original',
+    'archive_collection_membership_conflict',
     'archive_immutable_metadata_conflict',
     'archive_metadata_stale',
     'thoth_location_lookup_failed',
@@ -82,6 +83,7 @@ ISSUE_ORDER = (
 
 ACTION_ORDER = (
     'resolve_identifier_collision',
+    'resolve_archive_collection_membership',
     'resolve_archive_immutable_metadata',
     'restore_pdf_source',
     'restore_json_export',
@@ -128,6 +130,7 @@ ISSUE_STATUS = {
     'missing_json_original': 'item_incomplete',
     'stale_pdf_original': 'files_stale',
     'stale_json_original': 'files_stale',
+    'archive_collection_membership_conflict': 'metadata_conflict',
     'archive_immutable_metadata_conflict': 'metadata_conflict',
     'archive_metadata_stale': 'metadata_stale',
     'thoth_location_lookup_failed': 'error',
@@ -272,6 +275,13 @@ def _archive_report(item, desired, inspection):
             'current': inspection['metadata_current'],
             'problems': inspection['metadata_problems'],
             'mutable_problems': inspection['mutable_metadata_problems'],
+            'initial_only_problems': inspection[
+                'initial_only_metadata_problems'],
+            'admin_only_problems': inspection[
+                'admin_only_metadata_problems'],
+            'restricted_problems': inspection[
+                'restricted_metadata_problems'],
+            # Compatibility for existing report consumers.
             'immutable_problems': inspection[
                 'immutable_metadata_problems'],
             'patch_fields': sorted(inspection['metadata_patch']),
@@ -718,6 +728,10 @@ class InternetArchiveReconciler:
                 if inspection['immutable_metadata_problems']:
                     issues.append('archive_immutable_metadata_conflict')
                     actions.append('resolve_archive_immutable_metadata')
+                if inspection['admin_only_metadata_problems']:
+                    issues.append('archive_collection_membership_conflict')
+                    actions.append(
+                        'resolve_archive_collection_membership')
                 if inspection['mutable_metadata_problems']:
                     issues.append('archive_metadata_stale')
                     actions.append('update_archive_metadata')
@@ -769,6 +783,7 @@ class InternetArchiveReconciler:
             'malformed_metadata',
             'archive_request_failed',
             'identifier_collision',
+            'archive_collection_membership_conflict',
             'archive_immutable_metadata_conflict',
             'thoth_location_lookup_failed',
             'duplicate_locations',

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -69,6 +69,7 @@ ISSUE_ORDER = (
     'missing_json_original',
     'stale_pdf_original',
     'stale_json_original',
+    'archive_immutable_metadata_conflict',
     'archive_metadata_stale',
     'thoth_location_lookup_failed',
     'location_missing',
@@ -81,6 +82,7 @@ ISSUE_ORDER = (
 
 ACTION_ORDER = (
     'resolve_identifier_collision',
+    'resolve_archive_immutable_metadata',
     'restore_pdf_source',
     'restore_json_export',
     'fix_work_eligibility',
@@ -95,6 +97,7 @@ ACTION_ORDER = (
 
 STATUS_ORDER = (
     'identifier_collision',
+    'metadata_conflict',
     'error',
     'source_unavailable',
     'duplicate_locations',
@@ -125,6 +128,7 @@ ISSUE_STATUS = {
     'missing_json_original': 'item_incomplete',
     'stale_pdf_original': 'files_stale',
     'stale_json_original': 'files_stale',
+    'archive_immutable_metadata_conflict': 'metadata_conflict',
     'archive_metadata_stale': 'metadata_stale',
     'thoth_location_lookup_failed': 'error',
     'location_missing': 'location_missing',
@@ -267,6 +271,9 @@ def _archive_report(item, desired, inspection):
         'metadata': {
             'current': inspection['metadata_current'],
             'problems': inspection['metadata_problems'],
+            'mutable_problems': inspection['mutable_metadata_problems'],
+            'immutable_problems': inspection[
+                'immutable_metadata_problems'],
             'patch_fields': sorted(inspection['metadata_patch']),
         },
         'unrelated': {
@@ -665,7 +672,10 @@ class InternetArchiveReconciler:
                     elif not state['current']:
                         issues.append(stale_issue)
                         actions.append(action)
-                if not inspection['metadata_current']:
+                if inspection['immutable_metadata_problems']:
+                    issues.append('archive_immutable_metadata_conflict')
+                    actions.append('resolve_archive_immutable_metadata')
+                if inspection['mutable_metadata_problems']:
                     issues.append('archive_metadata_stale')
                     actions.append('update_archive_metadata')
         except Exception as error:
@@ -716,6 +726,7 @@ class InternetArchiveReconciler:
             'malformed_metadata',
             'archive_request_failed',
             'identifier_collision',
+            'archive_immutable_metadata_conflict',
             'thoth_location_lookup_failed',
             'duplicate_locations',
         }
@@ -910,7 +921,11 @@ def validate_apply_credentials(environment=None):
 
 
 def summarise(results):
-    ambiguous_statuses = {'identifier_collision', 'duplicate_locations'}
+    ambiguous_statuses = {
+        'identifier_collision',
+        'metadata_conflict',
+        'duplicate_locations',
+    }
     failed_statuses = {'error', 'source_unavailable', 'ineligible'}
     return {
         'inspected': len(results),

--- a/reconcile_internet_archive.py
+++ b/reconcile_internet_archive.py
@@ -747,11 +747,16 @@ class InternetArchiveReconciler:
             elif state == 'completed':
                 applied_actions.append(action)
 
+        archive_actions = [
+            action for action in before['auto_applicable_actions']
+            if action in ARCHIVE_ACTIONS
+        ]
+        location_actions = [
+            action for action in before['auto_applicable_actions']
+            if action in LOCATION_ACTIONS
+        ]
+
         try:
-            archive_actions = [
-                action for action in before['auto_applicable_actions']
-                if action in ARCHIVE_ACTIONS
-            ]
             if archive_actions:
                 context['uploader'].apply_archive_repairs(
                     context['item'],
@@ -768,25 +773,6 @@ class InternetArchiveReconciler:
                         attempted_actions.append(action)
                     if action not in applied_actions:
                         applied_actions.append(action)
-
-            location_actions = [
-                action for action in before['auto_applicable_actions']
-                if action in LOCATION_ACTIONS
-            ]
-            if location_actions:
-                location_result = upsert_location(
-                    self.thoth,
-                    context['location_input'],
-                    progress=record_progress,
-                )
-                # A successful alternate implementation without progress
-                # callbacks still indicates a mutation when it returns an ID.
-                if location_result is not None:
-                    for action in location_actions:
-                        if action not in attempted_actions:
-                            attempted_actions.append(action)
-                        if action not in applied_actions:
-                            applied_actions.append(action)
         except InternetArchiveVerificationError as error:
             uncertain_actions = [
                 action for action in applied_actions
@@ -804,24 +790,30 @@ class InternetArchiveReconciler:
                 before, attempted_actions, applied_actions,
                 uncertain_actions, 'archive_mutation_failed', str(error))
         except Exception as error:
-            selected_location_actions = [
-                action for action in before['auto_applicable_actions']
-                if action in LOCATION_ACTIONS
-            ]
-            if selected_location_actions and not any(
-                    action in attempted_actions
-                    for action in selected_location_actions):
-                attempted_actions.extend(selected_location_actions)
-            issue = (
-                'thoth_location_mutation_failed'
-                if any(
-                    action in LOCATION_ACTIONS
-                    for action in attempted_actions)
-                else 'archive_mutation_failed'
-            )
             return self._failed_apply_result(
                 before, attempted_actions, applied_actions,
-                uncertain_actions, issue, str(error))
+                uncertain_actions, 'archive_mutation_failed', str(error))
+
+        try:
+            if location_actions:
+                location_result = upsert_location(
+                    self.thoth,
+                    context['location_input'],
+                    progress=record_progress,
+                )
+                # A successful alternate implementation without progress
+                # callbacks still indicates a mutation when it returns an ID.
+                if location_result is not None:
+                    for action in location_actions:
+                        if action not in attempted_actions:
+                            attempted_actions.append(action)
+                        if action not in applied_actions:
+                            applied_actions.append(action)
+        except Exception as error:
+            return self._failed_apply_result(
+                before, attempted_actions, applied_actions,
+                uncertain_actions, 'thoth_location_mutation_failed',
+                str(error))
 
         verification_base = deepcopy(before)
         verification_base.update({

--- a/tests/test_ia_bulk_disseminate_workflow.py
+++ b/tests/test_ia_bulk_disseminate_workflow.py
@@ -1,0 +1,393 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / '.github' / 'workflows' / 'ia_bulk_disseminate.yml'
+DISSEMINATE = ROOT / '.github' / 'workflows' / 'disseminate.yml'
+HELPER = ROOT / '.github' / 'scripts' / 'ia_selection_workflow.py'
+WORK_ID = '11111111-1111-4111-8111-111111111111'
+
+
+def load_yaml(path):
+    """Parse workflow YAML semantically using Ruby's standard YAML parser."""
+    program = (
+        'data=YAML.safe_load(File.read(ARGV[0]), aliases: true);'
+        'data["on"]=data.delete(true) if data.key?(true);'
+        'puts JSON.generate(data)'
+    )
+    result = subprocess.run(
+        ['ruby', '-rjson', '-ryaml', '-e', program, str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+class TestIABulkDisseminateWorkflow(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = load_yaml(WORKFLOW)
+        cls.disseminate = load_yaml(DISSEMINATE)
+
+    def test_daily_schedule_replaces_old_monthly_schedule(self):
+        schedules = self.workflow['on']['schedule']
+        self.assertEqual(schedules, [{'cron': '40 4 * * *'}])
+        self.assertNotIn('40 4 7 * *', [
+            schedule['cron'] for schedule in schedules])
+
+    def test_manual_defaults_are_bounded(self):
+        inputs = self.workflow['on']['workflow_dispatch']['inputs']
+        self.assertEqual(inputs['lookback_hours']['default'], 30)
+        self.assertEqual(inputs['max_works']['default'], 200)
+        self.assertEqual(inputs['max_works']['type'], 'number')
+
+    def test_dedicated_workflow_does_not_call_generic_bulk(self):
+        uses = [
+            job.get('uses') for job in self.workflow['jobs'].values()
+            if isinstance(job, dict)
+        ]
+        self.assertNotIn(
+            './.github/workflows/bulk_disseminate.yml', uses)
+        self.assertIn('./.github/workflows/disseminate.yml', uses)
+
+    def test_workflow_concurrency_queues_runs(self):
+        self.assertEqual(self.workflow['concurrency'], {
+            'group': 'internet-archive-scheduled-dissemination',
+            'cancel-in-progress': False,
+        })
+
+    def test_selection_job_is_read_only_and_has_no_environment(self):
+        select = self.workflow['jobs']['select']
+        self.assertNotIn('environment', select)
+        self.assertEqual(select['permissions'], {'contents': 'read'})
+
+    def test_selection_job_uses_required_runtime(self):
+        steps = self.workflow['jobs']['select']['steps']
+        self.assertEqual(steps[0]['uses'], 'actions/checkout@v6')
+        setup = next(
+            step for step in steps
+            if step.get('uses') == 'actions/setup-python@v6')
+        self.assertEqual(setup['with']['python-version'], '3.12')
+        install = next(
+            step for step in steps
+            if step.get('name') == 'Install selection dependencies')
+        self.assertIn('requirements_obtain_new_ids.txt', install['run'])
+
+    def test_selection_step_passes_only_publisher_and_exception_variables(self):
+        step = next(
+            step for step in self.workflow['jobs']['select']['steps']
+            if step.get('name') == 'Select recently updated eligible works')
+        self.assertEqual(set(step['env']), {
+            'ENV_PUBLISHERS', 'ENV_EXCEPTIONS'})
+        serialised = json.dumps(step)
+        for credential in (
+                'THOTH_PAT', 'IA_S3_ACCESS', 'IA_S3_SECRET',
+                'ia_s3_access', 'ia_s3_secret'):
+            self.assertNotIn(credential, serialised)
+
+    def test_selection_command_uses_bounded_inputs_and_report(self):
+        step = next(
+            step for step in self.workflow['jobs']['select']['steps']
+            if step.get('name') == 'Select recently updated eligible works')
+        command = step['run']
+        self.assertIn('--lookback-hours', command)
+        self.assertIn('lookback_hours="${{ inputs.lookback_hours }}"', command)
+        self.assertIn('lookback_hours=30', command)
+        self.assertIn('--max-ids', command)
+        self.assertIn('max_works="${{ inputs.max_works }}"', command)
+        self.assertIn('max_works=200', command)
+        self.assertIn('--report internet-archive-selection.json', command)
+
+    def test_selection_artifact_is_always_uploaded_for_30_days(self):
+        step = next(
+            step for step in self.workflow['jobs']['select']['steps']
+            if step.get('uses') == 'actions/upload-artifact@v7')
+        self.assertEqual(step['if'], '${{ always() }}')
+        self.assertEqual(step['with']['retention-days'], 30)
+        self.assertEqual(step['with']['if-no-files-found'], 'warn')
+        self.assertIn('internet-archive-selection.json', step['with']['path'])
+        self.assertIn('internet-archive-selection.log', step['with']['path'])
+        artifact = self.workflow['jobs']['select']['env']['ARTIFACT_NAME']
+        self.assertIn('ia-selection-', artifact)
+        self.assertIn('github.run_id', artifact)
+        self.assertIn('github.run_attempt', artifact)
+
+    def test_selection_summary_always_runs(self):
+        step = next(
+            step for step in self.workflow['jobs']['select']['steps']
+            if step.get('name') == 'Write selection summary')
+        self.assertEqual(step['if'], '${{ always() }}')
+        self.assertIn(' summary', step['run'])
+
+    def test_selection_outputs_include_status_and_overflow(self):
+        outputs = self.workflow['jobs']['select']['outputs']
+        self.assertEqual(set(outputs), {
+            'work_ids', 'selected_count', 'omitted_count', 'truncated',
+            'selection_exit_status', 'artifact_name',
+        })
+
+    def test_matrix_uses_only_selected_ids_with_four_way_parallelism(self):
+        job = self.workflow['jobs']['disseminate']
+        self.assertEqual(job['strategy']['fail-fast'], False)
+        self.assertEqual(job['strategy']['max-parallel'], 4)
+        self.assertEqual(
+            job['strategy']['matrix']['work-id'],
+            '${{ fromJSON(needs.select.outputs.work_ids) }}',
+        )
+        self.assertEqual(job['with'], {
+            'platform': 'InternetArchive',
+            'work-id': '${{ matrix.work-id }}',
+        })
+
+    def test_empty_selection_skips_dissemination(self):
+        self.assertEqual(
+            self.workflow['jobs']['disseminate']['if'],
+            "${{ needs.select.outputs.selected_count != '0' }}",
+        )
+
+    def test_final_status_always_depends_on_both_upstreams(self):
+        final = self.workflow['jobs']['final-status']
+        self.assertEqual(final['if'], '${{ always() }}')
+        self.assertEqual(set(final['needs']), {'select', 'disseminate'})
+        self.assertEqual(final['permissions'], {'contents': 'read'})
+        self.assertNotIn('environment', final)
+        step = final['steps'][-1]
+        self.assertEqual(set(step['env']), {
+            'SELECTION_RESULT', 'DISSEMINATION_RESULT', 'SELECTED_COUNT',
+            'OMITTED_COUNT', 'TRUNCATED', 'ARTIFACT_NAME',
+        })
+
+    def test_reusable_dissemination_has_platform_work_concurrency(self):
+        concurrency = self.disseminate['concurrency']
+        self.assertEqual(concurrency['cancel-in-progress'], False)
+        self.assertIn('inputs.platform', concurrency['group'])
+        self.assertIn('inputs.work-id', concurrency['group'])
+
+    def test_other_platform_schedules_are_unchanged(self):
+        expected = {
+            'cr_bulk_disseminate.yml': '45 * * * *',
+            'fs_bulk_disseminate.yml': '40 4 7 * *',
+            'zn_bulk_disseminate.yml': '40 4 7 * *',
+            'cul_bulk_disseminate.yml': '40 4 7 * *',
+            'gp_bulk_disseminate.yaml': '50 5 * * *',
+            'bkci_bulk_disseminate.yaml': '40 6 6 * *',
+            'oapen_bulk_disseminate.yaml': '20 2 * * 1',
+            'eh_bulk_disseminate.yaml': '20 2 * * 2',
+            'jstor_bulk_disseminate.yaml': '20 2 * * 3',
+            'muse_bulk_disseminate.yaml': '20 2 * * 4',
+            'pq_bulk_disseminate.yaml': '20 2 * * 5',
+        }
+        for filename, cron in expected.items():
+            with self.subTest(filename=filename):
+                workflow = load_yaml(
+                    ROOT / '.github' / 'workflows' / filename)
+                self.assertEqual(
+                    workflow['on']['schedule'], [{'cron': cron}])
+
+    def test_tests_do_not_dispatch_mutation_workflows(self):
+        source = Path(__file__).read_text(encoding='utf-8')
+        self.assertNotIn('gh' + ' workflow run', source)
+        self.assertNotIn('curl ' + '-X POST', source)
+
+
+class TestIASelectionWorkflowHelper(unittest.TestCase):
+
+    def run_helper(self, *arguments, report=None, ids=None, status=0, **env):
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        workdir = Path(temporary_directory.name)
+        report_path = workdir / 'report.json'
+        ids_path = workdir / 'selected.json'
+        status_path = workdir / 'status.txt'
+        output_path = workdir / 'github-output'
+        summary_path = workdir / 'step-summary'
+        if report is not None:
+            report_path.write_text(json.dumps(report), encoding='utf-8')
+        if ids is not None:
+            ids_path.write_text(json.dumps(ids), encoding='utf-8')
+        status_path.write_text('{}\n'.format(status), encoding='utf-8')
+        environment = {
+            **os.environ,
+            'GITHUB_OUTPUT': str(output_path),
+            'GITHUB_STEP_SUMMARY': str(summary_path),
+            **env,
+        }
+        replacements = {
+            '{report}': str(report_path),
+            '{ids}': str(ids_path),
+            '{status}': str(status_path),
+        }
+        command = [
+            replacements.get(argument, argument) for argument in arguments]
+        result = subprocess.run(
+            [sys.executable, str(HELPER), *command],
+            cwd=workdir,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result, workdir
+
+    @staticmethod
+    def report(selected=None, omitted=None, truncated=False):
+        selected = selected or []
+        omitted = omitted or []
+        return {
+            'window': {
+                'start': '2026-07-21T22:40:00Z',
+                'end': '2026-07-23T04:40:00Z',
+                'lookback_hours': 30,
+            },
+            'publisher_ids': ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+            'queried_count': len(selected) + len(omitted),
+            'eligible_count': len(selected) + len(omitted),
+            'selected_count': len(selected),
+            'omitted_count': len(omitted),
+            'truncated': truncated,
+            'selected': [
+                {
+                    'work_id': work_id,
+                    'updated_at_with_relations': '2026-07-23T04:00:00Z',
+                } for work_id in selected
+            ],
+            'omitted': [
+                {
+                    'work_id': work_id,
+                    'updated_at_with_relations': '2026-07-23T04:01:00Z',
+                } for work_id in omitted
+            ],
+            'excluded_counts': {'configured_exception': 2},
+        }
+
+    def test_outputs_are_compact_and_machine_readable(self):
+        report = self.report([WORK_ID])
+        result, workdir = self.run_helper(
+            'outputs',
+            '--report', '{report}',
+            '--selected-ids', '{ids}',
+            '--status', '{status}',
+            '--artifact-name', 'ia-selection-123-1',
+            report=report,
+            ids=[WORK_ID],
+        )
+        self.assertEqual(result.returncode, 0)
+        output = (workdir / 'github-output').read_text(encoding='utf-8')
+        self.assertIn('work_ids=["{}"]\n'.format(WORK_ID), output)
+        self.assertIn('selected_count=1\n', output)
+        self.assertIn('truncated=false\n', output)
+
+    def test_selection_guard_rejects_failed_selection(self):
+        result, _workdir = self.run_helper(
+            'selection-guard',
+            '--report', '{report}',
+            '--selected-ids', '{ids}',
+            '--status', '{status}',
+            report=self.report(),
+            ids=[],
+            status=1,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('Selection failed', result.stderr)
+
+    def test_selection_guard_rejects_mismatched_report_and_stdout(self):
+        result, _workdir = self.run_helper(
+            'selection-guard',
+            '--report', '{report}',
+            '--selected-ids', '{ids}',
+            '--status', '{status}',
+            report=self.report([WORK_ID]),
+            ids=[],
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('does not match', result.stderr)
+
+    def test_summary_contains_counts_not_work_ids(self):
+        result, workdir = self.run_helper(
+            'summary',
+            '--report', '{report}',
+            '--status', '{status}',
+            '--artifact-name', 'ia-selection-123-1',
+            report=self.report([WORK_ID]),
+            ids=[WORK_ID],
+        )
+        self.assertEqual(result.returncode, 0)
+        summary = (workdir / 'step-summary').read_text(encoding='utf-8')
+        self.assertIn('- Selected works: `1`', summary)
+        self.assertIn('- `configured_exception`: 2', summary)
+        self.assertIn('ia-selection-123-1', summary)
+        self.assertNotIn(WORK_ID, summary)
+
+    def test_truncation_causes_final_guard_failure(self):
+        result, workdir = self.run_helper(
+            'final-guard',
+            SELECTION_RESULT='success',
+            DISSEMINATION_RESULT='success',
+            SELECTED_COUNT='200',
+            OMITTED_COUNT='3',
+            TRUNCATED='true',
+            ARTIFACT_NAME='ia-selection-123-1',
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('3 eligible works were omitted', result.stderr)
+        summary = (workdir / 'step-summary').read_text(encoding='utf-8')
+        self.assertIn('bounded manual reconciliation', summary)
+        self.assertIn('ia-selection-123-1', summary)
+
+    def test_selection_failure_causes_final_guard_failure(self):
+        result, _workdir = self.run_helper(
+            'final-guard',
+            SELECTION_RESULT='failure',
+            DISSEMINATION_RESULT='skipped',
+            SELECTED_COUNT='0',
+            OMITTED_COUNT='0',
+            TRUNCATED='false',
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('selection job result', result.stderr)
+
+    def test_dissemination_failure_is_not_concealed(self):
+        result, _workdir = self.run_helper(
+            'final-guard',
+            SELECTION_RESULT='success',
+            DISSEMINATION_RESULT='failure',
+            SELECTED_COUNT='2',
+            OMITTED_COUNT='0',
+            TRUNCATED='false',
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('dissemination job result', result.stderr)
+
+    def test_non_truncated_empty_selection_succeeds(self):
+        result, _workdir = self.run_helper(
+            'final-guard',
+            SELECTION_RESULT='success',
+            DISSEMINATION_RESULT='skipped',
+            SELECTED_COUNT='0',
+            OMITTED_COUNT='0',
+            TRUNCATED='false',
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_successful_nonempty_selection_succeeds(self):
+        result, _workdir = self.run_helper(
+            'final-guard',
+            SELECTION_RESULT='success',
+            DISSEMINATION_RESULT='success',
+            SELECTED_COUNT='2',
+            OMITTED_COUNT='0',
+            TRUNCATED='false',
+        )
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ia_reconcile_workflow.py
+++ b/tests/test_ia_reconcile_workflow.py
@@ -1,0 +1,196 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / ".github" / "scripts" / "ia_reconcile_workflow.py"
+WORK_ID = "11111111-2222-3333-4444-555555555555"
+WORK_ID_2 = "22222222-3333-4444-5555-666666666666"
+PUBLISHER_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+class TestIAReconcileWorkflow(unittest.TestCase):
+    def run_helper(self, *arguments, **environment):
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        workdir = Path(temporary_directory.name)
+        github_output = workdir / "github-output"
+        step_summary = workdir / "step-summary"
+        env = {
+            **os.environ,
+            "ARTIFACT_NAME": "ia-reconciliation-123-1",
+            "GITHUB_OUTPUT": str(github_output),
+            "GITHUB_REF": "refs/heads/develop",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "123",
+            "GITHUB_STEP_SUMMARY": str(step_summary),
+            "INPUT_CONFIRM_APPLY": "",
+            "INPUT_LIMIT": "100",
+            "INPUT_OFFSET": "0",
+            "INPUT_PUBLISHER_ID": "",
+            "INPUT_WORK_IDS": "",
+            **environment,
+        }
+        result = subprocess.run(
+            [sys.executable, str(HELPER), *arguments],
+            cwd=workdir,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result, workdir
+
+    def test_mixed_work_ids_are_normalised_deduplicated_and_sorted(self):
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "dry-run",
+            INPUT_WORK_IDS=f"{WORK_ID_2},\n{WORK_ID}\n{WORK_ID_2},,",
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            (workdir / "normalised-work-ids.txt").read_text().splitlines(),
+            [WORK_ID, WORK_ID_2],
+        )
+        context = json.loads(
+            (workdir / "reconciliation-run-context.json").read_text()
+        )
+        self.assertEqual(context["explicit_work_id_count"], 2)
+        self.assertEqual(context["possible_batch_size"], 2)
+        self.assertEqual(context["validation_errors"], [])
+
+    def test_no_selection_is_rejected_with_annotation_and_diagnostics(self):
+        result, workdir = self.run_helper(
+            "validate", "--mode", "dry-run"
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("title=No selection criteria", result.stdout)
+        self.assertIn(
+            "VALIDATION ERROR:",
+            (workdir / "internet-archive-reconciliation.log").read_text(),
+        )
+        self.assertTrue(
+            (workdir / "reconciliation-run-context.json").is_file()
+        )
+
+    def test_malformed_uuid_is_rejected(self):
+        result, _ = self.run_helper(
+            "validate",
+            "--mode",
+            "dry-run",
+            INPUT_WORK_IDS="not-a-uuid",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("title=Malformed UUID", result.stdout)
+
+    def test_invalid_limit_and_offset_are_rejected(self):
+        cases = (
+            ({"INPUT_LIMIT": "0", "INPUT_WORK_IDS": WORK_ID}, "Invalid limit"),
+            (
+                {"INPUT_OFFSET": "-1", "INPUT_WORK_IDS": WORK_ID},
+                "Invalid offset",
+            ),
+        )
+        for environment, annotation_title in cases:
+            with self.subTest(annotation_title=annotation_title):
+                result, _ = self.run_helper(
+                    "validate", "--mode", "dry-run", **environment
+                )
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(
+                    f"title={annotation_title}", result.stdout
+                )
+
+    def test_combined_publisher_batch_over_200_is_rejected(self):
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "dry-run",
+            INPUT_LIMIT="200",
+            INPUT_PUBLISHER_ID=PUBLISHER_ID,
+            INPUT_WORK_IDS=WORK_ID,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("title=Combined batch exceeds 200", result.stdout)
+        context = json.loads(
+            (workdir / "reconciliation-run-context.json").read_text()
+        )
+        self.assertEqual(context["possible_batch_size"], 201)
+
+    def test_apply_requires_confirmation_and_develop_ref(self):
+        result, _ = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_WORK_IDS=WORK_ID,
+            GITHUB_REF="refs/heads/feature/make-ia-idempotent",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("title=Missing apply confirmation", result.stdout)
+        self.assertIn("title=Apply ref restriction", result.stdout)
+
+    def test_apply_summary_counts_actions_without_per_work_details(self):
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_CONFIRM_APPLY="APPLY",
+            INPUT_WORK_IDS=WORK_ID,
+        )
+        self.assertEqual(result.returncode, 0)
+        report = {
+            "results": [{
+                "work_id": WORK_ID,
+                "attempted_actions": ["upload_pdf_original", "update_metadata"],
+                "applied_actions": ["upload_pdf_original"],
+                "uncertain_actions": ["update_metadata"],
+            }],
+            "summary": {
+                "inspected": 1,
+                "current": 0,
+                "repairable": 0,
+                "ambiguous": 0,
+                "failed": 1,
+                "repaired": 0,
+                "by_status": {"error": 1},
+            },
+        }
+        (workdir / "internet-archive-reconciliation.json").write_text(
+            json.dumps(report)
+        )
+        (workdir / "reconciliation-exit-status.txt").write_text("1\n")
+
+        summary_result = subprocess.run(
+            [sys.executable, str(HELPER), "summary"],
+            cwd=workdir,
+            env={
+                **os.environ,
+                "ARTIFACT_NAME": "ia-reconciliation-123-1",
+                "GITHUB_STEP_SUMMARY": str(workdir / "step-summary"),
+            },
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(summary_result.returncode, 0)
+        summary = (workdir / "step-summary").read_text()
+        self.assertIn("- Attempted actions: 2", summary)
+        self.assertIn("- Applied actions: 1", summary)
+        self.assertIn("- Uncertain actions: 1", summary)
+        self.assertNotIn(WORK_ID, summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -201,7 +201,7 @@ class TestIAUploader(unittest.TestCase):
         self.assertTrue(pdf_call['verify'])
         self.assertTrue(pdf_call['queue_derive'])
         self.item.modify_metadata.assert_not_called()
-        self.item.identifier_available.assert_called_once_with()
+        self.assertEqual(self.item.identifier_available.call_count, 2)
         self._assert_location(locations[0])
 
     def test_new_item_initial_upload_sets_mediatype_texts(self):
@@ -464,6 +464,79 @@ class TestIAUploader(unittest.TestCase):
         self.item.modify_metadata.assert_not_called()
         self.item.refresh.assert_not_called()
 
+    def test_apply_archive_repairs_refreshes_owned_item_before_mutation(self):
+        self._set_existing_item(files=[])
+        desired = self.uploader.build_desired_state()
+        stale_inspection = self.uploader.inspect_item(self.item, desired)
+
+        def replace_ownership(item):
+            item.metadata['thoth-work-id'] = 'another-work-id'
+
+        self.item.refresh_hook = replace_ownership
+
+        with self.assertRaisesRegex(
+                InternetArchiveIdentifierCollisionError,
+                'another-work-id'):
+            self.uploader.apply_archive_repairs(
+                self.item,
+                desired,
+                inspection=stale_inspection,
+                access_key='access-key',
+                secret_key='secret-key',
+            )
+
+        self.item.refresh.assert_called_once_with()
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+
+    def test_apply_archive_repairs_rechecks_legacy_collection_before_mutation(
+            self):
+        metadata = self._desired_metadata()
+        metadata.pop('thoth-work-id')
+        self._set_existing_item(metadata=metadata, files=[])
+        desired = self.uploader.build_desired_state()
+        stale_inspection = self.uploader.inspect_item(self.item, desired)
+
+        def remove_collection(item):
+            item.metadata['collection'] = 'unrelated-collection'
+
+        self.item.refresh_hook = remove_collection
+
+        with self.assertRaisesRegex(
+                InternetArchiveIdentifierCollisionError,
+                'not an identifiable legacy member'):
+            self.uploader.apply_archive_repairs(
+                self.item,
+                desired,
+                inspection=stale_inspection,
+                access_key='access-key',
+                secret_key='secret-key',
+            )
+
+        self.item.refresh.assert_called_once_with()
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+
+    def test_apply_archive_repairs_refresh_failure_is_non_mutating(self):
+        self._set_existing_item(files=[])
+        desired = self.uploader.build_desired_state()
+        stale_inspection = self.uploader.inspect_item(self.item, desired)
+        self.item.refresh.side_effect = HTTPError('refresh failed')
+
+        with self.assertRaisesRegex(
+                DisseminationError,
+                'refresh.*immediately before mutation'):
+            self.uploader.apply_archive_repairs(
+                self.item,
+                desired,
+                inspection=stale_inspection,
+                access_key='access-key',
+                secret_key='secret-key',
+            )
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+
     def test_correct_mediatype_with_title_drift_updates_only_title(self):
         metadata = self._desired_metadata()
         metadata['title'] = 'Old title'
@@ -709,7 +782,7 @@ class TestIAUploader(unittest.TestCase):
                     'after 3 attempts'):
                 self.uploader.upload_to_platform()
 
-        self.assertEqual(self.item.refresh.call_count, 3)
+        self.assertEqual(self.item.refresh.call_count, 4)
         self.assertEqual(self.mock_sleep.call_count, 2)
 
     def test_derived_files_do_not_satisfy_final_verification(self):
@@ -741,14 +814,14 @@ class TestIAUploader(unittest.TestCase):
             make_response()
 
         def reveal_metadata(item):
-            if item.refresh.call_count >= 2:
+            if item.refresh.call_count >= 3:
                 item.metadata = dict(desired_metadata)
 
         self.item.refresh_hook = reveal_metadata
 
         locations = self.uploader.upload_to_platform()
 
-        self.assertEqual(self.item.refresh.call_count, 2)
+        self.assertEqual(self.item.refresh.call_count, 3)
         self.mock_sleep.assert_called_once()
         self.item.modify_metadata.assert_called_once()
         self._assert_location(locations[0])
@@ -767,7 +840,7 @@ class TestIAUploader(unittest.TestCase):
         self.assertIn('metadata discrepancies', str(raised.exception))
         self.assertIn('title', str(raised.exception))
         self.assertIn('Old title', str(raised.exception))
-        self.assertEqual(self.item.refresh.call_count, 3)
+        self.assertEqual(self.item.refresh.call_count, 4)
         self.assertEqual(self.mock_sleep.call_count, 2)
 
     def test_metadata_verification_times_out_when_removed_field_remains(self):
@@ -783,7 +856,7 @@ class TestIAUploader(unittest.TestCase):
 
         self.assertIn('description', str(raised.exception))
         self.assertIn('expected it to be absent', str(raised.exception))
-        self.assertEqual(self.item.refresh.call_count, 2)
+        self.assertEqual(self.item.refresh.call_count, 3)
         self.mock_sleep.assert_called_once()
 
     def test_unrelated_metadata_does_not_prevent_verification(self):
@@ -817,11 +890,13 @@ class TestIAUploader(unittest.TestCase):
             make_response() for _ in kwargs['files']]
 
         def reveal_new_item(item):
+            if item.refresh.call_count == 1:
+                return
             item.files = [
                 original_file(PDF_NAME, self.pdf_bytes),
                 original_file(JSON_NAME, self.json_bytes),
             ]
-            if item.refresh.call_count == 1:
+            if item.refresh.call_count == 2:
                 item.metadata = {'title': 'Stale title'}
             else:
                 item.metadata = dict(desired_metadata)
@@ -832,7 +907,7 @@ class TestIAUploader(unittest.TestCase):
 
         self.assertEqual(self.mock_upload.call_count, 2)
         self.item.modify_metadata.assert_not_called()
-        self.assertEqual(self.item.refresh.call_count, 2)
+        self.assertEqual(self.item.refresh.call_count, 3)
         self.mock_sleep.assert_called_once()
         self._assert_location(locations[0])
 
@@ -870,6 +945,8 @@ class TestIAUploader(unittest.TestCase):
             if item.refresh.call_count == 1:
                 item.files = []
             elif item.refresh.call_count == 2:
+                item.files = []
+            elif item.refresh.call_count == 3:
                 item.files = [
                     original_file(PDF_NAME, b'stale PDF'),
                     original_file(JSON_NAME, self.json_bytes),
@@ -886,7 +963,7 @@ class TestIAUploader(unittest.TestCase):
 
         self.assertEqual(self.mock_upload.call_count, 2)
         self.item.modify_metadata.assert_not_called()
-        self.assertEqual(self.item.refresh.call_count, 3)
+        self.assertEqual(self.item.refresh.call_count, 4)
         self.assertEqual(self.mock_sleep.call_count, 2)
         self._assert_location(locations[0])
 

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -373,6 +373,163 @@ class TestIAUploader(unittest.TestCase):
                     'missing as an original file'):
                 self.uploader.upload_to_platform()
 
+    def test_metadata_verification_retries_until_change_is_visible(self):
+        desired_metadata = self._desired_metadata()
+        stale_metadata = dict(desired_metadata, title='Old title')
+        self._set_existing_item(metadata=stale_metadata)
+        self.item.modify_metadata.side_effect = lambda *args, **kwargs: \
+            make_response()
+
+        def reveal_metadata(item):
+            if item.refresh.call_count >= 2:
+                item.metadata = dict(desired_metadata)
+
+        self.item.refresh_hook = reveal_metadata
+
+        locations = self.uploader.upload_to_platform()
+
+        self.assertEqual(self.item.refresh.call_count, 2)
+        self.mock_sleep.assert_called_once()
+        self.item.modify_metadata.assert_called_once()
+        self._assert_location(locations[0])
+
+    def test_metadata_verification_times_out_when_change_stays_stale(self):
+        metadata = self._desired_metadata()
+        metadata['title'] = 'Old title'
+        self._set_existing_item(metadata=metadata)
+        self.item.modify_metadata.side_effect = lambda *args, **kwargs: \
+            make_response()
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 3):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader.upload_to_platform()
+
+        self.assertIn('metadata discrepancies', str(raised.exception))
+        self.assertIn('title', str(raised.exception))
+        self.assertIn('Old title', str(raised.exception))
+        self.assertEqual(self.item.refresh.call_count, 3)
+        self.assertEqual(self.mock_sleep.call_count, 2)
+
+    def test_metadata_verification_times_out_when_removed_field_remains(self):
+        metadata = self._desired_metadata()
+        self.uploader.metadata['data']['work']['longAbstract'] = None
+        self._set_existing_item(metadata=metadata)
+        self.item.modify_metadata.side_effect = lambda *args, **kwargs: \
+            make_response()
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader.upload_to_platform()
+
+        self.assertIn('description', str(raised.exception))
+        self.assertIn('expected it to be absent', str(raised.exception))
+        self.assertEqual(self.item.refresh.call_count, 2)
+        self.mock_sleep.assert_called_once()
+
+    def test_unrelated_metadata_does_not_prevent_verification(self):
+        metadata = self._desired_metadata()
+        metadata['unrelated-field'] = ['keep', 'both']
+        self._set_existing_item(metadata=metadata)
+
+        locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.item.refresh.assert_called_once()
+        self._assert_location(locations[0])
+
+    def test_unrelated_collection_memberships_do_not_prevent_verification(self):
+        metadata = self._desired_metadata()
+        metadata['collection'] = [
+            'other-collection', IAUploader.THOTH_COLLECTION]
+        self._set_existing_item(metadata=metadata)
+
+        locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.item.refresh.assert_called_once()
+        self._assert_location(locations[0])
+
+    def test_new_item_waits_for_files_and_metadata_to_become_visible(self):
+        desired_metadata = self._desired_metadata()
+        self.mock_upload.side_effect = lambda **kwargs: [
+            make_response() for _ in kwargs['files']]
+
+        def reveal_new_item(item):
+            item.files = [
+                original_file(PDF_NAME, self.pdf_bytes),
+                original_file(JSON_NAME, self.json_bytes),
+            ]
+            if item.refresh.call_count == 1:
+                item.metadata = {'title': 'Stale title'}
+            else:
+                item.metadata = dict(desired_metadata)
+
+        self.item.refresh_hook = reveal_new_item
+
+        locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_called_once()
+        self.item.modify_metadata.assert_not_called()
+        self.assertEqual(self.item.refresh.call_count, 2)
+        self.mock_sleep.assert_called_once()
+        self._assert_location(locations[0])
+
+    def test_second_run_is_read_only_after_eventual_metadata_update(self):
+        desired_metadata = self._desired_metadata()
+        stale_metadata = dict(desired_metadata, title='Old title')
+        self._set_existing_item(metadata=stale_metadata)
+        self.item.modify_metadata.side_effect = lambda *args, **kwargs: \
+            make_response()
+
+        def reveal_metadata(item):
+            if item.refresh.call_count >= 2:
+                item.metadata = dict(desired_metadata)
+
+        self.item.refresh_hook = reveal_metadata
+
+        first_locations = self.uploader.upload_to_platform()
+        self._assert_location(first_locations[0])
+        self.assertEqual(self.item.refresh.call_count, 2)
+        self.mock_upload.reset_mock()
+        self.item.modify_metadata.reset_mock()
+
+        second_locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self._assert_location(second_locations[0])
+
+    def test_file_verification_retries_until_originals_are_visible(self):
+        self._set_existing_item(files=[])
+        self.mock_upload.side_effect = lambda **kwargs: [
+            make_response() for _ in kwargs['files']]
+
+        def reveal_files(item):
+            if item.refresh.call_count == 1:
+                item.files = []
+            elif item.refresh.call_count == 2:
+                item.files = [
+                    original_file(PDF_NAME, b'stale PDF'),
+                    original_file(JSON_NAME, self.json_bytes),
+                ]
+            else:
+                item.files = [
+                    original_file(PDF_NAME, self.pdf_bytes),
+                    original_file(JSON_NAME, self.json_bytes),
+                ]
+
+        self.item.refresh_hook = reveal_files
+
+        locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_called_once()
+        self.item.modify_metadata.assert_not_called()
+        self.assertEqual(self.item.refresh.call_count, 3)
+        self.assertEqual(self.mock_sleep.call_count, 2)
+        self._assert_location(locations[0])
+
     def test_checksum_skipped_empty_response_is_not_a_failure(self):
         self._set_existing_item(files=[
             original_file(PDF_NAME, b'old PDF'),

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -1,0 +1,515 @@
+import hashlib
+import importlib
+import json
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from requests import Response
+from requests.exceptions import HTTPError
+
+from errors import (
+    DisseminationError,
+    InternetArchiveIdentifierCollisionError,
+    InternetArchiveVerificationError,
+)
+from iauploader import IAUploader
+from uploader import Publication
+
+
+WORK_ID = '11111111-2222-3333-4444-555555555555'
+PDF_NAME = '{}.pdf'.format(WORK_ID)
+JSON_NAME = '{}.json'.format(WORK_ID)
+
+
+def make_response(status_code=200, body=None):
+    response = Response()
+    response.status_code = status_code
+    response._content = json.dumps(
+        body if body is not None else {'success': True}
+    ).encode('utf-8')
+    response.encoding = 'utf-8'
+    return response
+
+
+def original_file(name, contents):
+    return {
+        'name': name,
+        'source': 'original',
+        'md5': hashlib.md5(contents).hexdigest(),
+    }
+
+
+class FakeItem:
+    def __init__(self, identifier, exists, metadata=None, files=None):
+        self.identifier = identifier
+        self.exists = exists
+        self.metadata = dict(metadata or {})
+        self.files = list(files or [])
+        self.refresh = MagicMock(side_effect=self._refresh)
+        self.modify_metadata = MagicMock(side_effect=self._modify_metadata)
+        self.refresh_hook = None
+
+    def _refresh(self):
+        if self.refresh_hook is not None:
+            self.refresh_hook(self)
+
+    def _modify_metadata(self, metadata, **kwargs):
+        for key, value in metadata.items():
+            if value == 'REMOVE_TAG':
+                self.metadata.pop(key, None)
+            else:
+                self.metadata[key] = value
+        return make_response()
+
+    def set_original(self, name, contents):
+        self.files = [
+            file_metadata for file_metadata in self.files
+            if file_metadata.get('name') != name
+        ]
+        self.files.append(original_file(name, contents))
+
+
+class TestIAUploader(unittest.TestCase):
+    def setUp(self):
+        self.get_item_patcher = patch('iauploader.get_item')
+        self.upload_patcher = patch('iauploader.upload')
+        self.sleep_patcher = patch('iauploader.sleep')
+        self.mock_get_item = self.get_item_patcher.start()
+        self.mock_upload = self.upload_patcher.start()
+        self.mock_sleep = self.sleep_patcher.start()
+        self.addCleanup(self.get_item_patcher.stop)
+        self.addCleanup(self.upload_patcher.stop)
+        self.addCleanup(self.sleep_patcher.stop)
+
+        self.pdf_bytes = b'current PDF bytes'
+        self.json_bytes = b'{"current":"metadata"}'
+        self.uploader = IAUploader.__new__(IAUploader)
+        self.uploader.work_id = WORK_ID
+        self.uploader.export_url = 'https://export.example'
+        self.uploader.version = '1.4.1'
+        self.uploader.metadata = {
+            'data': {
+                'work': {
+                    'fullTitle': 'A Test Book',
+                    'publicationDate': '2026-01-02',
+                    'longAbstract': 'A long description',
+                    'pageCount': 250,
+                    'lccn': '2026000001',
+                    'license': 'https://creativecommons.org/licenses/by/4.0/',
+                    'oclc': '12345',
+                    'doi': 'https://doi.org/10.0000/test',
+                    'contributions': [
+                        {'fullName': 'First Author', 'mainContribution': True},
+                        {'fullName': 'Editor', 'mainContribution': False},
+                    ],
+                    'publications': [
+                        {
+                            'publicationType': 'PDF',
+                            'publicationId': 'publication-id',
+                            'isbn': '978-1-234-56789-0',
+                        },
+                    ],
+                    'subjects': [{'subjectCode': 'ABC123'}],
+                    'languages': [{'languageCode': 'eng'}],
+                    'issues': [{
+                        'issueOrdinal': 2,
+                        'series': {
+                            'issnPrint': '1234-5678',
+                            'issnDigital': None,
+                        },
+                    }],
+                    'imprint': {
+                        'publisher': {
+                            'publisherName': 'Test Publisher',
+                        },
+                    },
+                },
+            },
+        }
+        self.uploader.get_variable_from_env = MagicMock(
+            side_effect=lambda name, platform: {
+                'ia_s3_access': 'access-key',
+                'ia_s3_secret': 'secret-key',
+            }[name]
+        )
+        self.uploader.get_formatted_metadata = MagicMock(
+            return_value=self.json_bytes)
+        self.uploader.get_publication_details = MagicMock(
+            return_value=Publication(
+                'PDF', 'publication-id', self.pdf_bytes, '.pdf'))
+
+        self.item = FakeItem(WORK_ID, False)
+        self.mock_get_item.return_value = self.item
+        self.mock_upload.side_effect = self._successful_upload
+
+    def _desired_metadata(self):
+        return self.uploader.parse_metadata()
+
+    def _set_existing_item(self, metadata=None, files=None):
+        self.item.exists = True
+        self.item.metadata = dict(
+            self._desired_metadata() if metadata is None else metadata)
+        self.item.files = list(
+            [
+                original_file(PDF_NAME, self.pdf_bytes),
+                original_file(JSON_NAME, self.json_bytes),
+            ] if files is None else files)
+
+    def _successful_upload(self, **kwargs):
+        for name, file_object in kwargs['files'].items():
+            contents = file_object.read()
+            self.item.set_original(name, contents)
+        if kwargs.get('metadata') is not None:
+            self.item.metadata = dict(kwargs['metadata'])
+        self.item.exists = True
+        return [make_response() for _ in kwargs['files']]
+
+    def _assert_location(self, location):
+        self.assertEqual(location.publication_id, 'publication-id')
+        self.assertEqual(location.location_platform, 'INTERNET_ARCHIVE')
+        self.assertEqual(
+            location.landing_page,
+            'https://archive.org/details/{}'.format(WORK_ID))
+        self.assertEqual(
+            location.full_text_url,
+            'https://archive.org/download/{}/{}.pdf'.format(
+                WORK_ID, WORK_ID))
+        self.assertEqual(
+            location.checksum, hashlib.md5(self.pdf_bytes).hexdigest())
+        self.assertEqual(location.checksum_algorithm, 'MD5')
+
+    def test_new_item_creation_uploads_both_files_with_metadata(self):
+        locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_called_once()
+        call = self.mock_upload.call_args.kwargs
+        self.assertEqual(set(call['files']), {PDF_NAME, JSON_NAME})
+        self.assertEqual(call['metadata'], self._desired_metadata())
+        self.assertTrue(call['checksum'])
+        self.assertTrue(call['verify'])
+        self.assertTrue(call['queue_derive'])
+        self.item.modify_metadata.assert_not_called()
+        self._assert_location(locations[0])
+
+    def test_existing_current_item_skips_files_and_metadata(self):
+        self._set_existing_item()
+
+        locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.assertGreaterEqual(self.item.refresh.call_count, 1)
+        self._assert_location(locations[0])
+
+    def test_existing_item_with_changed_pdf_uploads_only_pdf(self):
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, b'old PDF'),
+            original_file(JSON_NAME, self.json_bytes),
+        ])
+
+        self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            set(self.mock_upload.call_args.kwargs['files']), {PDF_NAME})
+        self.assertTrue(self.mock_upload.call_args.kwargs['queue_derive'])
+        self.assertTrue(self.mock_upload.call_args.kwargs['checksum'])
+        self.assertTrue(self.mock_upload.call_args.kwargs['verify'])
+        self.assertIsNone(self.mock_upload.call_args.kwargs['metadata'])
+
+    def test_existing_item_with_changed_json_uploads_only_json(self):
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, b'old JSON'),
+        ])
+
+        self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            set(self.mock_upload.call_args.kwargs['files']), {JSON_NAME})
+
+    def test_existing_item_missing_json_uploads_only_json(self):
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+        ])
+
+        self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            set(self.mock_upload.call_args.kwargs['files']), {JSON_NAME})
+
+    def test_existing_item_missing_pdf_uploads_only_pdf(self):
+        self._set_existing_item(files=[
+            original_file(JSON_NAME, self.json_bytes),
+        ])
+
+        self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            set(self.mock_upload.call_args.kwargs['files']), {PDF_NAME})
+
+    def test_existing_item_uses_explicit_metadata_update(self):
+        metadata = self._desired_metadata()
+        metadata['title'] = 'Old title'
+        metadata['unrelated-field'] = 'keep me'
+        self._set_existing_item(metadata=metadata)
+
+        self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_called_once()
+        metadata_patch = self.item.modify_metadata.call_args.args[0]
+        self.assertEqual(metadata_patch, {'title': 'A Test Book'})
+        self.assertEqual(self.item.metadata['unrelated-field'], 'keep me')
+        self.assertFalse(
+            self.item.modify_metadata.call_args.kwargs.get('append', False))
+
+    def test_obsolete_optional_metadata_field_is_removed(self):
+        metadata = self._desired_metadata()
+        self.uploader.metadata['data']['work']['longAbstract'] = None
+        self._set_existing_item(metadata=metadata)
+
+        self.uploader.upload_to_platform()
+
+        metadata_patch = self.item.modify_metadata.call_args.args[0]
+        self.assertEqual(metadata_patch['description'], 'REMOVE_TAG')
+        self.assertNotIn('description', self.item.metadata)
+
+    def test_missing_page_count_does_not_produce_none_string(self):
+        self.uploader.metadata['data']['work']['pageCount'] = None
+
+        metadata = self.uploader.parse_metadata()
+
+        self.assertNotIn('imagecount', metadata)
+        self.assertNotIn('None', metadata.values())
+
+    @patch('iauploader.logging.warning')
+    def test_legacy_thoth_collection_item_adds_ownership_marker(
+            self, mock_warning):
+        metadata = self._desired_metadata()
+        metadata.pop('thoth-work-id')
+        self._set_existing_item(metadata=metadata)
+
+        self.uploader.upload_to_platform()
+
+        mock_warning.assert_called_once()
+        metadata_patch = self.item.modify_metadata.call_args.args[0]
+        self.assertEqual(metadata_patch['thoth-work-id'], WORK_ID)
+
+    def test_existing_item_with_matching_marker_is_accepted(self):
+        metadata = self._desired_metadata()
+        metadata.pop('collection')
+        metadata['thoth-work-id'] = [WORK_ID]
+        self._set_existing_item(metadata=metadata)
+
+        locations = self.uploader.upload_to_platform()
+
+        metadata_patch = self.item.modify_metadata.call_args.args[0]
+        self.assertEqual(
+            metadata_patch['collection'], IAUploader.THOTH_COLLECTION)
+        self.assertNotIn('thoth-work-id', metadata_patch)
+        self._assert_location(locations[0])
+
+    def test_collision_with_another_thoth_work_id_is_refused(self):
+        metadata = self._desired_metadata()
+        metadata['thoth-work-id'] = [WORK_ID, 'another-work-id']
+        self._set_existing_item(metadata=metadata)
+
+        with self.assertRaisesRegex(
+                InternetArchiveIdentifierCollisionError,
+                'another-work-id'):
+            self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.uploader.get_formatted_metadata.assert_not_called()
+
+    def test_collision_without_thoth_ownership_is_refused(self):
+        metadata = self._desired_metadata()
+        metadata.pop('thoth-work-id')
+        metadata['collection'] = 'unrelated-collection'
+        self._set_existing_item(metadata=metadata)
+
+        with self.assertRaisesRegex(
+                InternetArchiveIdentifierCollisionError,
+                'refusing to modify'):
+            self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+
+    def test_checksum_verification_timeout_is_bounded(self):
+        self._set_existing_item(files=[])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 3):
+            with self.assertRaisesRegex(
+                    InternetArchiveVerificationError,
+                    'after 3 attempts'):
+                self.uploader.upload_to_platform()
+
+        self.assertEqual(self.item.refresh.call_count, 3)
+        self.assertEqual(self.mock_sleep.call_count, 2)
+
+    def test_derived_files_do_not_satisfy_final_verification(self):
+        self._set_existing_item(files=[
+            {
+                'name': PDF_NAME,
+                'source': 'derivative',
+                'md5': hashlib.md5(self.pdf_bytes).hexdigest(),
+            },
+            {
+                'name': JSON_NAME,
+                'source': 'derivative',
+                'md5': hashlib.md5(self.json_bytes).hexdigest(),
+            },
+        ])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 1):
+            with self.assertRaisesRegex(
+                    InternetArchiveVerificationError,
+                    'missing as an original file'):
+                self.uploader.upload_to_platform()
+
+    def test_checksum_skipped_empty_response_is_not_a_failure(self):
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, b'old PDF'),
+            original_file(JSON_NAME, self.json_bytes),
+        ])
+
+        def skipped_after_race(**kwargs):
+            for name, file_object in kwargs['files'].items():
+                self.item.set_original(name, file_object.read())
+            return [Response()]
+
+        self.mock_upload.side_effect = skipped_after_race
+
+        locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_called_once()
+        self._assert_location(locations[0])
+
+    def test_second_identical_run_makes_no_mutating_api_calls(self):
+        first_locations = self.uploader.upload_to_platform()
+        self._assert_location(first_locations[0])
+        self.mock_upload.reset_mock()
+        self.item.modify_metadata.reset_mock()
+
+        second_locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self._assert_location(second_locations[0])
+
+    def test_partial_upload_failure_is_repaired_on_next_run(self):
+        def fail_after_pdf(**kwargs):
+            file_object = kwargs['files'][PDF_NAME]
+            self.item.set_original(PDF_NAME, file_object.read())
+            self.item.metadata = dict(kwargs['metadata'])
+            self.item.exists = True
+            raise HTTPError('simulated JSON upload failure')
+
+        self.mock_upload.side_effect = fail_after_pdf
+        with self.assertRaisesRegex(
+                DisseminationError, 'simulated JSON upload failure'):
+            self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            {file_metadata['name'] for file_metadata in self.item.files},
+            {PDF_NAME})
+        self.mock_upload.reset_mock()
+        self.mock_upload.side_effect = self._successful_upload
+
+        locations = self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            set(self.mock_upload.call_args.kwargs['files']), {JSON_NAME})
+        self._assert_location(locations[0])
+
+    def test_repeatable_values_remain_lists_and_other_collections_are_kept(self):
+        metadata = self._desired_metadata()
+        metadata['creator'] = 'Old Author'
+        metadata['collection'] = ['other-collection', 'thoth-archiving-network']
+        self._set_existing_item(metadata=metadata)
+
+        self.uploader.upload_to_platform()
+
+        metadata_patch = self.item.modify_metadata.call_args.args[0]
+        self.assertEqual(metadata_patch['creator'], ['First Author'])
+        self.assertEqual(
+            self.item.metadata['collection'],
+            ['other-collection', 'thoth-archiving-network'])
+
+    def test_matching_marker_adds_thoth_collection_without_removing_other_one(self):
+        metadata = self._desired_metadata()
+        metadata['collection'] = 'other-collection'
+        self._set_existing_item(metadata=metadata)
+
+        self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            self.item.modify_metadata.call_args.args[0]['collection'],
+            ['other-collection', 'thoth-archiving-network'])
+
+
+class TestDisseminatorCLI(unittest.TestCase):
+    def test_main_returns_success_or_converts_uploader_error_to_failure(self):
+        modules = {
+            'oapensworduploader': 'OAPENSWORDUploader',
+            'souploader': 'SOUploader',
+            'culuploader': 'CULUploader',
+            'crossrefuploader': 'CrossrefUploader',
+            'fsuploader': 'FigshareUploader',
+            'zenodouploader': 'ZenodoUploader',
+            'museuploader': 'MUSEUploader',
+            'jstoruploader': 'JSTORUploader',
+            'ebscouploader': 'EBSCOUploader',
+            'proquestuploader': 'ProquestUploader',
+            'googleplayuploader': 'GooglePlayUploader',
+            'bkciuploader': 'BKCIUploader',
+        }
+        stub_modules = {}
+        for module_name, class_name in modules.items():
+            module = ModuleType(module_name)
+            setattr(module, class_name, type(class_name, (), {}))
+            stub_modules[module_name] = module
+        dotenv = ModuleType('dotenv')
+        dotenv.load_dotenv = MagicMock()
+        stub_modules['dotenv'] = dotenv
+
+        sys.modules.pop('disseminator', None)
+        self.addCleanup(lambda: sys.modules.pop('disseminator', None))
+        with patch.dict(sys.modules, stub_modules):
+            disseminator = importlib.import_module('disseminator')
+
+        arguments = SimpleNamespace(
+            work_id=WORK_ID,
+            platform='InternetArchive',
+            export_url='https://export.example',
+            client_url=None,
+        )
+        with patch.object(
+                disseminator, 'get_arguments', return_value=arguments), \
+                patch.object(
+                    disseminator, 'run',
+                    side_effect=InternetArchiveIdentifierCollisionError(
+                        'identifier collision')), \
+                patch.object(disseminator.logging, 'error') as mock_logging:
+            status = disseminator.main()
+
+        self.assertEqual(status, 1)
+        mock_logging.assert_called_once()
+
+        with patch.object(
+                disseminator, 'get_arguments', return_value=arguments), \
+                patch.object(disseminator, 'run') as mock_run, \
+                patch.object(disseminator.logging, 'error') as mock_logging:
+            status = disseminator.main()
+
+        self.assertEqual(status, 0)
+        mock_run.assert_called_once()
+        mock_logging.assert_not_called()
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -42,13 +42,17 @@ def original_file(name, contents):
 
 
 class FakeItem:
-    def __init__(self, identifier, exists, metadata=None, files=None):
+    def __init__(
+            self, identifier, exists, metadata=None, files=None,
+            identifier_available=True):
         self.identifier = identifier
         self.exists = exists
         self.metadata = dict(metadata or {})
         self.files = list(files or [])
         self.refresh = MagicMock(side_effect=self._refresh)
         self.modify_metadata = MagicMock(side_effect=self._modify_metadata)
+        self.identifier_available = MagicMock(
+            return_value=identifier_available)
         self.refresh_hook = None
 
     def _refresh(self):
@@ -195,7 +199,45 @@ class TestIAUploader(unittest.TestCase):
         self.assertTrue(pdf_call['verify'])
         self.assertTrue(pdf_call['queue_derive'])
         self.item.modify_metadata.assert_not_called()
+        self.item.identifier_available.assert_called_once_with()
         self._assert_location(locations[0])
+
+    def test_unavailable_missing_identifier_fast_fails_before_sources(self):
+        self.item.identifier_available.return_value = False
+
+        with self.assertRaisesRegex(
+                InternetArchiveIdentifierCollisionError,
+                'no public item metadata.*reported the identifier unavailable'):
+            self.uploader.upload_to_platform()
+
+        self.item.identifier_available.assert_called_once_with()
+        self.uploader.get_formatted_metadata.assert_not_called()
+        self.uploader.get_publication_details.assert_not_called()
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+
+    def test_identifier_availability_failure_fast_fails_before_sources(self):
+        self.item.identifier_available.side_effect = RuntimeError(
+            'availability endpoint failed')
+
+        with self.assertRaisesRegex(
+                DisseminationError, 'Unable to check.*availability endpoint failed'):
+            self.uploader.upload_to_platform()
+
+        self.uploader.get_formatted_metadata.assert_not_called()
+        self.uploader.get_publication_details.assert_not_called()
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+
+    def test_invalid_identifier_availability_response_is_rejected(self):
+        self.item.identifier_available.return_value = 'available'
+
+        with self.assertRaisesRegex(
+                DisseminationError, 'invalid response'):
+            self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.uploader.get_formatted_metadata.assert_not_called()
 
     def test_existing_current_item_skips_files_and_metadata(self):
         self._set_existing_item()
@@ -205,6 +247,7 @@ class TestIAUploader(unittest.TestCase):
         self.mock_upload.assert_not_called()
         self.item.modify_metadata.assert_not_called()
         self.assertGreaterEqual(self.item.refresh.call_count, 1)
+        self.item.identifier_available.assert_not_called()
         self._assert_location(locations[0])
 
     def test_existing_item_with_changed_pdf_uploads_only_pdf(self):
@@ -300,6 +343,7 @@ class TestIAUploader(unittest.TestCase):
         mock_warning.assert_called_once()
         metadata_patch = self.item.modify_metadata.call_args.args[0]
         self.assertEqual(metadata_patch['thoth-work-id'], WORK_ID)
+        self.item.identifier_available.assert_not_called()
 
     def test_existing_item_with_matching_marker_is_accepted(self):
         metadata = self._desired_metadata()

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -183,13 +183,17 @@ class TestIAUploader(unittest.TestCase):
     def test_new_item_creation_uploads_both_files_with_metadata(self):
         locations = self.uploader.upload_to_platform()
 
-        self.mock_upload.assert_called_once()
-        call = self.mock_upload.call_args.kwargs
-        self.assertEqual(set(call['files']), {PDF_NAME, JSON_NAME})
-        self.assertEqual(call['metadata'], self._desired_metadata())
-        self.assertTrue(call['checksum'])
-        self.assertTrue(call['verify'])
-        self.assertTrue(call['queue_derive'])
+        self.assertEqual(self.mock_upload.call_count, 2)
+        pdf_call, json_call = [
+            call.kwargs for call in self.mock_upload.call_args_list
+        ]
+        self.assertEqual(set(pdf_call['files']), {PDF_NAME})
+        self.assertEqual(pdf_call['metadata'], self._desired_metadata())
+        self.assertEqual(set(json_call['files']), {JSON_NAME})
+        self.assertIsNone(json_call['metadata'])
+        self.assertTrue(pdf_call['checksum'])
+        self.assertTrue(pdf_call['verify'])
+        self.assertTrue(pdf_call['queue_derive'])
         self.item.modify_metadata.assert_not_called()
         self._assert_location(locations[0])
 
@@ -470,7 +474,7 @@ class TestIAUploader(unittest.TestCase):
 
         locations = self.uploader.upload_to_platform()
 
-        self.mock_upload.assert_called_once()
+        self.assertEqual(self.mock_upload.call_count, 2)
         self.item.modify_metadata.assert_not_called()
         self.assertEqual(self.item.refresh.call_count, 2)
         self.mock_sleep.assert_called_once()
@@ -524,7 +528,7 @@ class TestIAUploader(unittest.TestCase):
 
         locations = self.uploader.upload_to_platform()
 
-        self.mock_upload.assert_called_once()
+        self.assertEqual(self.mock_upload.call_count, 2)
         self.item.modify_metadata.assert_not_called()
         self.assertEqual(self.item.refresh.call_count, 3)
         self.assertEqual(self.mock_sleep.call_count, 2)

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -13,6 +13,7 @@ from errors import (
     DisseminationError,
     InternetArchiveIdentifierCollisionError,
     InternetArchiveImmutableMetadataError,
+    InternetArchiveRestrictedMetadataError,
     InternetArchiveVerificationError,
 )
 from iauploader import IAUploader
@@ -210,6 +211,14 @@ class TestIAUploader(unittest.TestCase):
             'metadata']
         self.assertEqual(initial_metadata['mediatype'], 'texts')
 
+    def test_new_item_initial_upload_sets_thoth_collection(self):
+        self.uploader.upload_to_platform()
+
+        initial_metadata = self.mock_upload.call_args_list[0].kwargs[
+            'metadata']
+        self.assertEqual(
+            initial_metadata['collection'], IAUploader.THOTH_COLLECTION)
+
     def test_new_item_final_verification_requires_mediatype(self):
         desired_metadata = self._desired_metadata()
 
@@ -228,6 +237,27 @@ class TestIAUploader(unittest.TestCase):
             with self.assertRaisesRegex(
                     InternetArchiveVerificationError,
                     "mediatype is None, expected 'texts'"):
+                self.uploader.upload_to_platform()
+
+    def test_new_item_final_verification_requires_thoth_collection(self):
+        desired_metadata = self._desired_metadata()
+
+        def upload_without_collection(**kwargs):
+            for name, file_object in kwargs['files'].items():
+                self.item.set_original(name, file_object.read())
+            if kwargs.get('metadata') is not None:
+                self.item.metadata = dict(desired_metadata)
+                self.item.metadata.pop('collection')
+            self.item.exists = True
+            return [make_response() for _ in kwargs['files']]
+
+        self.mock_upload.side_effect = upload_without_collection
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 1):
+            with self.assertRaisesRegex(
+                    InternetArchiveVerificationError,
+                    "collection is None, expected to include "
+                    "'thoth-archiving-network'"):
                 self.uploader.upload_to_platform()
 
     def test_existing_correct_mediatype_remains_repairable(self):
@@ -292,6 +322,70 @@ class TestIAUploader(unittest.TestCase):
             if field == 'mediatype'
         ])
 
+    def test_admin_only_collection_is_never_in_metadata_patch(self):
+        current = self._desired_metadata()
+        current.pop('collection')
+
+        metadata_patch = self.uploader._managed_metadata_patch(
+            current, self._desired_metadata())
+
+        self.assertNotIn('collection', metadata_patch)
+
+    def test_missing_desired_collection_never_produces_remove_tag(self):
+        current = self._desired_metadata()
+        desired = self._desired_metadata()
+        desired.pop('collection')
+
+        metadata_patch = self.uploader._managed_metadata_patch(
+            current, desired)
+
+        self.assertNotIn('collection', metadata_patch)
+
+    def test_collection_comparison_accepts_scalar_and_list_membership(self):
+        desired = self.uploader.build_desired_state()
+        for collection in (
+                IAUploader.THOTH_COLLECTION,
+                ['unrelated', IAUploader.THOTH_COLLECTION],
+        ):
+            with self.subTest(collection=collection):
+                metadata = self._desired_metadata()
+                metadata['collection'] = collection
+                self._set_existing_item(metadata=metadata)
+
+                inspection = self.uploader.inspect_item(self.item, desired)
+
+                self.assertEqual(
+                    inspection['admin_only_metadata_problems'], [])
+                self.assertNotIn('collection', inspection['metadata_patch'])
+
+    def test_missing_collection_reports_admin_only_conflict(self):
+        metadata = self._desired_metadata()
+        metadata.pop('collection')
+        self._set_existing_item(metadata=metadata)
+        desired = self.uploader.build_desired_state()
+
+        inspection = self.uploader.inspect_item(self.item, desired)
+
+        self.assertEqual(inspection['admin_only_metadata_problems'], [
+            "collection is None, expected to include "
+            "'thoth-archiving-network'",
+        ])
+        self.assertNotIn('collection', inspection['metadata_patch'])
+
+    def test_unrelated_collection_reports_admin_only_conflict(self):
+        metadata = self._desired_metadata()
+        metadata['collection'] = 'unrelated-collection'
+        self._set_existing_item(metadata=metadata)
+        desired = self.uploader.build_desired_state()
+
+        inspection = self.uploader.inspect_item(self.item, desired)
+
+        self.assertEqual(inspection['admin_only_metadata_problems'], [
+            "collection is 'unrelated-collection', expected to include "
+            "'thoth-archiving-network'",
+        ])
+        self.assertNotIn('collection', inspection['metadata_patch'])
+
     def test_direct_dissemination_rejects_immutable_mediatype_conflict(self):
         metadata = self._desired_metadata()
         metadata['mediatype'] = 'data'
@@ -334,6 +428,30 @@ class TestIAUploader(unittest.TestCase):
         self.item.metadata['mediatype'] = 'data'
 
         with self.assertRaises(InternetArchiveImmutableMetadataError):
+            self.uploader.apply_archive_repairs(
+                self.item,
+                desired,
+                inspection=stale_inspection,
+                access_key='access-key',
+                secret_key='secret-key',
+            )
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.item.refresh.assert_not_called()
+
+    def test_apply_archive_repairs_rechecks_admin_only_collection(self):
+        self._set_existing_item()
+        desired = self.uploader.build_desired_state()
+        stale_inspection = self.uploader.inspect_item(self.item, desired)
+        self.item.metadata['collection'] = 'unrelated-collection'
+
+        with self.assertRaisesRegex(
+                InternetArchiveRestrictedMetadataError,
+                "item {}.*collection membership "
+                "\\['unrelated-collection'\\].*must include "
+                "'thoth-archiving-network'.*administrator intervention.*"
+                "no automatic mutation was attempted".format(WORK_ID)):
             self.uploader.apply_archive_repairs(
                 self.item,
                 desired,
@@ -525,19 +643,23 @@ class TestIAUploader(unittest.TestCase):
         self.assertEqual(metadata_patch['thoth-work-id'], WORK_ID)
         self.item.identifier_available.assert_not_called()
 
-    def test_existing_item_with_matching_marker_is_accepted(self):
+    def test_matching_marker_with_missing_collection_is_restricted_conflict(self):
         metadata = self._desired_metadata()
         metadata.pop('collection')
         metadata['thoth-work-id'] = [WORK_ID]
         self._set_existing_item(metadata=metadata)
 
-        locations = self.uploader.upload_to_platform()
+        with self.assertRaisesRegex(
+                InternetArchiveRestrictedMetadataError,
+                "item {}.*collection membership \\[\\].*must include "
+                "'thoth-archiving-network'.*administrator intervention.*"
+                "no automatic mutation was attempted".format(WORK_ID)):
+            self.uploader.upload_to_platform()
 
-        metadata_patch = self.item.modify_metadata.call_args.args[0]
-        self.assertEqual(
-            metadata_patch['collection'], IAUploader.THOTH_COLLECTION)
-        self.assertNotIn('thoth-work-id', metadata_patch)
-        self._assert_location(locations[0])
+        self.uploader.get_variable_from_env.assert_not_called()
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.item.refresh.assert_not_called()
 
     def test_collision_with_another_thoth_work_id_is_refused(self):
         metadata = self._desired_metadata()
@@ -837,16 +959,18 @@ class TestIAUploader(unittest.TestCase):
             self.item.metadata['collection'],
             ['other-collection', 'thoth-archiving-network'])
 
-    def test_matching_marker_adds_thoth_collection_without_removing_other_one(self):
+    def test_matching_marker_with_only_unrelated_collection_is_restricted(self):
         metadata = self._desired_metadata()
         metadata['collection'] = 'other-collection'
-        self._set_existing_item(metadata=metadata)
+        self._set_existing_item(metadata=metadata, files=[])
 
-        self.uploader.upload_to_platform()
+        with self.assertRaises(InternetArchiveRestrictedMetadataError):
+            self.uploader.upload_to_platform()
 
-        self.assertEqual(
-            self.item.modify_metadata.call_args.args[0]['collection'],
-            ['other-collection', 'thoth-archiving-network'])
+        self.uploader.get_variable_from_env.assert_not_called()
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.item.refresh.assert_not_called()
 
 
 class TestDisseminatorCLI(unittest.TestCase):

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -4,7 +4,7 @@ import json
 import sys
 import unittest
 from types import ModuleType, SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from requests import Response
 from requests.exceptions import HTTPError
@@ -317,6 +317,16 @@ class TestIAUploader(unittest.TestCase):
         self.item.modify_metadata.assert_not_called()
         self.item.refresh.assert_not_called()
 
+    def test_immutable_conflict_does_not_read_credentials(self):
+        metadata = self._desired_metadata()
+        metadata['mediatype'] = 'data'
+        self._set_existing_item(metadata=metadata)
+
+        with self.assertRaises(InternetArchiveImmutableMetadataError):
+            self.uploader.upload_to_platform()
+
+        self.uploader.get_variable_from_env.assert_not_called()
+
     def test_apply_archive_repairs_rechecks_initial_only_metadata(self):
         self._set_existing_item()
         desired = self.uploader.build_desired_state()
@@ -396,6 +406,29 @@ class TestIAUploader(unittest.TestCase):
         self.assertGreaterEqual(self.item.refresh.call_count, 1)
         self.item.identifier_available.assert_not_called()
         self._assert_location(locations[0])
+
+    def test_current_item_does_not_read_credentials(self):
+        self._set_existing_item()
+
+        self.uploader.upload_to_platform()
+
+        self.uploader.get_variable_from_env.assert_not_called()
+
+    def test_item_requiring_mutation_reads_credentials(self):
+        metadata = self._desired_metadata()
+        metadata['title'] = 'Old title'
+        self._set_existing_item(metadata=metadata)
+
+        self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            self.uploader.get_variable_from_env.call_args_list,
+            [
+                call('ia_s3_access', 'Internet Archive'),
+                call('ia_s3_secret', 'Internet Archive'),
+            ],
+        )
+        self.item.modify_metadata.assert_called_once()
 
     def test_existing_item_with_changed_pdf_uploads_only_pdf(self):
         self._set_existing_item(files=[
@@ -519,6 +552,16 @@ class TestIAUploader(unittest.TestCase):
         self.mock_upload.assert_not_called()
         self.item.modify_metadata.assert_not_called()
         self.uploader.get_formatted_metadata.assert_not_called()
+
+    def test_identifier_collision_does_not_read_credentials(self):
+        metadata = self._desired_metadata()
+        metadata['thoth-work-id'] = 'another-work-id'
+        self._set_existing_item(metadata=metadata)
+
+        with self.assertRaises(InternetArchiveIdentifierCollisionError):
+            self.uploader.upload_to_platform()
+
+        self.uploader.get_variable_from_env.assert_not_called()
 
     def test_collision_without_thoth_ownership_is_refused(self):
         metadata = self._desired_metadata()

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -12,6 +12,7 @@ from requests.exceptions import HTTPError
 from errors import (
     DisseminationError,
     InternetArchiveIdentifierCollisionError,
+    InternetArchiveImmutableMetadataError,
     InternetArchiveVerificationError,
 )
 from iauploader import IAUploader
@@ -201,6 +202,152 @@ class TestIAUploader(unittest.TestCase):
         self.item.modify_metadata.assert_not_called()
         self.item.identifier_available.assert_called_once_with()
         self._assert_location(locations[0])
+
+    def test_new_item_initial_upload_sets_mediatype_texts(self):
+        self.uploader.upload_to_platform()
+
+        initial_metadata = self.mock_upload.call_args_list[0].kwargs[
+            'metadata']
+        self.assertEqual(initial_metadata['mediatype'], 'texts')
+
+    def test_new_item_final_verification_requires_mediatype(self):
+        desired_metadata = self._desired_metadata()
+
+        def upload_without_mediatype(**kwargs):
+            for name, file_object in kwargs['files'].items():
+                self.item.set_original(name, file_object.read())
+            if kwargs.get('metadata') is not None:
+                self.item.metadata = dict(desired_metadata)
+                self.item.metadata.pop('mediatype')
+            self.item.exists = True
+            return [make_response() for _ in kwargs['files']]
+
+        self.mock_upload.side_effect = upload_without_mediatype
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 1):
+            with self.assertRaisesRegex(
+                    InternetArchiveVerificationError,
+                    "mediatype is None, expected 'texts'"):
+                self.uploader.upload_to_platform()
+
+    def test_existing_correct_mediatype_remains_repairable(self):
+        metadata = self._desired_metadata()
+        metadata['title'] = 'Old title'
+        self._set_existing_item(metadata=metadata)
+        desired = self.uploader.build_desired_state()
+
+        inspection = self.uploader.inspect_item(self.item, desired)
+
+        self.assertEqual(inspection['immutable_metadata_problems'], [])
+        self.assertEqual(
+            inspection['metadata_patch'], {'title': 'A Test Book'})
+        self.assertIn('title', inspection['mutable_metadata_problems'][0])
+
+    def test_existing_different_mediatype_reports_immutable_conflict(self):
+        metadata = self._desired_metadata()
+        metadata['mediatype'] = 'data'
+        self._set_existing_item(metadata=metadata)
+        desired = self.uploader.build_desired_state()
+
+        inspection = self.uploader.inspect_item(self.item, desired)
+
+        self.assertEqual(inspection['immutable_metadata_problems'], [
+            "mediatype is 'data', expected 'texts'",
+        ])
+        self.assertEqual(inspection['mutable_metadata_problems'], [])
+        self.assertNotIn('mediatype', inspection['metadata_patch'])
+
+    def test_existing_missing_mediatype_reports_immutable_conflict(self):
+        metadata = self._desired_metadata()
+        metadata.pop('mediatype')
+        self._set_existing_item(metadata=metadata)
+        desired = self.uploader.build_desired_state()
+
+        inspection = self.uploader.inspect_item(self.item, desired)
+
+        self.assertEqual(inspection['immutable_metadata_problems'], [
+            "mediatype is None, expected 'texts'",
+        ])
+        self.assertNotIn('mediatype', inspection['metadata_patch'])
+
+    def test_immutable_mediatype_is_never_in_metadata_patch(self):
+        current = self._desired_metadata()
+        current['mediatype'] = 'data'
+
+        patch = self.uploader._managed_metadata_patch(
+            current, self._desired_metadata())
+
+        self.assertNotIn('mediatype', patch)
+
+    def test_immutable_mediatype_is_never_removed(self):
+        current = self._desired_metadata()
+        desired = self._desired_metadata()
+        desired.pop('mediatype')
+
+        patch = self.uploader._managed_metadata_patch(current, desired)
+
+        self.assertNotIn('mediatype', patch)
+        self.assertNotIn('REMOVE_TAG', [
+            value for field, value in patch.items()
+            if field == 'mediatype'
+        ])
+
+    def test_direct_dissemination_rejects_immutable_mediatype_conflict(self):
+        metadata = self._desired_metadata()
+        metadata['mediatype'] = 'data'
+        self._set_existing_item(metadata=metadata)
+
+        with self.assertRaisesRegex(
+                InternetArchiveImmutableMetadataError,
+                "item {}.*mediatype is 'data', required 'texts'.*"
+                "only be set during item creation.*"
+                "no automatic mutation was attempted".format(WORK_ID)):
+            self.uploader.upload_to_platform()
+
+    def test_direct_immutable_conflict_performs_zero_mutations(self):
+        metadata = self._desired_metadata()
+        metadata.pop('mediatype')
+        metadata.pop('thoth-work-id')
+        self._set_existing_item(metadata=metadata, files=[])
+
+        with self.assertRaises(InternetArchiveImmutableMetadataError):
+            self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.item.refresh.assert_not_called()
+
+    def test_apply_archive_repairs_rechecks_initial_only_metadata(self):
+        self._set_existing_item()
+        desired = self.uploader.build_desired_state()
+        stale_inspection = self.uploader.inspect_item(self.item, desired)
+        self.item.metadata['mediatype'] = 'data'
+
+        with self.assertRaises(InternetArchiveImmutableMetadataError):
+            self.uploader.apply_archive_repairs(
+                self.item,
+                desired,
+                inspection=stale_inspection,
+                access_key='access-key',
+                secret_key='secret-key',
+            )
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.item.refresh.assert_not_called()
+
+    def test_correct_mediatype_with_title_drift_updates_only_title(self):
+        metadata = self._desired_metadata()
+        metadata['title'] = 'Old title'
+        self._set_existing_item(metadata=metadata)
+
+        self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.assertEqual(
+            self.item.modify_metadata.call_args.args[0],
+            {'title': 'A Test Book'},
+        )
 
     def test_unavailable_missing_identifier_fast_fails_before_sources(self):
         self.item.identifier_available.return_value = False

--- a/tests/test_obtain_new_ids.py
+++ b/tests/test_obtain_new_ids.py
@@ -1,7 +1,605 @@
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timedelta, UTC
+from io import StringIO
+import json
+import os
+from pathlib import Path
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 from types import SimpleNamespace
 
+from internet_archive_policy import SUPPORTED_WORK_TYPES
+from obtain_new_ids import (
+    DEFAULT_IA_LOOKBACK_HOURS,
+    DEFAULT_IA_MAX_IDS,
+    IA_QUERY_PAGE_SIZE,
+    InternetArchiveIDFinder,
+    InternetArchiveSelectionError,
+    MonthlyIDFinder,
+    WeeklyIDFinder,
+    canonical_utc_timestamp,
+    get_arguments,
+    get_id_finder,
+    lookback_hours_type,
+    main,
+    max_ids_type,
+    parse_api_timestamp,
+)
+from thothapi import (
+    INTERNET_ARCHIVE_SELECTION_QUERY,
+    ThothGraphQLResponseError,
+    get_internet_archive_selection_works,
+)
+
+
+NOW = datetime(2026, 7, 23, 4, 40, tzinfo=UTC)
+PUBLISHER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+WORK_ID = '11111111-1111-4111-8111-111111111111'
+
+
+def selection_work(
+        work_id=WORK_ID, updated_at='2026-07-23T04:00:00Z',
+        status='ACTIVE', work_type='MONOGRAPH', publications=None):
+    if publications is None:
+        publications = [{
+            'publicationType': 'PDF',
+            'locations': [{
+                'canonical': True,
+                'fullTextUrl': 'https://example.test/book.pdf',
+            }],
+        }]
+    return {
+        'workId': work_id,
+        'updatedAtWithRelations': updated_at,
+        'workStatus': status,
+        'workType': work_type,
+        'publications': publications,
+    }
+
+
+def numbered_work(number, updated_at=None):
+    work_id = '00000000-0000-4000-8000-{:012x}'.format(number)
+    if updated_at is None:
+        updated_at = (
+            NOW - timedelta(hours=29) + timedelta(minutes=number)
+        ).isoformat().replace('+00:00', 'Z')
+    return selection_work(work_id=work_id, updated_at=updated_at)
+
+
+class InternetArchiveFinderTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.thoth = MagicMock()
+        self.thoth.publisher.return_value = SimpleNamespace(
+            publisherId=PUBLISHER_ID)
+        self.environment = patch.dict(os.environ, {
+            'ENV_PUBLISHERS': json.dumps([PUBLISHER_ID]),
+            'ENV_EXCEPTIONS': '',
+        })
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+
+    def finder(self, works=None, **kwargs):
+        finder = InternetArchiveIDFinder(
+            thoth=self.thoth,
+            now_provider=lambda: NOW,
+            **kwargs,
+        )
+        finder_patch = patch(
+            'obtain_new_ids.get_internet_archive_selection_works',
+            return_value=list(works or []),
+        )
+        query = finder_patch.start()
+        self.addCleanup(finder_patch.stop)
+        return finder, query
+
+
+class TestInternetArchiveArgumentsAndMapping(
+        InternetArchiveFinderTestCase):
+
+    def test_internet_archive_maps_to_dedicated_finder(self):
+        args = get_arguments(['--platform', 'InternetArchive'])
+        self.assertIsInstance(
+            get_id_finder(args, thoth=self.thoth),
+            InternetArchiveIDFinder,
+        )
+
+    def test_other_monthly_platforms_stay_monthly(self):
+        for platform in ('Figshare', 'Zenodo', 'CUL'):
+            with self.subTest(platform=platform), patch(
+                    'obtain_new_ids.get_thoth_client',
+                    return_value=self.thoth):
+                args = get_arguments(['--platform', platform])
+                self.assertIsInstance(get_id_finder(args), MonthlyIDFinder)
+
+    def test_weekly_platforms_stay_weekly(self):
+        for platform in (
+                'OAPEN', 'EBSCOHost', 'JSTOR', 'ProjectMUSE', 'ProQuest'):
+            with self.subTest(platform=platform), patch(
+                    'obtain_new_ids.get_thoth_client',
+                    return_value=self.thoth):
+                args = get_arguments(['--platform', platform])
+                self.assertIsInstance(get_id_finder(args), WeeklyIDFinder)
+
+    def test_default_lookback_and_limit(self):
+        args = get_arguments(['--platform', 'InternetArchive'])
+        self.assertEqual(args.lookback_hours, DEFAULT_IA_LOOKBACK_HOURS)
+        self.assertEqual(args.max_ids, DEFAULT_IA_MAX_IDS)
+
+    def test_maximum_lookback_is_accepted(self):
+        self.assertEqual(lookback_hours_type('168'), 168)
+
+    def test_invalid_lookbacks_are_rejected(self):
+        for value in ('0', '-1', 'nan', 'inf', '-inf', '169', 'not-a-number'):
+            with self.subTest(value=value), self.assertRaises(
+                    Exception):
+                lookback_hours_type(value)
+
+    def test_fractional_positive_lookback_is_accepted(self):
+        self.assertEqual(lookback_hours_type('1.5'), 1.5)
+
+    def test_max_ids_bounds(self):
+        self.assertEqual(max_ids_type('1'), 1)
+        self.assertEqual(max_ids_type('200'), 200)
+        for value in ('0', '201', '1.5', 'nan'):
+            with self.subTest(value=value), self.assertRaises(Exception):
+                max_ids_type(value)
+
+
+class TestInternetArchiveConfiguration(InternetArchiveFinderTestCase):
+
+    def test_publisher_ids_are_normalised_deduplicated_and_sorted(self):
+        os.environ['ENV_PUBLISHERS'] = json.dumps([
+            PUBLISHER_ID.upper(), PUBLISHER_ID])
+        finder, _query = self.finder()
+        finder.select()
+        self.assertEqual(finder.publisher_ids, [PUBLISHER_ID])
+        self.thoth.publisher.assert_called_once_with(
+            publisher_id=PUBLISHER_ID)
+
+    def test_empty_publisher_list_fails_safely(self):
+        os.environ['ENV_PUBLISHERS'] = '[]'
+        finder, _query = self.finder()
+        with self.assertRaises(InternetArchiveSelectionError):
+            finder.select()
+
+    def test_malformed_publisher_uuid_fails(self):
+        os.environ['ENV_PUBLISHERS'] = '["not-a-uuid"]'
+        finder, _query = self.finder()
+        with self.assertRaises(InternetArchiveSelectionError):
+            finder.select()
+
+    def test_non_array_publishers_fail(self):
+        os.environ['ENV_PUBLISHERS'] = '"{}"'.format(PUBLISHER_ID)
+        finder, _query = self.finder()
+        with self.assertRaises(InternetArchiveSelectionError):
+            finder.select()
+
+    def test_unknown_publisher_fails(self):
+        self.thoth.publisher.return_value = None
+        finder, _query = self.finder()
+        with self.assertRaises(InternetArchiveSelectionError):
+            finder.select()
+
+    def test_publisher_lookup_error_is_sanitised(self):
+        self.thoth.publisher.side_effect = RuntimeError(
+            'upstream response with irrelevant internals')
+        finder, _query = self.finder()
+        with self.assertRaisesRegex(
+                InternetArchiveSelectionError,
+                'could not be confirmed'):
+            finder.select()
+
+    def test_exceptions_are_normalised_and_deduplicated(self):
+        os.environ['ENV_EXCEPTIONS'] = json.dumps([
+            WORK_ID.upper(), WORK_ID])
+        finder, _query = self.finder([selection_work()])
+        report = finder.select()
+        self.assertEqual(report['exception_ids'], [WORK_ID])
+        self.assertEqual(
+            report['excluded_counts'], {'configured_exception': 1})
+
+    def test_invalid_exception_configuration_fails(self):
+        for value in ('{}', '["bad"]', '[1]', 'null'):
+            with self.subTest(value=value):
+                os.environ['ENV_EXCEPTIONS'] = value
+                finder, _query = self.finder()
+                with self.assertRaises(InternetArchiveSelectionError):
+                    finder.select()
+
+
+class TestInternetArchiveWindowAndQuery(InternetArchiveFinderTestCase):
+
+    def test_one_injected_now_is_used_for_entire_run(self):
+        now_provider = MagicMock(return_value=NOW)
+        finder = InternetArchiveIDFinder(
+            thoth=self.thoth, now_provider=now_provider)
+        with patch(
+                'obtain_new_ids.get_internet_archive_selection_works',
+                return_value=[selection_work()]):
+            finder.select()
+        now_provider.assert_called_once_with()
+
+    def test_window_is_deterministic(self):
+        finder, _query = self.finder([selection_work()])
+        report = finder.select()
+        self.assertEqual(report['window'], {
+            'start': '2026-07-21T22:40:00Z',
+            'end': '2026-07-23T04:40:00Z',
+            'lookback_hours': 30,
+        })
+        self.assertEqual(report['generated_at'], report['window']['end'])
+
+    def test_query_uses_relation_update_start_and_policy(self):
+        finder, query = self.finder()
+        finder.select()
+        query.assert_called_once_with(
+            self.thoth,
+            [PUBLISHER_ID],
+            SUPPORTED_WORK_TYPES,
+            '2026-07-21T22:40:00Z',
+            page_size=IA_QUERY_PAGE_SIZE,
+        )
+
+    def test_relation_only_update_is_included(self):
+        work = selection_work()
+        work['updatedAt'] = '2020-01-01T00:00:00Z'
+        finder, _query = self.finder([work])
+        self.assertEqual(finder.select()['selected_count'], 1)
+
+    def test_update_equal_to_window_start_is_excluded(self):
+        finder, _query = self.finder([
+            selection_work(updated_at='2026-07-21T22:40:00Z')])
+        report = finder.select()
+        self.assertEqual(report['selected_count'], 0)
+        self.assertEqual(report['excluded'][0]['reason'], 'outside_window')
+
+    def test_update_before_window_start_is_excluded(self):
+        finder, _query = self.finder([
+            selection_work(updated_at='2026-07-21T22:39:59Z')])
+        self.assertEqual(
+            finder.select()['excluded'][0]['reason'], 'outside_window')
+
+    def test_update_at_window_end_is_included(self):
+        finder, _query = self.finder([
+            selection_work(updated_at='2026-07-23T04:40:00Z')])
+        self.assertEqual(finder.select()['selected_count'], 1)
+
+    def test_update_after_window_end_is_reported(self):
+        finder, _query = self.finder([
+            selection_work(updated_at='2026-07-23T04:40:01Z')])
+        report = finder.select()
+        self.assertEqual(report['selected_count'], 0)
+        self.assertEqual(report['excluded'][0]['reason'], 'after_window_end')
+
+    def test_missing_timestamp_is_reported(self):
+        finder, _query = self.finder([
+            selection_work(updated_at=None)])
+        self.assertEqual(
+            finder.select()['excluded'][0]['reason'],
+            'missing_update_timestamp',
+        )
+
+    def test_malformed_and_naive_timestamps_are_reported(self):
+        finder, _query = self.finder([
+            selection_work(
+                work_id=WORK_ID, updated_at='not-a-timestamp'),
+            selection_work(
+                work_id='22222222-2222-4222-8222-222222222222',
+                updated_at='2026-07-23T04:00:00'),
+        ])
+        report = finder.select()
+        self.assertEqual(
+            report['excluded_counts'], {'malformed_update_timestamp': 2})
+
+    def test_utc_and_offset_timestamps_normalise(self):
+        self.assertEqual(
+            canonical_utc_timestamp(
+                parse_api_timestamp('2026-07-23T05:00:00+01:00')),
+            '2026-07-23T04:00:00Z',
+        )
+        self.assertEqual(
+            canonical_utc_timestamp(
+                parse_api_timestamp('2026-07-23T04:00:00Z')),
+            '2026-07-23T04:00:00Z',
+        )
+
+
+class TestInternetArchiveEligibility(InternetArchiveFinderTestCase):
+
+    def assert_excluded(self, work, reason):
+        finder, _query = self.finder([work])
+        report = finder.select()
+        self.assertEqual(report['selected_count'], 0)
+        self.assertEqual(report['excluded'][0]['reason'], reason)
+
+    def test_active_supported_work_with_source_is_included(self):
+        finder, _query = self.finder([selection_work()])
+        self.assertEqual(finder.select()['selected_count'], 1)
+
+    def test_inactive_work_is_excluded(self):
+        self.assert_excluded(
+            selection_work(status='FORTHCOMING'), 'inactive')
+
+    def test_unsupported_work_type_is_excluded(self):
+        self.assert_excluded(
+            selection_work(work_type='BOOK_CHAPTER'),
+            'unsupported_work_type',
+        )
+
+    def test_work_without_pdf_is_excluded(self):
+        self.assert_excluded(
+            selection_work(publications=[]), 'no_pdf_publication')
+
+    def test_pdf_without_canonical_location_is_excluded(self):
+        self.assert_excluded(selection_work(publications=[{
+            'publicationType': 'PDF',
+            'locations': [{
+                'canonical': False,
+                'fullTextUrl': 'https://example.test/book.pdf',
+            }],
+        }]), 'no_canonical_pdf_location')
+
+    def test_canonical_pdf_without_url_is_excluded(self):
+        for value in (None, '', '   '):
+            with self.subTest(value=value):
+                self.assert_excluded(selection_work(publications=[{
+                    'publicationType': 'PDF',
+                    'locations': [{
+                        'canonical': True,
+                        'fullTextUrl': value,
+                    }],
+                }]), 'canonical_pdf_location_missing_full_text_url')
+
+    def test_source_eligibility_does_not_make_network_requests(self):
+        finder, _query = self.finder([selection_work()])
+        with patch('requests.get') as get, patch('requests.head') as head:
+            finder.select()
+        get.assert_not_called()
+        head.assert_not_called()
+
+    def test_exceptions_are_applied_before_capacity(self):
+        exception_id = numbered_work(1)['workId']
+        os.environ['ENV_EXCEPTIONS'] = json.dumps([exception_id])
+        finder, _query = self.finder(
+            [numbered_work(1), numbered_work(2)],
+            max_ids=1,
+        )
+        report = finder.select()
+        self.assertEqual(
+            [entry['work_id'] for entry in report['selected']],
+            [numbered_work(2)['workId']],
+        )
+        self.assertFalse(report['truncated'])
+
+
+class TestInternetArchiveOrderingAndCap(InternetArchiveFinderTestCase):
+
+    def test_duplicate_work_ids_retain_newest_valid_timestamp(self):
+        finder, _query = self.finder([
+            selection_work(updated_at='2026-07-23T01:00:00Z'),
+            selection_work(updated_at='2026-07-23T03:00:00Z'),
+        ])
+        report = finder.select()
+        self.assertEqual(report['eligible_count'], 1)
+        self.assertEqual(
+            report['selected'][0]['updated_at_with_relations'],
+            '2026-07-23T03:00:00Z',
+        )
+
+    def test_oldest_updates_sort_first(self):
+        finder, _query = self.finder([
+            numbered_work(2, '2026-07-23T03:00:00Z'),
+            numbered_work(1, '2026-07-23T01:00:00Z'),
+        ])
+        report = finder.select()
+        self.assertEqual(
+            [entry['work_id'] for entry in report['selected']],
+            [numbered_work(1)['workId'], numbered_work(2)['workId']],
+        )
+
+    def test_equal_timestamps_sort_by_work_id(self):
+        timestamp = '2026-07-23T03:00:00Z'
+        finder, _query = self.finder([
+            numbered_work(2, timestamp), numbered_work(1, timestamp)])
+        report = finder.select()
+        self.assertEqual(
+            [entry['work_id'] for entry in report['selected']],
+            sorted([numbered_work(2)['workId'], numbered_work(1)['workId']]),
+        )
+
+    def test_cap_selects_200_and_reports_every_overflow(self):
+        works = [numbered_work(number) for number in range(1, 204)]
+        finder, _query = self.finder(works)
+        report = finder.select()
+        self.assertEqual(report['selected_count'], 200)
+        self.assertEqual(report['omitted_count'], 3)
+        self.assertTrue(report['truncated'])
+        self.assertEqual(len(report['omitted']), 3)
+        self.assertEqual(
+            report['selected'] + report['omitted'],
+            sorted(
+                report['selected'] + report['omitted'],
+                key=lambda entry: (
+                    entry['updated_at_with_relations'], entry['work_id']),
+            ),
+        )
+
+    def test_custom_cap_is_applied_after_eligibility(self):
+        works = [
+            numbered_work(1),
+            selection_work(
+                work_id=numbered_work(2)['workId'],
+                updated_at=numbered_work(2)['updatedAtWithRelations'],
+                publications=[]),
+            numbered_work(3),
+        ]
+        finder, _query = self.finder(works, max_ids=1)
+        report = finder.select()
+        self.assertEqual(report['eligible_count'], 2)
+        self.assertEqual(report['selected_count'], 1)
+        self.assertEqual(report['omitted_count'], 1)
+
+    def test_selected_and_omitted_timestamps_are_canonical_utc(self):
+        finder, _query = self.finder([
+            numbered_work(1, '2026-07-23T03:00:00+01:00'),
+            numbered_work(2, '2026-07-23T04:00:00+01:00'),
+        ], max_ids=1)
+        report = finder.select()
+        self.assertEqual(
+            report['selected'][0]['updated_at_with_relations'],
+            '2026-07-23T02:00:00Z',
+        )
+        self.assertEqual(
+            report['omitted'][0]['updated_at_with_relations'],
+            '2026-07-23T03:00:00Z',
+        )
+
+
+class TestInternetArchiveOutputAndFailure(InternetArchiveFinderTestCase):
+
+    def test_empty_selection_outputs_exact_json_array(self):
+        finder, _query = self.finder([])
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            finder.run()
+        self.assertEqual(stdout.getvalue(), '[]\n')
+
+    def test_selected_stdout_is_compact_json_and_logs_stay_off_stdout(self):
+        finder, _query = self.finder([selection_work()])
+        stdout = StringIO()
+        stderr = StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            finder.run()
+        self.assertEqual(json.loads(stdout.getvalue()), [WORK_ID])
+        self.assertEqual(stdout.getvalue(), '["{}"]\n'.format(WORK_ID))
+
+    def test_report_output_is_deterministic(self):
+        first, _query = self.finder([selection_work()])
+        second, _query = self.finder([selection_work()])
+        self.assertEqual(first.select(), second.select())
+
+    def test_report_file_is_sorted_json_with_trailing_newline(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'selection.json'
+            finder, _query = self.finder(
+                [selection_work()], report_path=path)
+            with redirect_stdout(StringIO()):
+                finder.run()
+            content = path.read_text(encoding='utf-8')
+            self.assertTrue(content.endswith('\n'))
+            self.assertEqual(json.loads(content), finder.report)
+
+    def test_query_failure_returns_nonzero_and_writes_failure_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / 'failure.json'
+            with patch(
+                    'obtain_new_ids.get_internet_archive_selection_works',
+                    side_effect=RuntimeError('query unavailable')):
+                status = main([
+                    '--platform', 'InternetArchive',
+                    '--report', str(report_path),
+                ], now_provider=lambda: NOW, thoth=self.thoth)
+            self.assertEqual(status, 1)
+            report = json.loads(report_path.read_text(encoding='utf-8'))
+            self.assertEqual(report['status'], 'failed')
+            self.assertNotIn('environ', json.dumps(report).lower())
+
+    def test_truncation_warns_to_stderr_but_outputs_valid_json(self):
+        finder, _query = self.finder(
+            [numbered_work(1), numbered_work(2)], max_ids=1)
+        stdout = StringIO()
+        with redirect_stdout(stdout), self.assertLogs(level='WARNING') as logs:
+            finder.run()
+        self.assertEqual(json.loads(stdout.getvalue()), [
+            numbered_work(1)['workId']])
+        self.assertIn('selection artifact', '\n'.join(logs.output))
+
+
+class TestInternetArchiveGraphQLHelper(unittest.TestCase):
+
+    def test_query_requests_only_selection_fields_and_relation_order(self):
+        self.assertIn('updatedAtWithRelations', INTERNET_ARCHIVE_SELECTION_QUERY)
+        self.assertIn('UPDATED_AT_WITH_RELATIONS', INTERNET_ARCHIVE_SELECTION_QUERY)
+        self.assertIn('publications {', INTERNET_ARCHIVE_SELECTION_QUERY)
+        self.assertIn('locations {', INTERNET_ARCHIVE_SELECTION_QUERY)
+        self.assertNotIn('publicationDate', INTERNET_ARCHIVE_SELECTION_QUERY)
+
+    def test_pagination_uses_bounded_pages_and_retrieves_all(self):
+        first_page = [numbered_work(number) for number in range(100)]
+        second_page = [numbered_work(100)]
+        thoth = MagicMock()
+        thoth.client.execute.side_effect = [
+            {'data': {'works': first_page}},
+            {'data': {'works': second_page}},
+        ]
+        works = get_internet_archive_selection_works(
+            thoth, [PUBLISHER_ID], SUPPORTED_WORK_TYPES,
+            '2026-07-21T22:40:00Z')
+        self.assertEqual(len(works), 101)
+        self.assertEqual(
+            [call.args[1]['offset'] for call in thoth.client.execute.call_args_list],
+            [0, 100],
+        )
+        self.assertTrue(all(
+            call.args[1]['limit'] == 100
+            for call in thoth.client.execute.call_args_list))
+
+    def test_query_applies_publishers_status_types_and_start_filter(self):
+        thoth = MagicMock()
+        thoth.client.execute.return_value = {'data': {'works': []}}
+        get_internet_archive_selection_works(
+            thoth, [PUBLISHER_ID], SUPPORTED_WORK_TYPES,
+            '2026-07-21T22:40:00Z')
+        variables = thoth.client.execute.call_args.args[1]
+        self.assertEqual(variables['publishers'], [PUBLISHER_ID])
+        self.assertEqual(variables['workStatuses'], ['ACTIVE'])
+        self.assertEqual(variables['workTypes'], list(SUPPORTED_WORK_TYPES))
+        self.assertEqual(variables['updatedAtWithRelations'], {
+            'timestamp': '2026-07-21T22:40:00Z',
+            'expression': 'GREATER_THAN',
+        })
+
+    def test_graphql_errors_retain_message_without_extensions(self):
+        thoth = MagicMock()
+        thoth.client.execute.return_value = {
+            'errors': [{
+                'message': 'useful failure',
+                'path': ['works'],
+                'extensions': {'debug': 'internal'},
+            }],
+        }
+        with self.assertRaises(ThothGraphQLResponseError) as raised:
+            get_internet_archive_selection_works(
+                thoth, [PUBLISHER_ID], SUPPORTED_WORK_TYPES,
+                '2026-07-21T22:40:00Z')
+        self.assertIn('useful failure', str(raised.exception))
+        self.assertNotIn('internal', str(raised.exception))
+
+    def test_page_size_must_be_bounded(self):
+        for value in (0, 101, 1.5):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                get_internet_archive_selection_works(
+                    MagicMock(), [PUBLISHER_ID], SUPPORTED_WORK_TYPES,
+                    '2026-07-21T22:40:00Z', page_size=value)
+
+
+class TestExistingFinderJSONCompatibility(unittest.TestCase):
+
+    def test_existing_finder_stdout_is_valid_json(self):
+        finder = MagicMock()
+        finder.thoth_ids = ['a', 'b']
+        finder.get_publishers = MagicMock()
+        finder.get_query_parameters = MagicMock()
+        finder.get_thoth_ids = MagicMock()
+        finder.remove_exceptions = MagicMock()
+        finder.post_process = MagicMock()
+        from obtain_new_ids import IDFinder
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            IDFinder.run(finder)
+        self.assertEqual(json.loads(stdout.getvalue()), ['a', 'b'])
 
 def make_location(platform):
     return SimpleNamespace(locationPlatform=platform)

--- a/tests/test_reconcile_cli.py
+++ b/tests/test_reconcile_cli.py
@@ -1,0 +1,543 @@
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from reconcile_internet_archive import (
+    InternetArchiveReconciler,
+    ReconciliationConfigurationError,
+    _base_result,
+    load_local_environment,
+    main,
+    validate_apply_credentials,
+)
+from write_locations import LocationInput
+
+
+WORK_ID = '11111111-2222-3333-4444-555555555555'
+WORK_ID_2 = '22222222-3333-4444-5555-666666666666'
+PUBLICATION_ID = '99999999-8888-7777-6666-555555555555'
+LANDING_PAGE = 'https://archive.org/details/{}'.format(WORK_ID)
+FULL_TEXT_URL = 'https://archive.org/download/{}/{}.pdf'.format(
+    WORK_ID, WORK_ID)
+CREDENTIALS = {
+    'ia_s3_access': 'config-access',
+    'ia_s3_secret': 'config-secret',
+    'THOTH_PAT': 'config-token',
+}
+
+
+def result_for(work_id=WORK_ID, status='current', actions=()):
+    result = _base_result(work_id)
+    result.update({
+        'publisher_id': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        'title': 'A Test Book',
+        'publication_id': PUBLICATION_ID,
+        'pdf_source_url': 'https://source.example/book.pdf',
+        'eligible': True,
+        'status': status,
+        'issues': [] if status == 'current' else [status],
+        'recommended_actions': list(actions),
+        'auto_applicable_actions': list(actions),
+        'error': None,
+    })
+    return result
+
+
+def location_input():
+    return LocationInput(
+        PUBLICATION_ID,
+        'INTERNET_ARCHIVE',
+        LANDING_PAGE,
+        FULL_TEXT_URL,
+        '0123456789abcdef0123456789abcdef',
+        'MD5',
+    )
+
+
+def existing_location(**overrides):
+    values = {
+        'locationId': 'existing-location',
+        'publicationId': PUBLICATION_ID,
+        'locationPlatform': 'INTERNET_ARCHIVE',
+        'landingPage': LANDING_PAGE,
+        'fullTextUrl': FULL_TEXT_URL,
+        'canonical': False,
+        'checksum': '0123456789abcdef0123456789abcdef',
+        'checksumAlgorithm': 'MD5',
+    }
+    values.update(overrides)
+    return values
+
+
+def apply_context():
+    return {
+        'uploader': MagicMock(),
+        'desired': SimpleNamespace(publication_id=PUBLICATION_ID),
+        'item': object(),
+        'archive_inspection': {},
+        'location_input': location_input(),
+    }
+
+
+def write_config(path, values=CREDENTIALS):
+    path.write_text(
+        ''.join('{}={}\n'.format(key, value) for key, value in values.items()),
+        encoding='utf-8',
+    )
+
+
+class TestReconciliationCliStdout(unittest.TestCase):
+    def _reconciler(self, before, context=None, final=None):
+        thoth = MagicMock()
+        thoth.create_location.return_value = 'created-location'
+        thoth.update_location.return_value = 'updated-location'
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        reconciler.select_work_ids = MagicMock(return_value=[WORK_ID])
+        reconciler.inspect_work = MagicMock(
+            return_value=(before, context if context is not None else {}))
+        reconciler._inspect_remote = MagicMock(
+            return_value=final or result_for())
+        return reconciler
+
+    def _run(
+            self, reconciler, arguments, existing=(), environment=None,
+            capture_logs=False):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        environment = {} if environment is None else environment
+        contexts = [
+            patch.dict(os.environ, environment, clear=True),
+            patch(
+                'reconcile_internet_archive.load_local_environment',
+                return_value=None,
+            ),
+            patch(
+                'reconcile_internet_archive.InternetArchiveReconciler',
+                return_value=reconciler,
+            ),
+            patch(
+                'write_locations.retrieve_existing_locations',
+                return_value=list(existing),
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ]
+        for context in contexts:
+            context.__enter__()
+        log_context = self.assertLogs(level='INFO') if capture_logs else None
+        log_watcher = None
+        try:
+            if log_context is not None:
+                log_watcher = log_context.__enter__()
+            status = main(arguments)
+        finally:
+            if log_context is not None:
+                log_context.__exit__(None, None, None)
+            for context in reversed(contexts):
+                context.__exit__(None, None, None)
+        return SimpleNamespace(
+            status=status,
+            stdout=stdout.getvalue(),
+            stderr=stderr.getvalue(),
+            logs=[] if log_watcher is None else log_watcher.output,
+        )
+
+    def test_apply_create_keeps_default_json_stdout_parseable(self):
+        before = result_for(
+            status='location_missing',
+            actions=('create_thoth_location',),
+        )
+        reconciler = self._reconciler(before, apply_context())
+
+        run = self._run(
+            reconciler,
+            ['--work-id', WORK_ID, '--apply'],
+            environment=CREDENTIALS,
+            capture_logs=True,
+        )
+
+        report = json.loads(run.stdout)
+        self.assertEqual(run.status, 0)
+        self.assertEqual(report['results'][0]['status'], 'current')
+        self.assertNotIn('created-location', run.stdout)
+        self.assertIn('created-location', '\n'.join(run.logs))
+
+    def test_apply_update_keeps_default_json_stdout_parseable(self):
+        before = result_for(
+            status='location_stale',
+            actions=('update_thoth_location',),
+        )
+        reconciler = self._reconciler(before, apply_context())
+
+        run = self._run(
+            reconciler,
+            ['--work-id', WORK_ID, '--apply'],
+            existing=[existing_location(
+                landingPage='https://archive.org/details/old')],
+            environment=CREDENTIALS,
+        )
+
+        json.loads(run.stdout)
+        self.assertNotIn('updated-location', run.stdout)
+        reconciler.thoth.update_location.assert_called_once()
+
+    def test_apply_location_jsonl_has_only_json_lines(self):
+        before = result_for(
+            status='location_missing',
+            actions=('create_thoth_location',),
+        )
+        reconciler = self._reconciler(before, apply_context())
+
+        run = self._run(
+            reconciler,
+            ['--work-id', WORK_ID, '--apply', '--format', 'jsonl'],
+            environment=CREDENTIALS,
+        )
+
+        lines = run.stdout.strip().splitlines()
+        self.assertEqual(len(lines), 2)
+        for line in lines:
+            json.loads(line)
+        self.assertFalse(any(line == 'created-location' for line in lines))
+
+    def test_output_file_receives_report_and_stdout_stays_empty(self):
+        before = result_for(
+            status='location_missing',
+            actions=('create_thoth_location',),
+        )
+        reconciler = self._reconciler(before, apply_context())
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / 'report.json'
+            run = self._run(
+                reconciler,
+                [
+                    '--work-id', WORK_ID,
+                    '--apply',
+                    '--output', str(output),
+                ],
+                environment=CREDENTIALS,
+                capture_logs=True,
+            )
+            report = json.loads(output.read_text(encoding='utf-8'))
+
+        self.assertEqual(run.stdout, '')
+        self.assertEqual(report['results'][0]['status'], 'current')
+        self.assertIn('created-location', '\n'.join(run.logs))
+
+    def test_dry_run_without_credentials_has_valid_json_stdout(self):
+        reconciler = self._reconciler(result_for())
+
+        run = self._run(reconciler, ['--work-id', WORK_ID])
+
+        report = json.loads(run.stdout)
+        self.assertEqual(run.status, 0)
+        self.assertEqual(report['results'][0]['status'], 'current')
+
+    def test_apply_without_location_action_keeps_json_contract(self):
+        reconciler = self._reconciler(result_for())
+
+        run = self._run(
+            reconciler,
+            ['--work-id', WORK_ID, '--apply'],
+            environment=CREDENTIALS,
+        )
+
+        report = json.loads(run.stdout)
+        self.assertEqual(report['results'][0]['applied_actions'], [])
+        reconciler.thoth.create_location.assert_not_called()
+        reconciler.thoth.update_location.assert_not_called()
+
+    def test_location_mutation_failure_still_emits_valid_report_only(self):
+        before = result_for(
+            status='location_missing',
+            actions=('create_thoth_location',),
+        )
+        reconciler = self._reconciler(before, apply_context())
+        reconciler.thoth.create_location.side_effect = RuntimeError(
+            'mutation failed before an ID existed')
+
+        run = self._run(
+            reconciler,
+            ['--work-id', WORK_ID, '--apply'],
+            environment=CREDENTIALS,
+        )
+
+        report = json.loads(run.stdout)
+        self.assertEqual(run.status, 1)
+        self.assertIn(
+            'thoth_location_mutation_failed',
+            report['results'][0]['issues'],
+        )
+        self.assertNotIn('created-location', run.stdout)
+
+    def test_multiple_location_mutations_do_not_add_jsonl_id_lines(self):
+        first_before = result_for(
+            status='location_missing',
+            actions=('create_thoth_location',),
+        )
+        second_before = result_for(
+            WORK_ID_2,
+            status='location_missing',
+            actions=('create_thoth_location',),
+        )
+        reconciler = self._reconciler(first_before, apply_context())
+        reconciler.select_work_ids.return_value = [WORK_ID, WORK_ID_2]
+        reconciler.inspect_work.side_effect = [
+            (first_before, apply_context()),
+            (second_before, apply_context()),
+        ]
+        reconciler._inspect_remote.side_effect = [
+            result_for(WORK_ID),
+            result_for(WORK_ID_2),
+        ]
+        reconciler.thoth.create_location.side_effect = [
+            'first-location',
+            'second-location',
+        ]
+
+        run = self._run(
+            reconciler,
+            [
+                '--work-id', WORK_ID,
+                '--work-id', WORK_ID_2,
+                '--apply',
+                '--format', 'jsonl',
+            ],
+            environment=CREDENTIALS,
+        )
+
+        lines = run.stdout.strip().splitlines()
+        self.assertEqual(len(lines), 3)
+        for line in lines:
+            json.loads(line)
+        self.assertNotIn('first-location', run.stdout)
+        self.assertNotIn('second-location', run.stdout)
+
+
+class TestLocalEnvironmentLoading(unittest.TestCase):
+    def test_config_only_apply_credentials_pass_validation(self):
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, {}, clear=True):
+            config = Path(directory) / 'config.env'
+            write_config(config)
+
+            load_local_environment(config)
+            credentials = validate_apply_credentials()
+
+        self.assertEqual(credentials, CREDENTIALS)
+
+    def test_main_loads_config_before_validation_and_client_creation(self):
+        events = []
+        reconciler = MagicMock()
+        reconciler.select_work_ids.return_value = []
+        reconciler.reconcile.return_value = []
+
+        def load():
+            events.append('load')
+
+        def validate():
+            events.append('validate')
+            return CREDENTIALS
+
+        def create():
+            events.append('create')
+            return reconciler
+
+        with patch(
+                'reconcile_internet_archive.load_local_environment',
+                side_effect=load), patch(
+                'reconcile_internet_archive.validate_apply_credentials',
+                side_effect=validate), patch(
+                'reconcile_internet_archive.InternetArchiveReconciler',
+                side_effect=create), redirect_stdout(io.StringIO()):
+            status = main(['--work-id', WORK_ID, '--apply'])
+
+        self.assertEqual(status, 0)
+        self.assertEqual(events, ['load', 'validate', 'create'])
+
+    def test_process_environment_overrides_config_file(self):
+        process_values = {
+            'ia_s3_access': 'process-access',
+            'ia_s3_secret': 'process-secret',
+            'THOTH_PAT': 'process-token',
+        }
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, process_values, clear=True):
+            config = Path(directory) / 'config.env'
+            write_config(config)
+
+            load_local_environment(config)
+            credentials = validate_apply_credentials()
+
+        self.assertEqual(credentials, process_values)
+
+    def test_missing_config_file_is_harmless(self):
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, {}, clear=True):
+            missing = Path(directory) / 'missing-config.env'
+            self.assertIsNone(load_local_environment(missing))
+
+    def test_partial_config_reports_exact_missing_variables(self):
+        partial = {'ia_s3_access': 'access'}
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, {}, clear=True):
+            config = Path(directory) / 'config.env'
+            write_config(config, partial)
+            load_local_environment(config)
+
+            with self.assertRaisesRegex(
+                    ReconciliationConfigurationError,
+                    r'Apply mode requires: ia_s3_secret, THOTH_PAT$'):
+                validate_apply_credentials()
+
+    def test_dry_run_succeeds_without_credentials_or_config_file(self):
+        reconciler = MagicMock()
+        reconciler.select_work_ids.return_value = [WORK_ID]
+        reconciler.reconcile.return_value = [result_for()]
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, {}, clear=True), patch(
+                'reconcile_internet_archive.load_local_environment',
+                side_effect=lambda: load_local_environment(
+                    Path(directory) / 'missing.env')), patch(
+                'reconcile_internet_archive.InternetArchiveReconciler',
+                return_value=reconciler), redirect_stdout(io.StringIO()):
+            status = main(['--work-id', WORK_ID])
+
+        self.assertEqual(status, 0)
+
+    def test_github_style_process_environment_works_without_config(self):
+        reconciler = MagicMock()
+        reconciler.select_work_ids.return_value = [WORK_ID]
+        reconciler.reconcile.return_value = [result_for()]
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, CREDENTIALS, clear=True), patch(
+                'reconcile_internet_archive.load_local_environment',
+                side_effect=lambda: load_local_environment(
+                    Path(directory) / 'missing.env')), patch(
+                'reconcile_internet_archive.InternetArchiveReconciler',
+                return_value=reconciler), redirect_stdout(io.StringIO()):
+            status = main(['--work-id', WORK_ID, '--apply'])
+
+        self.assertEqual(status, 0)
+        reconciler.thoth.set_token.assert_called_once_with(
+            CREDENTIALS['THOTH_PAT'])
+
+    def test_config_thoth_pat_is_passed_to_client(self):
+        reconciler = MagicMock()
+        reconciler.select_work_ids.return_value = [WORK_ID]
+        reconciler.reconcile.return_value = [result_for()]
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, {}, clear=True):
+            config = Path(directory) / 'config.env'
+            write_config(config)
+            with patch(
+                    'reconcile_internet_archive.load_local_environment',
+                    side_effect=lambda: load_local_environment(config)), patch(
+                    'reconcile_internet_archive.InternetArchiveReconciler',
+                    return_value=reconciler), redirect_stdout(io.StringIO()):
+                status = main(['--work-id', WORK_ID, '--apply'])
+
+        self.assertEqual(status, 0)
+        reconciler.thoth.set_token.assert_called_once_with(
+            CREDENTIALS['THOTH_PAT'])
+
+    def test_config_archive_credentials_reach_selected_mutation(self):
+        before = result_for(
+            status='metadata_stale',
+            actions=('update_archive_metadata',),
+        )
+        context = apply_context()
+        reconciler = InternetArchiveReconciler(thoth=MagicMock())
+        reconciler.inspect_work = MagicMock(return_value=(before, context))
+        reconciler._inspect_remote = MagicMock(return_value=result_for())
+
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, {}, clear=True):
+            config = Path(directory) / 'config.env'
+            write_config(config)
+            load_local_environment(config)
+            credentials = validate_apply_credentials()
+            result = reconciler.reconcile_one(
+                WORK_ID,
+                apply=True,
+                credentials=credentials,
+            )
+
+        self.assertEqual(result['status'], 'current')
+        context['uploader'].apply_archive_repairs.assert_called_once()
+        call = context['uploader'].apply_archive_repairs.call_args
+        self.assertEqual(call.kwargs['access_key'], 'config-access')
+        self.assertEqual(call.kwargs['secret_key'], 'config-secret')
+
+    def test_current_apply_does_not_consume_archive_credentials(self):
+        context = apply_context()
+        reconciler = InternetArchiveReconciler(thoth=MagicMock())
+        reconciler.inspect_work = MagicMock(
+            return_value=(result_for(), context))
+
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, {}, clear=True):
+            config = Path(directory) / 'config.env'
+            write_config(config)
+            load_local_environment(config)
+            credentials = validate_apply_credentials()
+            result = reconciler.reconcile_one(
+                WORK_ID,
+                apply=True,
+                credentials=credentials,
+            )
+
+        self.assertEqual(result['status'], 'current')
+        context['uploader'].apply_archive_repairs.assert_not_called()
+
+    def test_import_does_not_load_config(self):
+        module_path = (
+            Path(__file__).resolve().parents[1]
+            / 'reconcile_internet_archive.py'
+        )
+        spec = importlib.util.spec_from_file_location(
+            'reconcile_import_probe',
+            module_path,
+        )
+        module = importlib.util.module_from_spec(spec)
+
+        with patch('dotenv.load_dotenv') as load_dotenv:
+            spec.loader.exec_module(module)
+
+        load_dotenv.assert_not_called()
+
+    def test_config_secret_in_exception_is_redacted_from_report(self):
+        reconciler = InternetArchiveReconciler(thoth=MagicMock())
+        reconciler.select_work_ids = MagicMock(return_value=[WORK_ID])
+        reconciler.reconcile_one = MagicMock(
+            side_effect=RuntimeError(
+                'remote rejected {}'.format(CREDENTIALS['ia_s3_secret'])))
+        stdout = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+                os.environ, {}, clear=True):
+            config = Path(directory) / 'config.env'
+            write_config(config)
+            with patch(
+                    'reconcile_internet_archive.load_local_environment',
+                    side_effect=lambda: load_local_environment(config)), patch(
+                    'reconcile_internet_archive.InternetArchiveReconciler',
+                    return_value=reconciler), redirect_stdout(stdout):
+                status = main(['--work-id', WORK_ID, '--apply'])
+
+        self.assertEqual(status, 1)
+        json.loads(stdout.getvalue())
+        self.assertNotIn(CREDENTIALS['ia_s3_secret'], stdout.getvalue())
+        self.assertIn('[REDACTED]', stdout.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -1522,6 +1522,10 @@ class TestApplyMode(unittest.TestCase):
             'upload_pdf_original',
             'create_thoth_location',
         ], status='files_stale')
+        post_archive = repairable_result(
+            ['create_thoth_location'],
+            status='location_missing',
+        )
         context = apply_context()
 
         def fail_location(*args, **kwargs):
@@ -1530,7 +1534,9 @@ class TestApplyMode(unittest.TestCase):
 
         with patch.object(
                 self.reconciler, 'inspect_work',
-                return_value=(before, context)), patch(
+                return_value=(before, context)), patch.object(
+                    self.reconciler, '_inspect_remote',
+                    return_value=post_archive) as inspect_remote, patch(
                     'reconcile_internet_archive.upsert_location',
                     side_effect=fail_location) as upsert:
             result = self.reconciler.reconcile_one(
@@ -1544,8 +1550,48 @@ class TestApplyMode(unittest.TestCase):
             result['applied_actions'], ['upload_pdf_original'])
         self.assertIn(
             'thoth_location_mutation_failed', result['issues'])
+        self.assertIn('location_missing', result['issues'])
+        self.assertNotIn('files_stale', result['issues'])
+        self.assertEqual(
+            result['recommended_actions'], ['create_thoth_location'])
+        self.assertNotIn(
+            'upload_pdf_original', result['recommended_actions'])
         self.assertNotIn('archive_mutation_failed', result['issues'])
+        self.assertEqual(result['before'], before)
+        inspect_remote.assert_called_once()
         upsert.assert_called_once()
+
+    def test_partial_apply_reinspection_failure_retains_both_diagnostics(self):
+        before = repairable_result([
+            'upload_pdf_original',
+            'create_thoth_location',
+        ], status='files_stale')
+        context = apply_context()
+
+        def fail_location(*args, **kwargs):
+            kwargs['progress']('create_thoth_location', 'attempted')
+            raise RuntimeError('location failed')
+
+        with patch.object(
+                self.reconciler, 'inspect_work',
+                return_value=(before, context)), patch.object(
+                    self.reconciler, '_inspect_remote',
+                    side_effect=RuntimeError('inspection failed')), patch(
+                    'reconcile_internet_archive.upsert_location',
+                    side_effect=fail_location):
+            result = self.reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        self.assertEqual(
+            result['applied_actions'], ['upload_pdf_original'])
+        self.assertIn('location failed', result['error'])
+        self.assertIn(
+            'post-apply reinspection failed: inspection failed',
+            result['error'],
+        )
+        self.assertIn(
+            'thoth_location_mutation_failed', result['issues'])
+        self.assertEqual(result['before'], before)
 
     def test_successful_mixed_repair_runs_both_phases_and_verification(self):
         context = apply_context()

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -88,13 +88,17 @@ def original_file(name, contents):
 
 
 class FakeItem:
-    def __init__(self, exists=True, metadata=None, files=None):
+    def __init__(
+            self, exists=True, metadata=None, files=None,
+            identifier_available=True):
         self.identifier = WORK_ID
         self.exists = exists
         self.metadata = dict(metadata or {})
         self.files = list(files or [])
         self.refresh = MagicMock()
         self.modify_metadata = MagicMock()
+        self.identifier_available = MagicMock(
+            return_value=identifier_available)
 
 
 def desired_metadata(metadata=None):
@@ -301,10 +305,12 @@ class TestDryRunInspection(unittest.TestCase):
         self.assertEqual(result['issues'], [])
 
     def test_missing_archive_item(self):
-        result, _, _, _ = self.harness.inspect(
-            item=FakeItem(exists=False), locations=[])
+        item = FakeItem(exists=False)
+        result, _, _, _ = self.harness.inspect(item=item, locations=[])
 
         self.assertEqual(result['status'], 'item_missing')
+        self.assertTrue(result['internet_archive']['identifier_available'])
+        item.identifier_available.assert_called_once_with()
         self.assertEqual(result['recommended_actions'], [
             'create_archive_item',
             'upload_pdf_original',
@@ -313,6 +319,52 @@ class TestDryRunInspection(unittest.TestCase):
         ])
         self.assertEqual(
             result['auto_applicable_actions'], result['recommended_actions'])
+
+    def test_unavailable_identifier_is_collision_not_missing(self):
+        item = FakeItem(exists=False, identifier_available=False)
+
+        result, _, _, _ = self.harness.inspect(item=item, locations=[])
+
+        self.assertEqual(result['status'], 'identifier_collision')
+        self.assertIn('identifier_collision', result['issues'])
+        self.assertNotIn('item_missing', result['issues'])
+        self.assertFalse(
+            result['internet_archive']['identifier_available'])
+        self.assertIn(
+            'no public item metadata was available',
+            result['internet_archive']['ownership_reason'],
+        )
+        self.assertEqual(result['auto_applicable_actions'], [])
+        item.identifier_available.assert_called_once_with()
+
+    def test_identifier_availability_failure_is_archive_request_error(self):
+        item = FakeItem(exists=False)
+        item.identifier_available.side_effect = RuntimeError(
+            'availability endpoint failed')
+
+        result, _, _, _ = self.harness.inspect(item=item, locations=[])
+
+        self.assertIn('archive_request_failed', result['issues'])
+        self.assertNotIn('item_missing', result['issues'])
+        self.assertIn('availability endpoint failed', result['error'])
+        self.assertEqual(result['auto_applicable_actions'], [])
+
+    def test_discoverable_state_uses_unavailable_identifier_rule(self):
+        item = FakeItem(exists=False, identifier_available=False)
+
+        result, _, _, _ = self.harness.inspect(
+            item=item,
+            locations=[],
+            pdf_error=DisseminationError('PDF unavailable'),
+        )
+
+        self.assertIn('pdf_source_unavailable', result['issues'])
+        self.assertIn('identifier_collision', result['issues'])
+        self.assertNotIn('item_missing', result['issues'])
+        self.assertFalse(
+            result['internet_archive']['identifier_available'])
+        self.assertEqual(result['auto_applicable_actions'], [])
+        item.identifier_available.assert_called_once_with()
 
     def test_missing_pdf_original(self):
         result, _, _, _ = self.harness.inspect(item=current_item(files=[
@@ -858,6 +910,48 @@ class TestApplyMode(unittest.TestCase):
         self.assertEqual(result['attempted_actions'], [])
         archive_repair.assert_not_called()
         upsert.assert_not_called()
+
+    def test_unavailable_identifier_apply_performs_zero_mutations(self):
+        thoth = MagicMock()
+        thoth.work_by_id.return_value = json.dumps(work_metadata())
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        item = FakeItem(exists=False, identifier_available=False)
+        with patch.object(
+                IAUploader, 'get_formatted_metadata',
+                return_value=JSON_BYTES), patch.object(
+                    IAUploader, 'get_publication_details',
+                    return_value=Publication(
+                        'PDF', PUBLICATION_ID, PDF_BYTES, '.pdf',
+                        'https://source.example/book.pdf')), \
+                patch('reconcile_internet_archive.get_item',
+                      return_value=item), patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    return_value=[]), patch.object(
+                    IAUploader, 'apply_archive_repairs') as archive_repair, \
+                patch('reconcile_internet_archive.upsert_location') as upsert:
+            result = reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        self.assertIn('identifier_collision', result['issues'])
+        self.assertEqual(result['auto_applicable_actions'], [])
+        self.assertEqual(result['attempted_actions'], [])
+        archive_repair.assert_not_called()
+        upsert.assert_not_called()
+        item.modify_metadata.assert_not_called()
+
+    def test_availability_failure_mixed_batch_continues(self):
+        failed = repairable_result([], status='error')
+        failed['issues'] = ['archive_request_failed']
+        failed['error'] = 'identifier availability request failed'
+        with patch.object(
+                self.reconciler, 'reconcile_one',
+                side_effect=[failed, current_result()]) as reconcile_one:
+            results = self.reconciler.reconcile(
+                [WORK_ID, WORK_ID_2], apply=True, credentials=CREDENTIALS)
+
+        self.assertEqual(results[0]['issues'], ['archive_request_failed'])
+        self.assertEqual(results[1]['status'], 'current')
+        self.assertEqual(reconcile_one.call_count, 2)
 
     def test_real_orchestration_records_successful_archive_repair(self):
         item = current_item(files=[

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -1903,7 +1903,8 @@ class TestOutput(unittest.TestCase):
             output = Path(directory) / 'report.json'
             with patch(
                     'reconcile_internet_archive.InternetArchiveReconciler',
-                    return_value=reconciler):
+                    return_value=reconciler), patch(
+                    'reconcile_internet_archive.load_local_environment'):
                 status = main([
                     '--work-id', WORK_ID,
                     '--output', str(output),

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -406,6 +406,135 @@ class TestDryRunInspection(unittest.TestCase):
         self.assertIn('title', result['internet_archive']['metadata'][
             'patch_fields'])
 
+    def test_immutable_mediatype_conflict_is_reported_for_manual_action(self):
+        metadata = desired_metadata()
+        metadata['mediatype'] = 'data'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertEqual(result['status'], 'metadata_conflict')
+        self.assertIn(
+            'archive_immutable_metadata_conflict', result['issues'])
+        self.assertIn(
+            'resolve_archive_immutable_metadata',
+            result['recommended_actions'],
+        )
+        archive_metadata = result['internet_archive']['metadata']
+        self.assertEqual(archive_metadata['mutable_problems'], [])
+        self.assertEqual(archive_metadata['immutable_problems'], [
+            "mediatype is 'data', expected 'texts'",
+        ])
+        self.assertNotIn('mediatype', archive_metadata['patch_fields'])
+
+    def test_immutable_only_conflict_is_not_mutable_metadata_drift(self):
+        metadata = desired_metadata()
+        metadata['mediatype'] = 'data'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertNotIn('archive_metadata_stale', result['issues'])
+        self.assertNotIn(
+            'update_archive_metadata', result['recommended_actions'])
+
+    def test_immutable_and_mutable_metadata_drift_retain_both_actions(self):
+        metadata = desired_metadata()
+        metadata['mediatype'] = 'data'
+        metadata['title'] = 'Old title'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertIn(
+            'archive_immutable_metadata_conflict', result['issues'])
+        self.assertIn('archive_metadata_stale', result['issues'])
+        self.assertEqual(result['recommended_actions'], [
+            'resolve_archive_immutable_metadata',
+            'update_archive_metadata',
+        ])
+        archive_metadata = result['internet_archive']['metadata']
+        self.assertEqual(archive_metadata['immutable_problems'], [
+            "mediatype is 'data', expected 'texts'",
+        ])
+        self.assertIn('title', archive_metadata['patch_fields'])
+        self.assertNotIn('mediatype', archive_metadata['patch_fields'])
+
+    def test_immutable_conflict_retains_missing_file_recommendations(self):
+        metadata = desired_metadata()
+        metadata['mediatype'] = 'data'
+
+        result, _, _, _ = self.harness.inspect(item=FakeItem(
+            exists=True,
+            metadata=metadata,
+            files=[],
+        ))
+
+        self.assertEqual(result['recommended_actions'], [
+            'resolve_archive_immutable_metadata',
+            'upload_pdf_original',
+            'upload_json_original',
+        ])
+        self.assertIn('missing_pdf_original', result['issues'])
+        self.assertIn('missing_json_original', result['issues'])
+
+    def test_immutable_conflict_retains_missing_location_recommendation(self):
+        metadata = desired_metadata()
+        metadata['mediatype'] = 'data'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata),
+            locations=[],
+        )
+
+        self.assertEqual(result['recommended_actions'], [
+            'resolve_archive_immutable_metadata',
+            'create_thoth_location',
+        ])
+        self.assertIn('location_missing', result['issues'])
+
+    def test_immutable_conflict_blocks_all_auto_applicable_actions(self):
+        metadata = desired_metadata()
+        metadata['mediatype'] = 'data'
+        metadata['title'] = 'Old title'
+
+        result, _, _, _ = self.harness.inspect(
+            item=FakeItem(exists=True, metadata=metadata, files=[]),
+            locations=[],
+        )
+
+        self.assertEqual(result['auto_applicable_actions'], [])
+        self.assertIn('update_archive_metadata', result[
+            'recommended_actions'])
+        self.assertIn('upload_pdf_original', result['recommended_actions'])
+        self.assertIn('create_thoth_location', result[
+            'recommended_actions'])
+
+    def test_correct_mediatype_with_mutable_drift_is_auto_repairable(self):
+        metadata = desired_metadata()
+        metadata['title'] = 'Old title'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertEqual(result['status'], 'metadata_stale')
+        self.assertEqual(
+            result['auto_applicable_actions'],
+            ['update_archive_metadata'],
+        )
+        self.assertEqual(
+            result['internet_archive']['metadata']['immutable_problems'], [])
+
+    def test_immutable_conflict_report_is_deterministic_across_inspections(self):
+        metadata = desired_metadata()
+        metadata['mediatype'] = 'data'
+        item = current_item(metadata=metadata)
+
+        first, _, _, _ = self.harness.inspect(item=item, locations=[])
+        second, _, _, _ = self.harness.inspect(item=item, locations=[])
+
+        self.assertEqual(first, second)
+
     def test_multiple_archive_discrepancies_are_ordered(self):
         metadata = desired_metadata()
         metadata['title'] = 'Old title'
@@ -1062,6 +1191,41 @@ class TestApplyMode(unittest.TestCase):
         upsert.assert_not_called()
         item.modify_metadata.assert_not_called()
 
+    def test_immutable_conflict_apply_performs_zero_mutations(self):
+        metadata = desired_metadata()
+        metadata['mediatype'] = 'data'
+        metadata.pop('thoth-work-id')
+        item = FakeItem(exists=True, metadata=metadata, files=[])
+        thoth = MagicMock()
+        thoth.work_by_id.return_value = json.dumps(work_metadata())
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        publication = Publication(
+            'PDF', PUBLICATION_ID, PDF_BYTES, '.pdf',
+            'https://source.example/book.pdf')
+
+        with patch.object(
+                IAUploader, 'get_formatted_metadata',
+                return_value=JSON_BYTES), patch.object(
+                    IAUploader, 'get_publication_details',
+                    return_value=publication), patch(
+                    'reconcile_internet_archive.get_item',
+                    return_value=item), patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    return_value=[]), patch.object(
+                    IAUploader, 'apply_archive_repairs') as archive_repair, \
+                patch('iauploader.upload') as upload, patch(
+                    'reconcile_internet_archive.upsert_location') as upsert:
+            result = reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        self.assertEqual(result['status'], 'metadata_conflict')
+        self.assertEqual(result['auto_applicable_actions'], [])
+        self.assertEqual(result['attempted_actions'], [])
+        archive_repair.assert_not_called()
+        upload.assert_not_called()
+        item.modify_metadata.assert_not_called()
+        upsert.assert_not_called()
+
     def test_availability_failure_mixed_batch_continues(self):
         failed = repairable_result([], status='error')
         failed['issues'] = ['archive_request_failed']
@@ -1219,6 +1383,22 @@ class TestOutput(unittest.TestCase):
         self.assertEqual(summary['failed'], 1)
         self.assertEqual(summary['repairable'], 0)
         self.assertEqual(summary['ambiguous'], 0)
+
+    def test_metadata_conflict_is_ambiguous_not_repairable(self):
+        result = repairable_result(
+            ['resolve_archive_immutable_metadata'],
+            status='metadata_conflict',
+        )
+        result['issues'] = ['archive_immutable_metadata_conflict']
+        result['auto_applicable_actions'] = []
+
+        summary = summarise([result])
+
+        self.assertEqual(summary['repairable'], 0)
+        self.assertEqual(summary['ambiguous'], 1)
+        self.assertEqual(summary['failed'], 0)
+        self.assertEqual(summary['repaired'], 0)
+        self.assertEqual(summary['by_status'], {'metadata_conflict': 1})
 
     def test_output_redacts_credential_values(self):
         result = current_result()

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -833,36 +833,69 @@ class TestApplyMode(unittest.TestCase):
         self.assertEqual(result['status'], 'error')
         self.assertIn('verification_failed', result['issues'])
 
-    def test_verification_timeout_reports_failure(self):
+    def test_archive_verification_timeout_does_not_attempt_location(self):
         context = apply_context()
-        context['uploader'].apply_archive_repairs.side_effect = \
-            InternetArchiveVerificationError('timed out')
-        before = repairable_result(['upload_pdf_original'], 'files_stale')
+        before = repairable_result([
+            'upload_pdf_original',
+            'create_thoth_location',
+        ], 'files_stale')
 
-        result, _, _ = self._apply(before, context)
+        def fail_verification(*args, **kwargs):
+            progress = kwargs['progress']
+            progress('upload_pdf_original', 'attempted')
+            progress('upload_pdf_original', 'completed')
+            raise InternetArchiveVerificationError('timed out')
+
+        context['uploader'].apply_archive_repairs.side_effect = \
+            fail_verification
+
+        result, _, upsert = self._apply(before, context)
 
         self.assertEqual(result['status'], 'error')
+        self.assertEqual(
+            result['attempted_actions'], ['upload_pdf_original'])
+        self.assertEqual(result['applied_actions'], [])
+        self.assertEqual(
+            result['uncertain_actions'], ['upload_pdf_original'])
         self.assertIn('verification_failed', result['issues'])
+        self.assertNotIn(
+            'create_thoth_location', result['attempted_actions'])
+        upsert.assert_not_called()
 
     def test_second_identical_apply_run_makes_zero_mutations(self):
         context = apply_context()
-        before = repairable_result(['update_archive_metadata'], 'metadata_stale')
-        current = current_result()
+        before = repairable_result([
+            'update_archive_metadata',
+            'create_thoth_location',
+        ], 'metadata_stale')
+        verification_current = current_result()
+        second_current = current_result()
         with patch.object(
                 self.reconciler, 'inspect_work',
-                side_effect=[(before, context), (current, context)]), \
+                side_effect=[
+                    (before, context),
+                    (second_current, context),
+                ]), \
                 patch.object(
                     self.reconciler, '_inspect_remote',
-                    return_value=current), patch(
-                    'reconcile_internet_archive.upsert_location'):
+                    return_value=verification_current), patch(
+                    'reconcile_internet_archive.upsert_location',
+                    return_value='location-id') as upsert:
             first = self.reconciler.reconcile_one(
                 WORK_ID, apply=True, credentials=CREDENTIALS)
             second = self.reconciler.reconcile_one(
                 WORK_ID, apply=True, credentials=CREDENTIALS)
 
         self.assertEqual(first['status'], 'current')
+        self.assertEqual(first['applied_actions'], [
+            'update_archive_metadata',
+            'create_thoth_location',
+        ])
         self.assertEqual(second['status'], 'current')
+        self.assertEqual(second['attempted_actions'], [])
+        self.assertEqual(second['applied_actions'], [])
         context['uploader'].apply_archive_repairs.assert_called_once()
+        upsert.assert_called_once()
 
     def test_applied_result_records_before_actions_and_final_state(self):
         context = apply_context()
@@ -874,16 +907,106 @@ class TestApplyMode(unittest.TestCase):
         self.assertEqual(result['applied_actions'], ['upload_pdf_original'])
         self.assertEqual(result['status'], 'current')
 
-    def test_archive_mutation_failure_is_recorded(self):
+    def test_archive_dissemination_error_does_not_attempt_location(self):
         context = apply_context()
         context['uploader'].apply_archive_repairs.side_effect = \
             DisseminationError('upload failed')
-        before = repairable_result(['upload_pdf_original'], 'files_stale')
+        before = repairable_result([
+            'upload_pdf_original',
+            'create_thoth_location',
+        ], 'files_stale')
 
-        result, _, _ = self._apply(before, context)
+        result, _, upsert = self._apply(before, context)
 
         self.assertEqual(result['status'], 'error')
+        self.assertEqual(result['attempted_actions'], [])
         self.assertIn('archive_mutation_failed', result['issues'])
+        self.assertNotIn(
+            'thoth_location_mutation_failed', result['issues'])
+        upsert.assert_not_called()
+
+    def test_archive_unexpected_error_does_not_attempt_location(self):
+        context = apply_context()
+        context['uploader'].apply_archive_repairs.side_effect = \
+            RuntimeError('unexpected archive failure')
+        before = repairable_result([
+            'upload_pdf_original',
+            'create_thoth_location',
+        ], 'files_stale')
+
+        result, _, upsert = self._apply(before, context)
+
+        self.assertEqual(result['attempted_actions'], [])
+        self.assertEqual(result['applied_actions'], [])
+        self.assertIn('archive_mutation_failed', result['issues'])
+        self.assertNotIn(
+            'thoth_location_mutation_failed', result['issues'])
+        upsert.assert_not_called()
+
+    def test_archive_only_unexpected_error_is_archive_failure(self):
+        context = apply_context()
+        context['uploader'].apply_archive_repairs.side_effect = \
+            RuntimeError('unexpected archive failure')
+        before = repairable_result(
+            ['upload_pdf_original'], 'files_stale')
+
+        result, _, upsert = self._apply(before, context)
+
+        self.assertEqual(result['attempted_actions'], [])
+        self.assertIn('archive_mutation_failed', result['issues'])
+        upsert.assert_not_called()
+
+    def test_archive_success_then_location_failure_preserves_progress(self):
+        before = repairable_result([
+            'upload_pdf_original',
+            'create_thoth_location',
+        ], status='files_stale')
+        context = apply_context()
+
+        def fail_location(*args, **kwargs):
+            kwargs['progress']('create_thoth_location', 'attempted')
+            raise RuntimeError('location failed')
+
+        with patch.object(
+                self.reconciler, 'inspect_work',
+                return_value=(before, context)), patch(
+                    'reconcile_internet_archive.upsert_location',
+                    side_effect=fail_location) as upsert:
+            result = self.reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        self.assertEqual(result['attempted_actions'], [
+            'upload_pdf_original',
+            'create_thoth_location',
+        ])
+        self.assertEqual(
+            result['applied_actions'], ['upload_pdf_original'])
+        self.assertIn(
+            'thoth_location_mutation_failed', result['issues'])
+        self.assertNotIn('archive_mutation_failed', result['issues'])
+        upsert.assert_called_once()
+
+    def test_successful_mixed_repair_runs_both_phases_and_verification(self):
+        context = apply_context()
+        before = repairable_result([
+            'upload_pdf_original',
+            'create_thoth_location',
+        ], 'files_stale')
+
+        result, inspect_remote, upsert = self._apply(before, context)
+
+        context['uploader'].apply_archive_repairs.assert_called_once()
+        upsert.assert_called_once()
+        inspect_remote.assert_called_once()
+        self.assertEqual(result['attempted_actions'], [
+            'upload_pdf_original',
+            'create_thoth_location',
+        ])
+        self.assertEqual(result['applied_actions'], [
+            'upload_pdf_original',
+            'create_thoth_location',
+        ])
+        self.assertEqual(result['status'], 'current')
 
     def test_ineligible_explicit_work_is_never_mutated(self):
         metadata = work_metadata(workStatus='DRAFT')
@@ -1020,11 +1143,16 @@ class TestApplyMode(unittest.TestCase):
         before = repairable_result(
             ['create_thoth_location'], status='location_missing')
         context = apply_context()
+
+        def fail_location(*args, **kwargs):
+            kwargs['progress']('create_thoth_location', 'attempted')
+            raise RuntimeError('location failed')
+
         with patch.object(
                 self.reconciler, 'inspect_work',
                 return_value=(before, context)), patch(
                     'reconcile_internet_archive.upsert_location',
-                    side_effect=RuntimeError('location failed')):
+                    side_effect=fail_location):
             result = self.reconciler.reconcile_one(
                 WORK_ID, apply=True, credentials=CREDENTIALS)
 
@@ -1032,6 +1160,7 @@ class TestApplyMode(unittest.TestCase):
             'create_thoth_location'])
         self.assertEqual(result['applied_actions'], [])
         self.assertIn('thoth_location_mutation_failed', result['issues'])
+        context['uploader'].apply_archive_repairs.assert_not_called()
 
 
 class TestOutput(unittest.TestCase):

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -21,6 +21,7 @@ from reconcile_internet_archive import (
     validate_apply_credentials,
 )
 from uploader import Publication
+from version import __version__
 
 
 WORK_ID = '11111111-2222-3333-4444-555555555555'
@@ -99,7 +100,7 @@ class FakeItem:
 def desired_metadata(metadata=None):
     uploader = IAUploader.__new__(IAUploader)
     uploader.work_id = WORK_ID
-    uploader.version = '1.3.2'
+    uploader.version = __version__
     uploader.metadata = metadata or work_metadata()
     return uploader.parse_metadata()
 
@@ -136,7 +137,8 @@ class InspectionHarness:
         thoth = MagicMock()
         thoth.work_by_id.return_value = json.dumps(metadata or work_metadata())
         reconciler = InternetArchiveReconciler(thoth=thoth)
-        item = item if item is not None else current_item(metadata)
+        item = item if item is not None else current_item(
+            metadata=desired_metadata(metadata))
         locations = [current_location()] if locations is None else locations
         json_side_effect = json_error
         pdf_side_effect = pdf_error
@@ -198,6 +200,18 @@ class TestSelectionAndCLI(unittest.TestCase):
                 PUBLISHER_ID, [WORK_ID_2, WORK_ID_3], 100, 0)
 
         self.assertEqual(selected, [WORK_ID, WORK_ID_2, WORK_ID_3])
+        self.assertEqual(reconciler.selection_by_work_id[WORK_ID_2], {
+            'explicit': True,
+            'publisher': True,
+        })
+        self.assertEqual(reconciler.selection_by_work_id[WORK_ID], {
+            'explicit': False,
+            'publisher': True,
+        })
+        self.assertEqual(reconciler.selection_by_work_id[WORK_ID_3], {
+            'explicit': True,
+            'publisher': False,
+        })
 
     def test_invalid_uuid_is_rejected(self):
         with redirect_stderr(io.StringIO()):
@@ -227,8 +241,27 @@ class TestSelectionAndCLI(unittest.TestCase):
             metadata=work_metadata(workStatus='DRAFT'))
 
         self.assertFalse(result['eligible'])
-        self.assertEqual(result['status'], 'ineligible')
         self.assertIn('ineligible_status', result['issues'])
+        self.assertTrue(result['internet_archive']['exists'])
+
+    def test_explicit_inactive_work_with_pdf_is_remotely_inspected(self):
+        result, _, get_item, get_locations = InspectionHarness().inspect(
+            metadata=work_metadata(workStatus='DRAFT'))
+
+        self.assertFalse(result['eligible'])
+        self.assertTrue(result['selection']['explicit'])
+        self.assertIn('ineligible_status', result['issues'])
+        get_item.assert_called_once_with(WORK_ID)
+        get_locations.assert_called_once()
+
+    def test_explicit_unsupported_work_with_pdf_is_remotely_inspected(self):
+        result, _, get_item, get_locations = InspectionHarness().inspect(
+            metadata=work_metadata(workType='CHAPTER'))
+
+        self.assertFalse(result['eligible'])
+        self.assertIn('unsupported_work_type', result['issues'])
+        get_item.assert_called_once_with(WORK_ID)
+        get_locations.assert_called_once()
 
     def test_publisher_selection_excludes_works_without_pdf(self):
         thoth = MagicMock()
@@ -272,7 +305,14 @@ class TestDryRunInspection(unittest.TestCase):
             item=FakeItem(exists=False), locations=[])
 
         self.assertEqual(result['status'], 'item_missing')
-        self.assertIn('create_archive_item', result['recommended_actions'])
+        self.assertEqual(result['recommended_actions'], [
+            'create_archive_item',
+            'upload_pdf_original',
+            'upload_json_original',
+            'create_thoth_location',
+        ])
+        self.assertEqual(
+            result['auto_applicable_actions'], result['recommended_actions'])
 
     def test_missing_pdf_original(self):
         result, _, _, _ = self.harness.inspect(item=current_item(files=[
@@ -343,8 +383,29 @@ class TestDryRunInspection(unittest.TestCase):
 
         self.assertEqual(result['status'], 'identifier_collision')
         self.assertEqual(
-            result['recommended_actions'], ['resolve_identifier_collision'])
+            result['recommended_actions'], [
+                'resolve_identifier_collision', 'create_thoth_location'])
+        self.assertEqual(result['auto_applicable_actions'], [])
         self.assertIn('location_missing', result['issues'])
+
+    def test_ineligible_work_retains_remote_issues_and_has_no_auto_actions(self):
+        result, _, _, _ = self.harness.inspect(
+            metadata=work_metadata(workStatus='DRAFT'),
+            item=FakeItem(exists=False),
+            locations=[],
+        )
+
+        self.assertIn('ineligible_status', result['issues'])
+        self.assertIn('item_missing', result['issues'])
+        self.assertIn('location_missing', result['issues'])
+        self.assertEqual(result['recommended_actions'], [
+            'fix_work_eligibility',
+            'create_archive_item',
+            'upload_pdf_original',
+            'upload_json_original',
+            'create_thoth_location',
+        ])
+        self.assertEqual(result['auto_applicable_actions'], [])
 
     def test_unknown_ownership_is_collision(self):
         metadata = desired_metadata()
@@ -361,8 +422,8 @@ class TestDryRunInspection(unittest.TestCase):
 
         self.assertEqual(result['status'], 'source_unavailable')
         self.assertEqual(result['issues'], ['pdf_source_unavailable'])
-        get_item.assert_not_called()
-        get_locations.assert_not_called()
+        get_item.assert_called_once_with(WORK_ID)
+        get_locations.assert_called_once()
 
     def test_json_export_unavailable(self):
         result, _, _, _ = self.harness.inspect(
@@ -393,6 +454,27 @@ class TestDryRunInspection(unittest.TestCase):
         self.assertEqual(
             result['recommended_actions'], ['resolve_duplicate_locations'])
 
+    def test_duplicate_locations_retain_independent_archive_recommendation(self):
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(files=[
+                original_file(PDF_NAME, b'old'),
+                original_file(JSON_NAME, JSON_BYTES),
+            ]),
+            locations=[
+                current_location(locationId='two'),
+                current_location(locationId='one'),
+            ],
+        )
+
+        self.assertEqual(result['recommended_actions'], [
+            'upload_pdf_original', 'resolve_duplicate_locations'])
+        self.assertEqual(result['auto_applicable_actions'], [])
+        self.assertEqual(
+            [location['location_id']
+             for location in result['thoth_location']['locations']],
+            ['one', 'two'],
+        )
+
     def test_archive_current_but_location_checksum_stale(self):
         result, _, _, _ = self.harness.inspect(locations=[
             current_location(checksum='old')])
@@ -419,6 +501,35 @@ class TestDryRunInspection(unittest.TestCase):
         self.assertEqual(unrelated['original_files'], ['unrelated.txt'])
         self.assertIn('unrelated-field', unrelated['metadata_fields'])
         self.assertEqual(unrelated['collections'], ['another-collection'])
+
+    def test_unrelated_collection_reporting_is_sorted(self):
+        metadata = desired_metadata()
+        metadata['collection'] = [
+            'zeta', IAUploader.THOTH_COLLECTION, 'alpha']
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertEqual(
+            result['internet_archive']['unrelated']['collections'],
+            ['alpha', 'zeta'],
+        )
+
+    def test_recommended_and_auto_actions_use_stable_ordering(self):
+        metadata = desired_metadata()
+        metadata['title'] = 'old'
+        result, _, _, _ = self.harness.inspect(
+            item=FakeItem(exists=True, metadata=metadata, files=[]),
+            locations=[],
+        )
+
+        expected = [
+            'upload_pdf_original',
+            'upload_json_original',
+            'update_archive_metadata',
+            'create_thoth_location',
+        ]
+        self.assertEqual(result['recommended_actions'], expected)
+        self.assertEqual(result['auto_applicable_actions'], expected)
 
     def test_dry_run_makes_zero_mutations(self):
         item = current_item(files=[original_file(PDF_NAME, PDF_BYTES)])
@@ -465,6 +576,17 @@ def repairable_result(actions, status='item_missing'):
         'status': status,
         'issues': [status],
         'recommended_actions': list(actions),
+        'auto_applicable_actions': [
+            action for action in actions
+            if action in {
+                'create_archive_item',
+                'upload_pdf_original',
+                'upload_json_original',
+                'update_archive_metadata',
+                'create_thoth_location',
+                'update_thoth_location',
+            }
+        ],
         'error': None,
     })
     return result
@@ -509,6 +631,43 @@ class TestApplyMode(unittest.TestCase):
                 WORK_ID, apply=True, credentials=CREDENTIALS)
         return result, inspect_remote, upsert
 
+    def _real_archive_apply(self, item, upload_side_effect=None, metadata=None):
+        thoth = MagicMock()
+        thoth.work_by_id.return_value = json.dumps(metadata or work_metadata())
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        publication = Publication(
+            'PDF', PUBLICATION_ID, PDF_BYTES, '.pdf',
+            'https://source.example/book.pdf')
+        response = MagicMock(status_code=200, text='')
+        response.json.return_value = {'success': True}
+        if upload_side_effect is None:
+            def upload_side_effect(**kwargs):
+                for name, file_object in kwargs['files'].items():
+                    item.files = [
+                        entry for entry in item.files
+                        if entry.get('name') != name
+                    ]
+                    item.files.append(original_file(name, file_object.read()))
+                if kwargs.get('metadata') is not None:
+                    item.metadata = dict(kwargs['metadata'])
+                item.exists = True
+                return [response]
+
+        with patch.object(
+                IAUploader, 'get_formatted_metadata',
+                return_value=JSON_BYTES), patch.object(
+                    IAUploader, 'get_publication_details',
+                    return_value=publication), patch(
+                    'reconcile_internet_archive.get_item',
+                    return_value=item), patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    return_value=[current_location()]), patch(
+                    'iauploader.upload', side_effect=upload_side_effect
+                ) as upload:
+            result = reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+        return result, upload
+
     def test_apply_without_credentials_fails_before_mutation(self):
         with self.assertRaises(ReconciliationConfigurationError):
             validate_apply_credentials({})
@@ -551,8 +710,10 @@ class TestApplyMode(unittest.TestCase):
         result, _, upsert = self._apply(before, context)
 
         context['uploader'].apply_archive_repairs.assert_not_called()
-        upsert.assert_called_once_with(
-            self.reconciler.thoth, context['location_input'])
+        upsert.assert_called_once()
+        self.assertEqual(upsert.call_args.args, (
+            self.reconciler.thoth, context['location_input']))
+        self.assertIn('progress', upsert.call_args.kwargs)
         self.assertEqual(result['applied_actions'], ['create_thoth_location'])
 
     def test_stale_location_does_not_mutate_current_archive(self):
@@ -672,6 +833,112 @@ class TestApplyMode(unittest.TestCase):
         self.assertEqual(result['status'], 'error')
         self.assertIn('archive_mutation_failed', result['issues'])
 
+    def test_ineligible_explicit_work_is_never_mutated(self):
+        metadata = work_metadata(workStatus='DRAFT')
+        thoth = MagicMock()
+        thoth.work_by_id.return_value = json.dumps(metadata)
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        with patch.object(
+                IAUploader, 'get_formatted_metadata',
+                return_value=JSON_BYTES), patch.object(
+                    IAUploader, 'get_publication_details',
+                    return_value=Publication(
+                        'PDF', PUBLICATION_ID, PDF_BYTES, '.pdf',
+                        'https://source.example/book.pdf')), \
+                patch('reconcile_internet_archive.get_item',
+                      return_value=FakeItem(exists=False)), patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    return_value=[]), patch.object(
+                    IAUploader, 'apply_archive_repairs') as archive_repair, \
+                patch('reconcile_internet_archive.upsert_location') as upsert:
+            result = reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        self.assertFalse(result['eligible'])
+        self.assertEqual(result['attempted_actions'], [])
+        archive_repair.assert_not_called()
+        upsert.assert_not_called()
+
+    def test_real_orchestration_records_successful_archive_repair(self):
+        item = current_item(files=[
+            original_file(PDF_NAME, b'old'),
+            original_file(JSON_NAME, JSON_BYTES),
+        ])
+
+        result, upload = self._real_archive_apply(item)
+
+        self.assertEqual(result['status'], 'current')
+        self.assertEqual(result['attempted_actions'], ['upload_pdf_original'])
+        self.assertEqual(result['applied_actions'], ['upload_pdf_original'])
+        self.assertEqual(result['uncertain_actions'], [])
+        upload.assert_called_once()
+
+    def test_real_orchestration_timeout_records_uncertain_activity(self):
+        item = current_item(files=[
+            original_file(PDF_NAME, b'old'),
+            original_file(JSON_NAME, JSON_BYTES),
+        ])
+        response = MagicMock(status_code=200, text='')
+        response.json.return_value = {'success': True}
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 1):
+            result, _ = self._real_archive_apply(
+                item, upload_side_effect=lambda **kwargs: [response])
+
+        self.assertEqual(result['status'], 'error')
+        self.assertEqual(result['attempted_actions'], ['upload_pdf_original'])
+        self.assertEqual(result['applied_actions'], [])
+        self.assertEqual(result['uncertain_actions'], ['upload_pdf_original'])
+        self.assertIn('verification_failed', result['issues'])
+
+    def test_real_orchestration_partial_archive_failure_is_accurate(self):
+        metadata = desired_metadata()
+        metadata['title'] = 'old'
+        item = current_item(metadata=metadata, files=[
+            original_file(PDF_NAME, b'old'),
+            original_file(JSON_NAME, JSON_BYTES),
+        ])
+        item.modify_metadata.side_effect = RuntimeError('metadata failed')
+
+        result, _ = self._real_archive_apply(item)
+
+        self.assertEqual(result['attempted_actions'], [
+            'upload_pdf_original', 'update_archive_metadata'])
+        self.assertEqual(result['applied_actions'], ['upload_pdf_original'])
+        self.assertIn('archive_mutation_failed', result['issues'])
+
+    def test_real_orchestration_second_apply_is_mutation_free(self):
+        item = current_item(files=[
+            original_file(PDF_NAME, b'old'),
+            original_file(JSON_NAME, JSON_BYTES),
+        ])
+
+        first, upload = self._real_archive_apply(item)
+        second, second_upload = self._real_archive_apply(item)
+
+        self.assertEqual(first['applied_actions'], ['upload_pdf_original'])
+        self.assertEqual(second['status'], 'current')
+        self.assertEqual(second['attempted_actions'], [])
+        upload.assert_called_once()
+        second_upload.assert_not_called()
+
+    def test_location_failure_records_attempt_without_success(self):
+        before = repairable_result(
+            ['create_thoth_location'], status='location_missing')
+        context = apply_context()
+        with patch.object(
+                self.reconciler, 'inspect_work',
+                return_value=(before, context)), patch(
+                    'reconcile_internet_archive.upsert_location',
+                    side_effect=RuntimeError('location failed')):
+            result = self.reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        self.assertEqual(result['attempted_actions'], [
+            'create_thoth_location'])
+        self.assertEqual(result['applied_actions'], [])
+        self.assertIn('thoth_location_mutation_failed', result['issues'])
+
 
 class TestOutput(unittest.TestCase):
     def test_json_output_is_deterministic(self):
@@ -716,6 +983,19 @@ class TestOutput(unittest.TestCase):
                 'current': 2,
             },
         })
+
+    def test_ineligible_remote_discrepancy_is_failed_not_repairable(self):
+        result = repairable_result(
+            ['create_archive_item'], status='item_missing')
+        result['eligible'] = False
+        result['issues'] = ['ineligible_status', 'item_missing']
+        result['auto_applicable_actions'] = []
+
+        summary = summarise([result])
+
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['repairable'], 0)
+        self.assertEqual(summary['ambiguous'], 0)
 
     def test_output_redacts_credential_values(self):
         result = current_result()

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -1,0 +1,753 @@
+import hashlib
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from errors import DisseminationError, InternetArchiveVerificationError
+from iauploader import IAUploader
+from reconcile_internet_archive import (
+    InternetArchiveReconciler,
+    ReconciliationConfigurationError,
+    _base_result,
+    main,
+    parse_arguments,
+    render_report,
+    summarise,
+    validate_apply_credentials,
+)
+from uploader import Publication
+
+
+WORK_ID = '11111111-2222-3333-4444-555555555555'
+WORK_ID_2 = '22222222-3333-4444-5555-666666666666'
+WORK_ID_3 = '33333333-4444-5555-6666-777777777777'
+PUBLISHER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+PUBLICATION_ID = '99999999-8888-7777-6666-555555555555'
+PDF_BYTES = b'current PDF bytes'
+JSON_BYTES = b'{"current":"metadata"}'
+PDF_MD5 = hashlib.md5(PDF_BYTES).hexdigest()
+PDF_NAME = '{}.pdf'.format(WORK_ID)
+JSON_NAME = '{}.json'.format(WORK_ID)
+LANDING_PAGE = 'https://archive.org/details/{}'.format(WORK_ID)
+FULL_TEXT_URL = 'https://archive.org/download/{}/{}'.format(
+    WORK_ID, PDF_NAME)
+
+
+def work_metadata(**overrides):
+    work = {
+        'workId': WORK_ID,
+        'workType': 'MONOGRAPH',
+        'workStatus': 'ACTIVE',
+        'fullTitle': 'A Test Book',
+        'title': 'A Test Book',
+        'publicationDate': '2026-01-02',
+        'longAbstract': 'A long description',
+        'pageCount': 250,
+        'lccn': '2026000001',
+        'license': 'https://creativecommons.org/licenses/by/4.0/',
+        'oclc': '12345',
+        'doi': 'https://doi.org/10.0000/test',
+        'contributions': [
+            {'fullName': 'First Author', 'mainContribution': True},
+        ],
+        'publications': [{
+            'publicationType': 'PDF',
+            'publicationId': PUBLICATION_ID,
+            'isbn': '978-1-234-56789-0',
+            'locations': [{
+                'canonical': True,
+                'fullTextUrl': 'https://source.example/book.pdf',
+            }],
+        }],
+        'subjects': [{'subjectCode': 'ABC123'}],
+        'languages': [{'languageCode': 'eng'}],
+        'issues': [],
+        'imprint': {
+            'publisher': {
+                'publisherId': PUBLISHER_ID,
+                'publisherName': 'Test Publisher',
+            },
+        },
+    }
+    work.update(overrides)
+    return {'data': {'work': work}}
+
+
+def original_file(name, contents):
+    return {
+        'name': name,
+        'source': 'original',
+        'md5': hashlib.md5(contents).hexdigest(),
+    }
+
+
+class FakeItem:
+    def __init__(self, exists=True, metadata=None, files=None):
+        self.identifier = WORK_ID
+        self.exists = exists
+        self.metadata = dict(metadata or {})
+        self.files = list(files or [])
+        self.refresh = MagicMock()
+        self.modify_metadata = MagicMock()
+
+
+def desired_metadata(metadata=None):
+    uploader = IAUploader.__new__(IAUploader)
+    uploader.work_id = WORK_ID
+    uploader.version = '1.3.2'
+    uploader.metadata = metadata or work_metadata()
+    return uploader.parse_metadata()
+
+
+def current_item(metadata=None, files=None):
+    return FakeItem(
+        metadata=metadata or desired_metadata(),
+        files=files or [
+            original_file(PDF_NAME, PDF_BYTES),
+            original_file(JSON_NAME, JSON_BYTES),
+        ],
+    )
+
+
+def current_location(**overrides):
+    location = {
+        'locationId': 'location-1',
+        'publicationId': PUBLICATION_ID,
+        'locationPlatform': 'INTERNET_ARCHIVE',
+        'landingPage': LANDING_PAGE,
+        'fullTextUrl': FULL_TEXT_URL,
+        'canonical': False,
+        'checksum': PDF_MD5,
+        'checksumAlgorithm': 'MD5',
+    }
+    location.update(overrides)
+    return location
+
+
+class InspectionHarness:
+    def inspect(self, item=None, locations=None, metadata=None,
+                json_bytes=JSON_BYTES, pdf_bytes=PDF_BYTES,
+                json_error=None, pdf_error=None):
+        thoth = MagicMock()
+        thoth.work_by_id.return_value = json.dumps(metadata or work_metadata())
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        item = item if item is not None else current_item(metadata)
+        locations = [current_location()] if locations is None else locations
+        json_side_effect = json_error
+        pdf_side_effect = pdf_error
+        publication = Publication(
+            'PDF', PUBLICATION_ID, pdf_bytes, '.pdf',
+            'https://source.example/book.pdf')
+        with patch.object(
+                IAUploader, 'get_formatted_metadata',
+                return_value=json_bytes, side_effect=json_side_effect), \
+                patch.object(
+                    IAUploader, 'get_publication_details',
+                    return_value=publication, side_effect=pdf_side_effect), \
+                patch(
+                    'reconcile_internet_archive.get_item',
+                    return_value=item) as get_item, \
+                patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    return_value=locations) as get_locations:
+            result, context = reconciler.inspect_work(WORK_ID)
+        return result, context, get_item, get_locations
+
+
+class TestSelectionAndCLI(unittest.TestCase):
+    def test_publisher_selection_is_stable_before_limit_and_offset(self):
+        thoth = MagicMock()
+        thoth.publisher.return_value = SimpleNamespace(publisherId=PUBLISHER_ID)
+        thoth.works.return_value = [
+            SimpleNamespace(
+                workId=WORK_ID_3,
+                publications=[SimpleNamespace(publicationType='PDF')]),
+            SimpleNamespace(
+                workId=WORK_ID,
+                publications=[SimpleNamespace(publicationType='PDF')]),
+            SimpleNamespace(
+                workId=WORK_ID_2,
+                publications=[SimpleNamespace(publicationType='PDF')]),
+        ]
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+
+        selected = reconciler.publisher_work_ids(PUBLISHER_ID, 1, 1)
+
+        self.assertEqual(selected, [WORK_ID_2])
+        kwargs = thoth.works.call_args.kwargs
+        self.assertEqual(kwargs['work_statuses'], '[ACTIVE]')
+        self.assertNotIn('CHAPTER', kwargs['work_types'])
+
+    def test_repeatable_explicit_work_ids_are_parsed(self):
+        arguments = parse_arguments([
+            '--work-id', WORK_ID, '--work-id', WORK_ID_2])
+
+        self.assertEqual(arguments.work_id, [WORK_ID, WORK_ID_2])
+
+    def test_combined_selection_is_deduplicated_and_sorted(self):
+        reconciler = InternetArchiveReconciler(thoth=MagicMock())
+        with patch.object(
+                reconciler, 'publisher_work_ids',
+                return_value=[WORK_ID_2, WORK_ID]):
+            selected = reconciler.select_work_ids(
+                PUBLISHER_ID, [WORK_ID_2, WORK_ID_3], 100, 0)
+
+        self.assertEqual(selected, [WORK_ID, WORK_ID_2, WORK_ID_3])
+
+    def test_invalid_uuid_is_rejected(self):
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                parse_arguments(['--work-id', 'not-a-uuid'])
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_missing_selection_criteria_is_rejected(self):
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                parse_arguments([])
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_invalid_limit_is_rejected(self):
+        for value in ('0', '-1'):
+            with self.subTest(value=value), redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit):
+                    parse_arguments(['--work-id', WORK_ID, '--limit', value])
+
+    def test_invalid_offset_is_rejected(self):
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                parse_arguments(['--work-id', WORK_ID, '--offset', '-1'])
+
+    def test_explicit_ineligible_work_is_reported(self):
+        result, _, _, _ = InspectionHarness().inspect(
+            metadata=work_metadata(workStatus='DRAFT'))
+
+        self.assertFalse(result['eligible'])
+        self.assertEqual(result['status'], 'ineligible')
+        self.assertIn('ineligible_status', result['issues'])
+
+    def test_publisher_selection_excludes_works_without_pdf(self):
+        thoth = MagicMock()
+        thoth.publisher.return_value = object()
+        thoth.works.return_value = [
+            SimpleNamespace(workId=WORK_ID, publications=[]),
+            SimpleNamespace(
+                workId=WORK_ID_2,
+                publications=[SimpleNamespace(publicationType='EPUB')]),
+            SimpleNamespace(
+                workId=WORK_ID_3,
+                publications=[SimpleNamespace(publicationType='PDF')]),
+        ]
+
+        selected = InternetArchiveReconciler(
+            thoth=thoth).publisher_work_ids(PUBLISHER_ID, 100, 0)
+
+        self.assertEqual(selected, [WORK_ID_3])
+
+    def test_unknown_publisher_fails_initial_selection(self):
+        thoth = MagicMock()
+        thoth.publisher.side_effect = RuntimeError('not found')
+
+        with self.assertRaises(ReconciliationConfigurationError):
+            InternetArchiveReconciler(thoth=thoth).publisher_work_ids(
+                PUBLISHER_ID, 100, 0)
+
+
+class TestDryRunInspection(unittest.TestCase):
+    def setUp(self):
+        self.harness = InspectionHarness()
+
+    def test_current_work(self):
+        result, _, _, _ = self.harness.inspect()
+
+        self.assertEqual(result['status'], 'current')
+        self.assertEqual(result['issues'], [])
+
+    def test_missing_archive_item(self):
+        result, _, _, _ = self.harness.inspect(
+            item=FakeItem(exists=False), locations=[])
+
+        self.assertEqual(result['status'], 'item_missing')
+        self.assertIn('create_archive_item', result['recommended_actions'])
+
+    def test_missing_pdf_original(self):
+        result, _, _, _ = self.harness.inspect(item=current_item(files=[
+            original_file(JSON_NAME, JSON_BYTES)]))
+
+        self.assertEqual(result['status'], 'item_incomplete')
+        self.assertIn('missing_pdf_original', result['issues'])
+
+    def test_missing_json_original(self):
+        result, _, _, _ = self.harness.inspect(item=current_item(files=[
+            original_file(PDF_NAME, PDF_BYTES)]))
+
+        self.assertIn('missing_json_original', result['issues'])
+
+    def test_stale_pdf_original(self):
+        result, _, _, _ = self.harness.inspect(item=current_item(files=[
+            original_file(PDF_NAME, b'old'),
+            original_file(JSON_NAME, JSON_BYTES),
+        ]))
+
+        self.assertEqual(result['status'], 'files_stale')
+        self.assertIn('upload_pdf_original', result['recommended_actions'])
+
+    def test_stale_json_original(self):
+        result, _, _, _ = self.harness.inspect(item=current_item(files=[
+            original_file(PDF_NAME, PDF_BYTES),
+            original_file(JSON_NAME, b'old'),
+        ]))
+
+        self.assertIn('stale_json_original', result['issues'])
+
+    def test_stale_metadata(self):
+        metadata = desired_metadata()
+        metadata['title'] = 'Old title'
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertEqual(result['status'], 'metadata_stale')
+        self.assertIn('title', result['internet_archive']['metadata'][
+            'patch_fields'])
+
+    def test_multiple_archive_discrepancies_are_ordered(self):
+        metadata = desired_metadata()
+        metadata['title'] = 'Old title'
+        result, _, _, _ = self.harness.inspect(item=current_item(
+            metadata=metadata,
+            files=[original_file(PDF_NAME, PDF_BYTES)],
+        ))
+
+        self.assertEqual(result['status'], 'item_incomplete')
+        self.assertEqual(result['issues'], [
+            'missing_json_original', 'archive_metadata_stale'])
+
+    def test_accepted_legacy_item_is_reported(self):
+        metadata = desired_metadata()
+        metadata.pop('thoth-work-id')
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertTrue(result['internet_archive']['accepted_legacy_item'])
+        self.assertIn('update_archive_metadata', result['recommended_actions'])
+
+    def test_conflicting_work_marker_is_collision(self):
+        metadata = desired_metadata()
+        metadata['thoth-work-id'] = 'another-work'
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata), locations=[])
+
+        self.assertEqual(result['status'], 'identifier_collision')
+        self.assertEqual(
+            result['recommended_actions'], ['resolve_identifier_collision'])
+        self.assertIn('location_missing', result['issues'])
+
+    def test_unknown_ownership_is_collision(self):
+        metadata = desired_metadata()
+        metadata.pop('thoth-work-id')
+        metadata['collection'] = 'not-thoth'
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertEqual(result['status'], 'identifier_collision')
+
+    def test_pdf_source_unavailable(self):
+        result, _, get_item, get_locations = self.harness.inspect(
+            pdf_error=DisseminationError('download failed'))
+
+        self.assertEqual(result['status'], 'source_unavailable')
+        self.assertEqual(result['issues'], ['pdf_source_unavailable'])
+        get_item.assert_not_called()
+        get_locations.assert_not_called()
+
+    def test_json_export_unavailable(self):
+        result, _, _, _ = self.harness.inspect(
+            json_error=DisseminationError('export failed'))
+
+        self.assertEqual(result['issues'], ['json_export_unavailable'])
+
+    def test_missing_thoth_location(self):
+        result, _, _, _ = self.harness.inspect(locations=[])
+
+        self.assertEqual(result['status'], 'location_missing')
+        self.assertEqual(result['thoth_location']['count'], 0)
+
+    def test_stale_thoth_location(self):
+        result, _, _, _ = self.harness.inspect(locations=[
+            current_location(landingPage='https://archive.org/details/old')])
+
+        self.assertEqual(result['status'], 'location_stale')
+        self.assertEqual(result['thoth_location']['location_id'], 'location-1')
+
+    def test_duplicate_thoth_locations(self):
+        result, _, _, _ = self.harness.inspect(locations=[
+            current_location(locationId='one'),
+            current_location(locationId='two'),
+        ])
+
+        self.assertEqual(result['status'], 'duplicate_locations')
+        self.assertEqual(
+            result['recommended_actions'], ['resolve_duplicate_locations'])
+
+    def test_archive_current_but_location_checksum_stale(self):
+        result, _, _, _ = self.harness.inspect(locations=[
+            current_location(checksum='old')])
+
+        self.assertEqual(result['status'], 'location_stale')
+        self.assertTrue(result['internet_archive']['metadata']['current'])
+
+    def test_unrelated_archive_data_is_ignored_but_reported(self):
+        metadata = desired_metadata()
+        metadata['unrelated-field'] = 'keep'
+        metadata['collection'] = [
+            IAUploader.THOTH_COLLECTION, 'another-collection']
+        result, _, _, _ = self.harness.inspect(item=current_item(
+            metadata=metadata,
+            files=[
+                original_file(PDF_NAME, PDF_BYTES),
+                original_file(JSON_NAME, JSON_BYTES),
+                original_file('unrelated.txt', b'keep'),
+            ],
+        ))
+
+        self.assertEqual(result['status'], 'current')
+        unrelated = result['internet_archive']['unrelated']
+        self.assertEqual(unrelated['original_files'], ['unrelated.txt'])
+        self.assertIn('unrelated-field', unrelated['metadata_fields'])
+        self.assertEqual(unrelated['collections'], ['another-collection'])
+
+    def test_dry_run_makes_zero_mutations(self):
+        item = current_item(files=[original_file(PDF_NAME, PDF_BYTES)])
+        result, _, _, _ = self.harness.inspect(item=item, locations=[])
+
+        self.assertNotEqual(result['status'], 'current')
+        item.modify_metadata.assert_not_called()
+
+    def test_dry_run_does_not_require_write_credentials(self):
+        with patch.dict('reconcile_internet_archive.environ', {}, clear=True):
+            result, _, _, _ = self.harness.inspect()
+
+        self.assertEqual(result['status'], 'current')
+
+    def test_location_lookup_failure_is_distinct(self):
+        thoth = MagicMock()
+        thoth.work_by_id.return_value = json.dumps(work_metadata())
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        with patch.object(
+                IAUploader, 'get_formatted_metadata',
+                return_value=JSON_BYTES), patch.object(
+                    IAUploader, 'get_publication_details',
+                    return_value=Publication(
+                        'PDF', PUBLICATION_ID, PDF_BYTES, '.pdf',
+                        'https://source.example/book.pdf')), patch(
+                    'reconcile_internet_archive.get_item',
+                    return_value=current_item()), patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    side_effect=RuntimeError('graphql down')):
+            result, _ = reconciler.inspect_work(WORK_ID)
+
+        self.assertIn('thoth_location_lookup_failed', result['issues'])
+        self.assertEqual(result['status'], 'error')
+
+
+def repairable_result(actions, status='item_missing'):
+    result = _base_result(WORK_ID)
+    result.update({
+        'publisher_id': PUBLISHER_ID,
+        'title': 'A Test Book',
+        'publication_id': PUBLICATION_ID,
+        'pdf_source_url': 'https://source.example/book.pdf',
+        'eligible': True,
+        'status': status,
+        'issues': [status],
+        'recommended_actions': list(actions),
+        'error': None,
+    })
+    return result
+
+
+def current_result():
+    result = repairable_result([], status='current')
+    result['issues'] = []
+    return result
+
+
+def apply_context():
+    return {
+        'uploader': MagicMock(),
+        'desired': SimpleNamespace(publication_id=PUBLICATION_ID),
+        'item': object(),
+        'archive_inspection': {},
+        'location_input': object(),
+    }
+
+
+CREDENTIALS = {
+    'ia_s3_access': 'access',
+    'ia_s3_secret': 'secret',
+    'THOTH_PAT': 'token',
+}
+
+
+class TestApplyMode(unittest.TestCase):
+    def setUp(self):
+        self.reconciler = InternetArchiveReconciler(thoth=MagicMock())
+
+    def _apply(self, before, context, final=None):
+        final = final or current_result()
+        with patch.object(
+                self.reconciler, 'inspect_work',
+                return_value=(before, context)), patch.object(
+                    self.reconciler, '_inspect_remote',
+                    return_value=final) as inspect_remote, patch(
+                    'reconcile_internet_archive.upsert_location') as upsert:
+            result = self.reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+        return result, inspect_remote, upsert
+
+    def test_apply_without_credentials_fails_before_mutation(self):
+        with self.assertRaises(ReconciliationConfigurationError):
+            validate_apply_credentials({})
+
+    def test_missing_item_is_created_and_reinspected(self):
+        context = apply_context()
+        before = repairable_result(['create_archive_item'])
+
+        result, inspect_remote, _ = self._apply(before, context)
+
+        context['uploader'].apply_archive_repairs.assert_called_once()
+        inspect_remote.assert_called_once()
+        self.assertEqual(result['status'], 'current')
+
+    def test_partial_item_repairs_only_requested_original(self):
+        context = apply_context()
+        before = repairable_result(
+            ['upload_json_original'], status='item_incomplete')
+
+        result, _, _ = self._apply(before, context)
+
+        self.assertEqual(result['applied_actions'], ['upload_json_original'])
+        context['uploader'].apply_archive_repairs.assert_called_once()
+
+    def test_stale_metadata_is_updated(self):
+        context = apply_context()
+        before = repairable_result(
+            ['update_archive_metadata'], status='metadata_stale')
+
+        result, _, _ = self._apply(before, context)
+
+        self.assertEqual(result['applied_actions'], [
+            'update_archive_metadata'])
+
+    def test_missing_location_does_not_mutate_current_archive(self):
+        context = apply_context()
+        before = repairable_result(
+            ['create_thoth_location'], status='location_missing')
+
+        result, _, upsert = self._apply(before, context)
+
+        context['uploader'].apply_archive_repairs.assert_not_called()
+        upsert.assert_called_once_with(
+            self.reconciler.thoth, context['location_input'])
+        self.assertEqual(result['applied_actions'], ['create_thoth_location'])
+
+    def test_stale_location_does_not_mutate_current_archive(self):
+        context = apply_context()
+        before = repairable_result(
+            ['update_thoth_location'], status='location_stale')
+
+        _, _, upsert = self._apply(before, context)
+
+        context['uploader'].apply_archive_repairs.assert_not_called()
+        upsert.assert_called_once()
+
+    def test_collision_is_not_mutated(self):
+        context = apply_context()
+        before = repairable_result(
+            ['resolve_identifier_collision'], status='identifier_collision')
+        before['issues'] = ['identifier_collision']
+
+        with patch.object(
+                self.reconciler, 'inspect_work',
+                return_value=(before, context)), patch(
+                    'reconcile_internet_archive.upsert_location') as upsert:
+            result = self.reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        context['uploader'].apply_archive_repairs.assert_not_called()
+        upsert.assert_not_called()
+        self.assertEqual(result['status'], 'identifier_collision')
+
+    def test_duplicate_locations_are_not_mutated(self):
+        context = apply_context()
+        before = repairable_result(
+            ['resolve_duplicate_locations'], status='duplicate_locations')
+        before['issues'] = ['duplicate_locations']
+
+        with patch.object(
+                self.reconciler, 'inspect_work',
+                return_value=(before, context)), patch(
+                    'reconcile_internet_archive.upsert_location') as upsert:
+            self.reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        context['uploader'].apply_archive_repairs.assert_not_called()
+        upsert.assert_not_called()
+
+    def test_mixed_batch_continues_after_failed_result(self):
+        failed = repairable_result([], status='error')
+        failed['error'] = 'failed'
+        with patch.object(
+                self.reconciler, 'reconcile_one',
+                side_effect=[failed, current_result()]) as reconcile_one:
+            results = self.reconciler.reconcile(
+                [WORK_ID, WORK_ID_2], apply=True, credentials=CREDENTIALS)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(reconcile_one.call_count, 2)
+
+    def test_failed_final_verification_reports_failure(self):
+        context = apply_context()
+        before = repairable_result(['upload_pdf_original'], 'files_stale')
+        final = repairable_result(['upload_pdf_original'], 'files_stale')
+
+        result, _, _ = self._apply(before, context, final=final)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('verification_failed', result['issues'])
+
+    def test_verification_timeout_reports_failure(self):
+        context = apply_context()
+        context['uploader'].apply_archive_repairs.side_effect = \
+            InternetArchiveVerificationError('timed out')
+        before = repairable_result(['upload_pdf_original'], 'files_stale')
+
+        result, _, _ = self._apply(before, context)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('verification_failed', result['issues'])
+
+    def test_second_identical_apply_run_makes_zero_mutations(self):
+        context = apply_context()
+        before = repairable_result(['update_archive_metadata'], 'metadata_stale')
+        current = current_result()
+        with patch.object(
+                self.reconciler, 'inspect_work',
+                side_effect=[(before, context), (current, context)]), \
+                patch.object(
+                    self.reconciler, '_inspect_remote',
+                    return_value=current), patch(
+                    'reconcile_internet_archive.upsert_location'):
+            first = self.reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+            second = self.reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        self.assertEqual(first['status'], 'current')
+        self.assertEqual(second['status'], 'current')
+        context['uploader'].apply_archive_repairs.assert_called_once()
+
+    def test_applied_result_records_before_actions_and_final_state(self):
+        context = apply_context()
+        before = repairable_result(['upload_pdf_original'], 'files_stale')
+
+        result, _, _ = self._apply(before, context)
+
+        self.assertEqual(result['before'], before)
+        self.assertEqual(result['applied_actions'], ['upload_pdf_original'])
+        self.assertEqual(result['status'], 'current')
+
+    def test_archive_mutation_failure_is_recorded(self):
+        context = apply_context()
+        context['uploader'].apply_archive_repairs.side_effect = \
+            DisseminationError('upload failed')
+        before = repairable_result(['upload_pdf_original'], 'files_stale')
+
+        result, _, _ = self._apply(before, context)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertIn('archive_mutation_failed', result['issues'])
+
+
+class TestOutput(unittest.TestCase):
+    def test_json_output_is_deterministic(self):
+        results = [current_result()]
+
+        self.assertEqual(render_report(results), render_report(results))
+        parsed = json.loads(render_report(results))
+        self.assertEqual(parsed['results'][0]['work_id'], WORK_ID)
+
+    def test_jsonl_contains_one_work_per_line_and_summary(self):
+        report = render_report(
+            [current_result(), current_result()], output_format='jsonl')
+        lines = report.strip().splitlines()
+
+        self.assertEqual(len(lines), 3)
+        self.assertIn('work_id', json.loads(lines[0]))
+        self.assertIn('summary', json.loads(lines[-1]))
+
+    def test_summary_counts_are_correct(self):
+        repairable = repairable_result(
+            ['update_archive_metadata'], status='metadata_stale')
+        ambiguous = repairable_result(
+            ['resolve_identifier_collision'], status='identifier_collision')
+        failed = repairable_result([], status='error')
+        repaired = current_result()
+        repaired['applied_actions'] = ['update_archive_metadata']
+
+        summary = summarise([
+            current_result(), repairable, ambiguous, failed, repaired])
+
+        self.assertEqual(summary, {
+            'inspected': 5,
+            'current': 2,
+            'repairable': 1,
+            'ambiguous': 1,
+            'failed': 1,
+            'repaired': 1,
+            'by_status': {
+                'identifier_collision': 1,
+                'error': 1,
+                'metadata_stale': 1,
+                'current': 2,
+            },
+        })
+
+    def test_output_redacts_credential_values(self):
+        result = current_result()
+        result['error'] = 'request included super-secret-value'
+
+        report = render_report([result], secrets=['super-secret-value'])
+
+        self.assertNotIn('super-secret-value', report)
+        self.assertIn('[REDACTED]', report)
+
+    def test_report_is_written_when_some_works_fail(self):
+        failed = repairable_result([], status='error')
+        failed['error'] = 'remote failure'
+        reconciler = MagicMock()
+        reconciler.select_work_ids.return_value = [WORK_ID]
+        reconciler.reconcile.return_value = [failed]
+        reconciler.thoth = MagicMock()
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / 'report.json'
+            with patch(
+                    'reconcile_internet_archive.InternetArchiveReconciler',
+                    return_value=reconciler):
+                status = main([
+                    '--work-id', WORK_ID,
+                    '--output', str(output),
+                ])
+
+            self.assertEqual(status, 1)
+            self.assertEqual(
+                json.loads(output.read_text())['results'][0]['error'],
+                'remote failure')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -90,8 +90,8 @@ def original_file(name, contents):
 class FakeItem:
     def __init__(
             self, exists=True, metadata=None, files=None,
-            identifier_available=True):
-        self.identifier = WORK_ID
+            identifier_available=True, identifier=WORK_ID):
+        self.identifier = identifier
         self.exists = exists
         self.metadata = dict(metadata or {})
         self.files = list(files or [])
@@ -163,6 +163,297 @@ class InspectionHarness:
                     return_value=locations) as get_locations:
             result, context = reconciler.inspect_work(WORK_ID)
         return result, context, get_item, get_locations
+
+
+class TestOwnershipPreflight(unittest.TestCase):
+    def _inspect(
+            self, item, metadata=None, locations=None, json_error=None,
+            pdf_error=None, apply=False):
+        thoth = MagicMock()
+        thoth.work_by_id.return_value = json.dumps(metadata or work_metadata())
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        events = []
+        publication = Publication(
+            'PDF', PUBLICATION_ID, PDF_BYTES, '.pdf',
+            'https://source.example/book.pdf')
+        original_classify = IAUploader.classify_item_ownership
+        original_build = IAUploader.build_desired_state
+
+        def get_archive_item(identifier):
+            events.append('get_item')
+            self.assertEqual(identifier, WORK_ID)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        def classify(uploader, archive_item):
+            events.append('classify_ownership')
+            return original_classify(uploader, archive_item)
+
+        def build_desired(uploader):
+            events.append('build_desired_state')
+            return original_build(uploader)
+
+        def get_json(_uploader, _format):
+            events.append('get_json_export')
+            if json_error is not None:
+                raise json_error
+            return JSON_BYTES
+
+        def get_pdf(_uploader, _publication_type):
+            events.append('download_pdf')
+            if pdf_error is not None:
+                raise pdf_error
+            return publication
+
+        with patch(
+                'reconcile_internet_archive.get_item',
+                side_effect=get_archive_item) as get_item_mock, patch.object(
+                    IAUploader, 'classify_item_ownership',
+                    autospec=True, side_effect=classify), patch.object(
+                    IAUploader, 'build_desired_state',
+                    autospec=True, side_effect=build_desired) as build, \
+                patch.object(
+                    IAUploader, 'get_formatted_metadata',
+                    autospec=True, side_effect=get_json) as get_json_mock, \
+                patch.object(
+                    IAUploader, 'get_publication_details',
+                    autospec=True, side_effect=get_pdf) as get_pdf_mock, patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    return_value=(
+                        [current_location()] if locations is None else locations
+                    )) as get_locations, patch.object(
+                    IAUploader, 'apply_archive_repairs') as archive_repair, \
+                patch(
+                    'reconcile_internet_archive.upsert_location') as upsert:
+            if apply:
+                result = reconciler.reconcile_one(
+                    WORK_ID, apply=True, credentials=CREDENTIALS)
+                context = None
+            else:
+                result, context = reconciler.inspect_work(WORK_ID)
+
+        return SimpleNamespace(
+            result=result,
+            context=context,
+            events=events,
+            get_item=get_item_mock,
+            build=build,
+            get_json=get_json_mock,
+            get_pdf=get_pdf_mock,
+            get_locations=get_locations,
+            archive_repair=archive_repair,
+            upsert=upsert,
+        )
+
+    def test_conflicting_marker_stops_before_desired_state_and_sources(self):
+        metadata = desired_metadata()
+        metadata['thoth-work-id'] = 'another-work'
+        inspected = self._inspect(
+            FakeItem(exists=True, metadata=metadata),
+            locations=[],
+        )
+
+        self.assertEqual(
+            inspected.events, ['get_item', 'classify_ownership'])
+        self.assertIn('identifier_collision', inspected.result['issues'])
+        self.assertEqual(
+            inspected.result['recommended_actions'], [
+                'resolve_identifier_collision', 'create_thoth_location'])
+        self.assertEqual(inspected.result['auto_applicable_actions'], [])
+        inspected.get_item.assert_called_once_with(WORK_ID)
+        inspected.build.assert_not_called()
+        inspected.get_json.assert_not_called()
+        inspected.get_pdf.assert_not_called()
+
+    def test_unavailable_missing_identifier_checks_once_before_sources(self):
+        item = FakeItem(exists=False, identifier_available=False)
+
+        inspected = self._inspect(item, locations=[])
+
+        self.assertEqual(
+            inspected.events, ['get_item', 'classify_ownership'])
+        item.identifier_available.assert_called_once_with()
+        self.assertIn('identifier_collision', inspected.result['issues'])
+        self.assertNotIn('item_missing', inspected.result['issues'])
+        inspected.build.assert_not_called()
+        inspected.get_json.assert_not_called()
+        inspected.get_pdf.assert_not_called()
+
+    def test_availability_exception_stops_sources_as_archive_failure(self):
+        item = FakeItem(exists=False)
+        item.identifier_available.side_effect = RuntimeError(
+            'availability endpoint failed')
+
+        inspected = self._inspect(item, locations=[])
+
+        self.assertIn('archive_request_failed', inspected.result['issues'])
+        self.assertIn('availability endpoint failed', inspected.result['error'])
+        self.assertEqual(inspected.result['auto_applicable_actions'], [])
+        inspected.build.assert_not_called()
+        inspected.get_json.assert_not_called()
+        inspected.get_pdf.assert_not_called()
+
+    def test_archive_request_failure_stops_sources(self):
+        inspected = self._inspect(
+            RuntimeError('Archive request failed'),
+            locations=[],
+        )
+
+        self.assertIn('archive_request_failed', inspected.result['issues'])
+        self.assertIn('Archive request failed', inspected.result['error'])
+        self.assertEqual(inspected.result['auto_applicable_actions'], [])
+        inspected.build.assert_not_called()
+        inspected.get_json.assert_not_called()
+        inspected.get_pdf.assert_not_called()
+
+    def test_invalid_availability_response_stops_sources(self):
+        item = FakeItem(exists=False, identifier_available='unknown')
+
+        inspected = self._inspect(item, locations=[])
+
+        self.assertIn('archive_request_failed', inspected.result['issues'])
+        self.assertIn('invalid response', inspected.result['error'])
+        item.identifier_available.assert_called_once_with()
+        inspected.build.assert_not_called()
+        inspected.get_json.assert_not_called()
+        inspected.get_pdf.assert_not_called()
+
+    def test_owned_item_skips_availability_then_builds_desired_state(self):
+        item = current_item()
+
+        inspected = self._inspect(item)
+
+        self.assertEqual(inspected.events[:3], [
+            'get_item', 'classify_ownership', 'build_desired_state'])
+        item.identifier_available.assert_not_called()
+        inspected.get_item.assert_called_once_with(WORK_ID)
+        inspected.build.assert_called_once()
+        self.assertEqual(inspected.result['status'], 'current')
+
+    def test_legacy_item_skips_availability_then_builds_desired_state(self):
+        metadata = desired_metadata()
+        metadata.pop('thoth-work-id')
+        item = current_item(metadata=metadata)
+
+        inspected = self._inspect(item)
+
+        self.assertEqual(inspected.events[:3], [
+            'get_item', 'classify_ownership', 'build_desired_state'])
+        item.identifier_available.assert_not_called()
+        self.assertTrue(
+            inspected.result['internet_archive']['accepted_legacy_item'])
+
+    def test_available_missing_identifier_builds_after_single_check(self):
+        item = FakeItem(exists=False, identifier_available=True)
+
+        inspected = self._inspect(item, locations=[])
+
+        self.assertEqual(inspected.events[:3], [
+            'get_item', 'classify_ownership', 'build_desired_state'])
+        item.identifier_available.assert_called_once_with()
+        inspected.get_item.assert_called_once_with(WORK_ID)
+        self.assertIn('item_missing', inspected.result['issues'])
+        self.assertIn(
+            'create_archive_item', inspected.result['auto_applicable_actions'])
+
+    def test_pdf_failure_preserves_ownership_and_location_inventory(self):
+        item = current_item()
+
+        inspected = self._inspect(
+            item,
+            pdf_error=DisseminationError('broken PDF URL'),
+        )
+
+        self.assertIn('pdf_source_unavailable', inspected.result['issues'])
+        self.assertEqual(
+            inspected.result['internet_archive']['ownership'], 'owned')
+        self.assertIsNone(inspected.result['internet_archive']['expected'])
+        self.assertEqual(inspected.result['thoth_location']['state'], 'observed')
+        self.assertEqual(inspected.result['auto_applicable_actions'], [])
+        inspected.get_item.assert_called_once_with(WORK_ID)
+
+    def test_json_failure_preserves_ownership_and_location_inventory(self):
+        item = current_item()
+
+        inspected = self._inspect(
+            item,
+            json_error=DisseminationError('export unavailable'),
+        )
+
+        self.assertIn('json_export_unavailable', inspected.result['issues'])
+        self.assertEqual(
+            inspected.result['internet_archive']['ownership'], 'owned')
+        self.assertEqual(inspected.result['thoth_location']['count'], 1)
+        self.assertEqual(inspected.result['auto_applicable_actions'], [])
+        inspected.get_item.assert_called_once_with(WORK_ID)
+
+    def test_collision_observes_existing_location_without_auto_action(self):
+        metadata = desired_metadata()
+        metadata['thoth-work-id'] = 'another-work'
+
+        inspected = self._inspect(
+            FakeItem(exists=True, metadata=metadata),
+            locations=[current_location()],
+        )
+
+        self.assertEqual(inspected.result['thoth_location']['state'], 'observed')
+        self.assertEqual(
+            inspected.result['recommended_actions'],
+            ['resolve_identifier_collision'])
+        self.assertEqual(inspected.result['auto_applicable_actions'], [])
+
+    def test_apply_collision_performs_zero_archive_or_location_mutations(self):
+        metadata = desired_metadata()
+        metadata['thoth-work-id'] = 'another-work'
+        item = FakeItem(exists=True, metadata=metadata)
+
+        inspected = self._inspect(item, locations=[], apply=True)
+
+        self.assertEqual(inspected.result['status'], 'identifier_collision')
+        self.assertEqual(inspected.result['attempted_actions'], [])
+        inspected.archive_repair.assert_not_called()
+        inspected.upsert.assert_not_called()
+        item.modify_metadata.assert_not_called()
+
+    def test_mixed_batch_skips_collided_broken_source_and_continues(self):
+        first_metadata = work_metadata()
+        first_metadata['data']['work']['publications'][0]['locations'][0][
+            'fullTextUrl'] = 'https://broken.example/book.pdf'
+        second_metadata = work_metadata(workId=WORK_ID_2)
+        thoth = MagicMock()
+        thoth.work_by_id.side_effect = [
+            json.dumps(first_metadata),
+            json.dumps(second_metadata),
+        ]
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        collided_metadata = desired_metadata()
+        collided_metadata['thoth-work-id'] = 'another-work'
+        items = {
+            WORK_ID: FakeItem(exists=True, metadata=collided_metadata),
+            WORK_ID_2: FakeItem(
+                exists=False, identifier_available=True, identifier=WORK_ID_2),
+        }
+
+        with patch(
+                'reconcile_internet_archive.get_item',
+                side_effect=lambda identifier: items[identifier]), patch.object(
+                    IAUploader, 'get_formatted_metadata',
+                    return_value=JSON_BYTES) as get_json, patch.object(
+                    IAUploader, 'get_publication_details',
+                    return_value=Publication(
+                        'PDF', PUBLICATION_ID, PDF_BYTES, '.pdf',
+                        'https://source.example/book.pdf')) as get_pdf, patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    return_value=[]):
+            results = reconciler.reconcile([WORK_ID, WORK_ID_2])
+
+        self.assertEqual(results[0]['status'], 'identifier_collision')
+        self.assertEqual(results[1]['status'], 'item_missing')
+        self.assertEqual(get_json.call_count, 1)
+        self.assertEqual(get_pdf.call_count, 1)
+        items[WORK_ID].identifier_available.assert_not_called()
+        items[WORK_ID_2].identifier_available.assert_called_once_with()
 
 
 class TestSelectionAndCLI(unittest.TestCase):
@@ -349,7 +640,7 @@ class TestDryRunInspection(unittest.TestCase):
         self.assertIn('availability endpoint failed', result['error'])
         self.assertEqual(result['auto_applicable_actions'], [])
 
-    def test_discoverable_state_uses_unavailable_identifier_rule(self):
+    def test_unavailable_identifier_short_circuits_source_failure(self):
         item = FakeItem(exists=False, identifier_available=False)
 
         result, _, _, _ = self.harness.inspect(
@@ -358,8 +649,8 @@ class TestDryRunInspection(unittest.TestCase):
             pdf_error=DisseminationError('PDF unavailable'),
         )
 
-        self.assertIn('pdf_source_unavailable', result['issues'])
         self.assertIn('identifier_collision', result['issues'])
+        self.assertNotIn('pdf_source_unavailable', result['issues'])
         self.assertNotIn('item_missing', result['issues'])
         self.assertFalse(
             result['internet_archive']['identifier_available'])

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -826,6 +826,147 @@ class TestDryRunInspection(unittest.TestCase):
 
         self.assertEqual(first, second)
 
+    def test_collection_conflict_is_reported_as_admin_only_manual_action(self):
+        metadata = desired_metadata()
+        metadata.pop('collection')
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertEqual(result['status'], 'metadata_conflict')
+        self.assertIn(
+            'archive_collection_membership_conflict', result['issues'])
+        self.assertIn(
+            'resolve_archive_collection_membership',
+            result['recommended_actions'],
+        )
+        archive_metadata = result['internet_archive']['metadata']
+        self.assertEqual(archive_metadata['mutable_problems'], [])
+        self.assertEqual(archive_metadata['initial_only_problems'], [])
+        self.assertEqual(archive_metadata['immutable_problems'], [])
+        self.assertEqual(archive_metadata['admin_only_problems'], [
+            "collection is None, expected to include "
+            "'thoth-archiving-network'",
+        ])
+        self.assertEqual(
+            archive_metadata['restricted_problems'],
+            archive_metadata['admin_only_problems'],
+        )
+        self.assertNotIn('collection', archive_metadata['patch_fields'])
+
+    def test_collection_only_conflict_is_not_mutable_metadata_drift(self):
+        metadata = desired_metadata()
+        metadata['collection'] = 'unrelated-collection'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertNotIn('archive_metadata_stale', result['issues'])
+        self.assertNotIn(
+            'update_archive_metadata', result['recommended_actions'])
+        self.assertEqual(result['recommended_actions'], [
+            'resolve_archive_collection_membership',
+        ])
+
+    def test_collection_and_mutable_drift_retain_both_actions(self):
+        metadata = desired_metadata()
+        metadata.pop('collection')
+        metadata['title'] = 'Old title'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertEqual(result['recommended_actions'], [
+            'resolve_archive_collection_membership',
+            'update_archive_metadata',
+        ])
+        self.assertIn('archive_metadata_stale', result['issues'])
+        self.assertEqual(
+            result['internet_archive']['metadata']['patch_fields'], ['title'])
+
+    def test_collection_conflict_retains_file_recommendations(self):
+        metadata = desired_metadata()
+        metadata['collection'] = []
+
+        result, _, _, _ = self.harness.inspect(item=FakeItem(
+            exists=True,
+            metadata=metadata,
+            files=[],
+        ))
+
+        self.assertEqual(result['recommended_actions'], [
+            'resolve_archive_collection_membership',
+            'upload_pdf_original',
+            'upload_json_original',
+        ])
+        self.assertIn('missing_pdf_original', result['issues'])
+        self.assertIn('missing_json_original', result['issues'])
+
+    def test_collection_conflict_retains_location_recommendation(self):
+        metadata = desired_metadata()
+        metadata['collection'] = 'unrelated-collection'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata),
+            locations=[],
+        )
+
+        self.assertEqual(result['recommended_actions'], [
+            'resolve_archive_collection_membership',
+            'create_thoth_location',
+        ])
+        self.assertIn('location_missing', result['issues'])
+
+    def test_collection_conflict_blocks_all_auto_applicable_actions(self):
+        metadata = desired_metadata()
+        metadata.pop('collection')
+        metadata['title'] = 'Old title'
+
+        result, _, _, _ = self.harness.inspect(
+            item=FakeItem(exists=True, metadata=metadata, files=[]),
+            locations=[],
+        )
+
+        self.assertEqual(result['auto_applicable_actions'], [])
+        self.assertIn(
+            'resolve_archive_collection_membership',
+            result['recommended_actions'],
+        )
+        self.assertIn(
+            'update_archive_metadata', result['recommended_actions'])
+        self.assertIn('upload_pdf_original', result['recommended_actions'])
+        self.assertIn(
+            'create_thoth_location', result['recommended_actions'])
+
+    def test_correct_collection_with_mutable_drift_is_auto_repairable(self):
+        metadata = desired_metadata()
+        metadata['collection'] = [
+            'unrelated-collection', IAUploader.THOTH_COLLECTION]
+        metadata['title'] = 'Old title'
+
+        result, _, _, _ = self.harness.inspect(
+            item=current_item(metadata=metadata))
+
+        self.assertEqual(result['status'], 'metadata_stale')
+        self.assertEqual(
+            result['auto_applicable_actions'],
+            ['update_archive_metadata'],
+        )
+        self.assertEqual(
+            result['internet_archive']['metadata']['admin_only_problems'], [])
+        self.assertEqual(
+            result['internet_archive']['metadata']['patch_fields'], ['title'])
+
+    def test_collection_conflict_report_is_deterministic(self):
+        metadata = desired_metadata()
+        metadata['collection'] = 'unrelated-collection'
+        item = current_item(metadata=metadata)
+
+        first, _, _, _ = self.harness.inspect(item=item, locations=[])
+        second, _, _, _ = self.harness.inspect(item=item, locations=[])
+
+        self.assertEqual(first, second)
+
     def test_multiple_archive_discrepancies_are_ordered(self):
         metadata = desired_metadata()
         metadata['title'] = 'Old title'
@@ -1517,6 +1658,41 @@ class TestApplyMode(unittest.TestCase):
         item.modify_metadata.assert_not_called()
         upsert.assert_not_called()
 
+    def test_collection_conflict_apply_performs_zero_mutations(self):
+        metadata = desired_metadata()
+        metadata['collection'] = 'unrelated-collection'
+        metadata['title'] = 'Old title'
+        item = FakeItem(exists=True, metadata=metadata, files=[])
+        thoth = MagicMock()
+        thoth.work_by_id.return_value = json.dumps(work_metadata())
+        reconciler = InternetArchiveReconciler(thoth=thoth)
+        publication = Publication(
+            'PDF', PUBLICATION_ID, PDF_BYTES, '.pdf',
+            'https://source.example/book.pdf')
+
+        with patch.object(
+                IAUploader, 'get_formatted_metadata',
+                return_value=JSON_BYTES), patch.object(
+                    IAUploader, 'get_publication_details',
+                    return_value=publication), patch(
+                    'reconcile_internet_archive.get_item',
+                    return_value=item), patch(
+                    'reconcile_internet_archive.retrieve_existing_locations',
+                    return_value=[]), patch.object(
+                    IAUploader, 'apply_archive_repairs') as archive_repair, \
+                patch('iauploader.upload') as upload, patch(
+                    'reconcile_internet_archive.upsert_location') as upsert:
+            result = reconciler.reconcile_one(
+                WORK_ID, apply=True, credentials=CREDENTIALS)
+
+        self.assertEqual(result['status'], 'metadata_conflict')
+        self.assertEqual(result['auto_applicable_actions'], [])
+        self.assertEqual(result['attempted_actions'], [])
+        archive_repair.assert_not_called()
+        upload.assert_not_called()
+        item.modify_metadata.assert_not_called()
+        upsert.assert_not_called()
+
     def test_availability_failure_mixed_batch_continues(self):
         failed = repairable_result([], status='error')
         failed['issues'] = ['archive_request_failed']
@@ -1681,6 +1857,22 @@ class TestOutput(unittest.TestCase):
             status='metadata_conflict',
         )
         result['issues'] = ['archive_immutable_metadata_conflict']
+        result['auto_applicable_actions'] = []
+
+        summary = summarise([result])
+
+        self.assertEqual(summary['repairable'], 0)
+        self.assertEqual(summary['ambiguous'], 1)
+        self.assertEqual(summary['failed'], 0)
+        self.assertEqual(summary['repaired'], 0)
+        self.assertEqual(summary['by_status'], {'metadata_conflict': 1})
+
+    def test_collection_conflict_is_ambiguous_not_repairable(self):
+        result = repairable_result(
+            ['resolve_archive_collection_membership'],
+            status='metadata_conflict',
+        )
+        result['issues'] = ['archive_collection_membership_conflict']
         result['auto_applicable_actions'] = []
 
         summary = summarise([result])

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,0 +1,184 @@
+import unittest
+from unittest.mock import MagicMock
+
+from iauploader import IAUploader
+from uploader import Publication, Uploader
+
+
+WORK_ID = '11111111-2222-3333-4444-555555555555'
+PUBLICATION_ID = '99999999-8888-7777-6666-555555555555'
+
+
+def multilingual_metadata(**legacy_fields):
+    work = {
+        'workId': WORK_ID,
+        'titles': [{
+            'canonical': True,
+            'title': 'Example',
+            'subtitle': 'A Study',
+            'fullTitle': 'Example: A Study',
+        }],
+    }
+    work.update(legacy_fields)
+    return {'data': {'work': work}}
+
+
+def internet_archive_metadata(**legacy_fields):
+    metadata = multilingual_metadata(**legacy_fields)
+    metadata['data']['work'].update({
+        'publicationDate': '2026-01-02',
+        'longAbstract': 'A long description',
+        'pageCount': 250,
+        'lccn': '2026000001',
+        'license': 'https://creativecommons.org/licenses/by/4.0/',
+        'oclc': '12345',
+        'doi': 'https://doi.org/10.0000/test',
+        'contributions': [{
+            'fullName': 'First Author',
+            'mainContribution': True,
+        }],
+        'publications': [{
+            'publicationType': 'PDF',
+            'publicationId': PUBLICATION_ID,
+            'isbn': '978-1-234-56789-0',
+            'locations': [{
+                'canonical': True,
+                'fullTextUrl': 'https://source.example/book.pdf',
+            }],
+        }],
+        'subjects': [{'subjectCode': 'ABC123'}],
+        'languages': [{'languageCode': 'eng'}],
+        'issues': [],
+        'imprint': {
+            'publisher': {
+                'publisherName': 'Test Publisher',
+            },
+        },
+    })
+    return metadata
+
+
+class TestNormaliseWorkMetadata(unittest.TestCase):
+    def test_absent_full_title_is_backfilled(self):
+        metadata = multilingual_metadata()
+
+        Uploader.normalise_work_metadata(metadata)
+
+        self.assertEqual(
+            metadata['data']['work']['fullTitle'], 'Example: A Study')
+
+    def test_null_full_title_is_backfilled(self):
+        metadata = multilingual_metadata(fullTitle=None)
+
+        Uploader.normalise_work_metadata(metadata)
+
+        self.assertEqual(
+            metadata['data']['work']['fullTitle'], 'Example: A Study')
+
+    def test_full_title_is_synthesised_when_canonical_value_is_absent(self):
+        metadata = multilingual_metadata()
+        metadata['data']['work']['titles'][0].pop('fullTitle')
+
+        Uploader.normalise_work_metadata(metadata)
+
+        self.assertEqual(
+            metadata['data']['work']['fullTitle'], 'Example: A Study')
+
+    def test_null_title_is_backfilled(self):
+        metadata = multilingual_metadata(title=None)
+
+        Uploader.normalise_work_metadata(metadata)
+
+        self.assertEqual(metadata['data']['work']['title'], 'Example')
+
+    def test_null_subtitle_is_backfilled(self):
+        metadata = multilingual_metadata(subtitle=None)
+
+        Uploader.normalise_work_metadata(metadata)
+
+        self.assertEqual(metadata['data']['work']['subtitle'], 'A Study')
+
+    def test_all_null_legacy_title_fields_are_backfilled(self):
+        metadata = multilingual_metadata(
+            title=None, subtitle=None, fullTitle=None)
+
+        Uploader.normalise_work_metadata(metadata)
+
+        self.assertEqual(metadata['data']['work']['title'], 'Example')
+        self.assertEqual(metadata['data']['work']['subtitle'], 'A Study')
+        self.assertEqual(
+            metadata['data']['work']['fullTitle'], 'Example: A Study')
+
+    def test_non_null_legacy_title_fields_are_preserved(self):
+        metadata = multilingual_metadata(
+            title='Legacy title',
+            subtitle='Legacy subtitle',
+            fullTitle='Legacy full title',
+        )
+
+        Uploader.normalise_work_metadata(metadata)
+
+        self.assertEqual(metadata['data']['work']['title'], 'Legacy title')
+        self.assertEqual(
+            metadata['data']['work']['subtitle'], 'Legacy subtitle')
+        self.assertEqual(
+            metadata['data']['work']['fullTitle'], 'Legacy full title')
+
+    def test_missing_multilingual_titles_keeps_legacy_state_unchanged(self):
+        metadata = {
+            'data': {
+                'work': {
+                    'title': None,
+                    'subtitle': None,
+                    'fullTitle': None,
+                },
+            },
+        }
+
+        Uploader.normalise_work_metadata(metadata)
+
+        self.assertEqual(metadata['data']['work'], {
+            'title': None,
+            'subtitle': None,
+            'fullTitle': None,
+            'shortAbstract': None,
+            'longAbstract': None,
+        })
+
+
+class TestIAUploaderNormalisedTitles(unittest.TestCase):
+    def setUp(self):
+        self.metadata = internet_archive_metadata(
+            title=None, subtitle=None, fullTitle=None)
+        Uploader.normalise_work_metadata(self.metadata)
+        self.uploader = IAUploader.__new__(IAUploader)
+        self.uploader.work_id = WORK_ID
+        self.uploader.export_url = 'https://export.example'
+        self.uploader.version = '1.5.0'
+        self.uploader.metadata = self.metadata
+
+    def test_null_full_title_produces_valid_archive_title(self):
+        parsed = self.uploader.parse_metadata()
+
+        self.assertEqual(parsed['title'], 'Example: A Study')
+
+    def test_null_full_title_does_not_reject_desired_state(self):
+        self.uploader.get_formatted_metadata = MagicMock(
+            return_value=b'{"example":"metadata"}')
+        self.uploader.get_publication_details = MagicMock(
+            return_value=Publication(
+                'PDF',
+                PUBLICATION_ID,
+                b'PDF bytes',
+                '.pdf',
+                'https://source.example/book.pdf',
+            ))
+
+        desired = self.uploader.build_desired_state()
+
+        self.assertEqual(desired.metadata['title'], 'Example: A Study')
+        self.assertEqual(desired.publication_id, PUBLICATION_ID)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_write_locations.py
+++ b/tests/test_write_locations.py
@@ -1,83 +1,440 @@
+import json
+import tempfile
 import unittest
-from unittest.mock import patch, MagicMock
-from thothlibrary import ThothError
-from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from thothlibrary.mutation import ThothMutation
+
+from thothapi import patch_thoth_client_mutations
+from write_locations import (
+    AuthenticationError,
+    DuplicateLocationsError,
+    LocationInput,
+    LocationLookupError,
+    LocationMutationError,
+    MalformedLocationError,
+    MissingTokenError,
+    PublicationNotFoundError,
+    configure_thoth_client,
+    main,
+    parse_location_line,
+    upsert_location,
+)
 
 
-def _make_thoth_error(text):
-    req = SimpleNamespace(method='POST', url='http://example.com/graphql')
-    rsp = SimpleNamespace(status_code=400, text=text)
-    return ThothError(req, rsp)
+PUBLICATION_ID = '11111111-2222-3333-4444-555555555555'
+LANDING_PAGE = 'https://archive.org/details/work-id'
+FULL_TEXT_URL = 'https://archive.org/download/work-id/work-id.pdf'
+CHECKSUM = '0123456789abcdef0123456789abcdef'
 
 
-class TestWriteLocations(unittest.TestCase):
+def location_input(**overrides):
+    values = {
+        'publication_id': PUBLICATION_ID,
+        'location_platform': 'INTERNET_ARCHIVE',
+        'landing_page': LANDING_PAGE,
+        'full_text_url': FULL_TEXT_URL,
+        'checksum': CHECKSUM,
+        'checksum_algorithm': 'MD5',
+    }
+    values.update(overrides)
+    return LocationInput(**values)
 
-    @patch('write_locations.get_thoth_client')
-    @patch('write_locations.environ')
-    def test_duplicate_location_is_skipped(self, mock_environ, mock_get_thoth):
-        """Test case 9: duplicate-platform ThothError is treated as successful skip."""
-        mock_environ.__getitem__.return_value = 'fake-token'
-        mock_thoth = MagicMock()
-        mock_get_thoth.return_value = mock_thoth
-        mock_thoth.create_location.side_effect = _make_thoth_error(
-            "A location on the selected platform already exists."
-        )
 
-        from write_locations import write_thoth_location
+def existing_location(**overrides):
+    values = {
+        'locationId': 'location-1',
+        'publicationId': PUBLICATION_ID,
+        'locationPlatform': 'INTERNET_ARCHIVE',
+        'landingPage': LANDING_PAGE,
+        'fullTextUrl': FULL_TEXT_URL,
+        'canonical': False,
+        'checksum': CHECKSUM,
+        'checksumAlgorithm': 'MD5',
+    }
+    values.update(overrides)
+    return values
 
-        with patch('write_locations.logging') as mock_logging:
-            result = write_thoth_location(
-                "pub-1", "OAPEN",
-                "https://library.oapen.org/handle/123",
-                "https://library.oapen.org/bitstream/handle/123/file.pdf",
-                None, None
-            )
+
+def graphql_response(locations):
+    return json.dumps({
+        'data': {
+            'publication': {
+                'publicationId': PUBLICATION_ID,
+                'locations': locations,
+            },
+        },
+    })
+
+
+def mock_thoth_with_locations(*responses):
+    thoth = MagicMock()
+    thoth.client.execute.side_effect = [
+        graphql_response(locations) for locations in responses
+    ]
+    thoth.create_location.return_value = 'created-location'
+    thoth.update_location.return_value = 'updated-location'
+    return thoth
+
+
+class TestLocationUpsert(unittest.TestCase):
+    def test_no_existing_platform_location_creates(self):
+        thoth = mock_thoth_with_locations([])
+
+        result = upsert_location(thoth, location_input())
+
+        self.assertEqual(result, 'created-location')
+        thoth.create_location.assert_called_once_with({
+            'publicationId': PUBLICATION_ID,
+            'landingPage': LANDING_PAGE,
+            'fullTextUrl': FULL_TEXT_URL,
+            'locationPlatform': 'INTERNET_ARCHIVE',
+            'canonical': False,
+            'checksum': CHECKSUM,
+            'checksumAlgorithm': 'MD5',
+        })
+        thoth.update_location.assert_not_called()
+
+    def test_identical_location_is_noop(self):
+        thoth = mock_thoth_with_locations([existing_location()])
+
+        with patch('write_locations.logging.info') as log_info:
+            result = upsert_location(thoth, location_input())
 
         self.assertIsNone(result)
-        mock_logging.info.assert_called_once()
-        self.assertIn("already exists", mock_logging.info.call_args[0][0])
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_not_called()
+        self.assertIn('already current', log_info.call_args.args[0])
 
-    @patch('write_locations.get_thoth_client')
-    @patch('write_locations.environ')
-    def test_unrelated_thoth_error_raises(self, mock_environ, mock_get_thoth):
-        """Test case 10: non-duplicate ThothError still fails."""
-        mock_environ.__getitem__.return_value = 'fake-token'
-        mock_thoth = MagicMock()
-        mock_get_thoth.return_value = mock_thoth
-        mock_thoth.create_location.side_effect = _make_thoth_error(
-            "Some other error occurred"
+    def test_changed_landing_page_updates(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(landingPage='https://archive.org/details/old')
+        ])
+
+        upsert_location(thoth, location_input())
+
+        update = thoth.update_location.call_args.args[0]
+        self.assertEqual(update['landingPage'], LANDING_PAGE)
+        thoth.create_location.assert_not_called()
+
+    def test_changed_full_text_url_updates(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(fullTextUrl='https://archive.org/download/old.pdf')
+        ])
+
+        upsert_location(thoth, location_input())
+
+        update = thoth.update_location.call_args.args[0]
+        self.assertEqual(update['fullTextUrl'], FULL_TEXT_URL)
+        thoth.create_location.assert_not_called()
+
+    def test_changed_checksum_and_algorithm_update(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(checksum='old', checksumAlgorithm='SHA1')
+        ])
+
+        upsert_location(thoth, location_input())
+
+        update = thoth.update_location.call_args.args[0]
+        self.assertEqual(update['checksum'], CHECKSUM)
+        self.assertEqual(update['checksumAlgorithm'], 'MD5')
+
+    def test_missing_incoming_checksum_preserves_existing_pair(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(landingPage='https://archive.org/details/old')
+        ])
+
+        upsert_location(thoth, location_input(
+            checksum=None,
+            checksum_algorithm=None,
+        ))
+
+        update = thoth.update_location.call_args.args[0]
+        self.assertEqual(update['checksum'], CHECKSUM)
+        self.assertEqual(update['checksumAlgorithm'], 'MD5')
+
+    def test_no_incoming_or_existing_checksum_is_valid_null_pair(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(
+                landingPage='https://archive.org/details/old',
+                checksum=None,
+                checksumAlgorithm=None,
+            )
+        ])
+
+        upsert_location(thoth, location_input(
+            checksum=None,
+            checksum_algorithm=None,
+        ))
+
+        update = thoth.update_location.call_args.args[0]
+        self.assertIsNone(update['checksum'])
+        self.assertIsNone(update['checksumAlgorithm'])
+
+    def test_incoming_checksum_without_algorithm_is_rejected(self):
+        thoth = mock_thoth_with_locations([])
+
+        with self.assertRaisesRegex(MalformedLocationError, 'both checksum'):
+            upsert_location(thoth, location_input(checksum_algorithm=None))
+
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_not_called()
+
+    def test_incoming_algorithm_without_checksum_is_rejected(self):
+        thoth = mock_thoth_with_locations([])
+
+        with self.assertRaisesRegex(MalformedLocationError, 'both checksum'):
+            upsert_location(thoth, location_input(checksum=None))
+
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_not_called()
+
+    def test_existing_canonical_status_is_preserved_on_update(self):
+        for canonical in (True, False):
+            with self.subTest(canonical=canonical):
+                thoth = mock_thoth_with_locations([
+                    existing_location(
+                        landingPage='https://archive.org/details/old',
+                        canonical=canonical,
+                    )
+                ])
+
+                upsert_location(thoth, location_input())
+
+                update = thoth.update_location.call_args.args[0]
+                self.assertIs(update['canonical'], canonical)
+                self.assertEqual(update['locationId'], 'location-1')
+                self.assertEqual(update['publicationId'], PUBLICATION_ID)
+
+    def test_another_platform_does_not_block_creation(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(
+                locationId='oapen-location',
+                locationPlatform='OAPEN',
+            )
+        ])
+
+        upsert_location(thoth, location_input())
+
+        thoth.create_location.assert_called_once()
+        thoth.update_location.assert_not_called()
+
+    def test_multiple_platform_locations_fail_with_all_ids(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(locationId='location-1'),
+            existing_location(locationId='location-2'),
+        ])
+
+        with self.assertRaises(DuplicateLocationsError) as raised:
+            upsert_location(thoth, location_input())
+
+        message = str(raised.exception)
+        self.assertIn(PUBLICATION_ID, message)
+        self.assertIn('INTERNET_ARCHIVE', message)
+        self.assertIn('location-1', message)
+        self.assertIn('location-2', message)
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_not_called()
+
+    def test_publication_not_found_is_useful_error(self):
+        thoth = MagicMock()
+        thoth.client.execute.return_value = json.dumps({
+            'errors': [{
+                'message': 'No record was found for the given ID.',
+                'path': ['publication'],
+            }],
+            'data': None,
+        })
+
+        with self.assertRaisesRegex(
+                PublicationNotFoundError, PUBLICATION_ID):
+            upsert_location(thoth, location_input())
+
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_not_called()
+
+    def test_authentication_failure_is_useful_error(self):
+        thoth = MagicMock()
+        thoth.client.execute.return_value = json.dumps({
+            'errors': [{'message': 'Unauthorized'}],
+            'data': None,
+        })
+
+        with self.assertRaisesRegex(AuthenticationError, 'Unauthorized'):
+            upsert_location(thoth, location_input())
+
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_not_called()
+
+    def test_graphql_transport_failure_preserves_diagnostic(self):
+        thoth = MagicMock()
+        thoth.client.execute.side_effect = ConnectionError('network down')
+
+        with self.assertRaisesRegex(LocationLookupError, 'network down'):
+            upsert_location(thoth, location_input())
+
+    def test_mutation_failure_preserves_diagnostic_and_kind(self):
+        thoth = mock_thoth_with_locations([])
+        thoth.create_location.side_effect = RuntimeError('validation exploded')
+
+        with self.assertRaisesRegex(
+                LocationMutationError,
+                'create location mutation failed.*validation exploded'):
+            upsert_location(thoth, location_input())
+
+    def test_update_mutation_failure_preserves_diagnostic_and_kind(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(landingPage='https://archive.org/details/old')
+        ])
+        thoth.update_location.side_effect = RuntimeError('permission mismatch')
+
+        with self.assertRaisesRegex(
+                LocationMutationError,
+                'update location mutation failed.*permission mismatch'):
+            upsert_location(thoth, location_input())
+
+        thoth.create_location.assert_not_called()
+
+    def test_second_identical_execution_after_create_is_noop(self):
+        current = existing_location(locationId='created-location')
+        thoth = mock_thoth_with_locations([], [current])
+
+        upsert_location(thoth, location_input())
+        upsert_location(thoth, location_input())
+
+        thoth.create_location.assert_called_once()
+        thoth.update_location.assert_not_called()
+
+    def test_second_identical_execution_after_update_is_noop(self):
+        stale = existing_location(landingPage='https://archive.org/details/old')
+        current = existing_location()
+        thoth = mock_thoth_with_locations([stale], [current])
+
+        upsert_location(thoth, location_input())
+        upsert_location(thoth, location_input())
+
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_called_once()
+
+    def test_complete_lookup_supplies_checksum_omitted_by_high_level_query(self):
+        thoth = mock_thoth_with_locations([
+            existing_location(landingPage='https://archive.org/details/old')
+        ])
+
+        upsert_location(thoth, location_input(
+            checksum=None,
+            checksum_algorithm=None,
+        ))
+
+        thoth.publication.assert_not_called()
+        query = thoth.client.execute.call_args.args[0]
+        self.assertIn('checksum\n', query)
+        self.assertIn('checksumAlgorithm', query)
+        update = thoth.update_location.call_args.args[0]
+        self.assertEqual(update['checksum'], CHECKSUM)
+        self.assertEqual(update['checksumAlgorithm'], 'MD5')
+
+    def test_incomplete_lookup_fields_are_not_treated_as_null(self):
+        incomplete = existing_location()
+        del incomplete['checksum']
+        thoth = mock_thoth_with_locations([incomplete])
+
+        with self.assertRaisesRegex(LocationLookupError, 'omitted.*checksum'):
+            upsert_location(thoth, location_input())
+
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_not_called()
+
+    def test_lookup_paginates_until_all_locations_are_retrieved(self):
+        first_page = [
+            existing_location(
+                locationId='other-{}'.format(index),
+                locationPlatform='OAPEN',
+            )
+            for index in range(100)
+        ]
+        requested = existing_location(locationId='requested-location')
+        thoth = mock_thoth_with_locations(first_page, [requested])
+
+        upsert_location(thoth, location_input())
+
+        self.assertEqual(thoth.client.execute.call_count, 2)
+        first_variables = thoth.client.execute.call_args_list[0].args[1]
+        second_variables = thoth.client.execute.call_args_list[1].args[1]
+        self.assertEqual(first_variables['offset'], 0)
+        self.assertEqual(second_variables['offset'], 100)
+        thoth.create_location.assert_not_called()
+        thoth.update_location.assert_not_called()
+
+
+class TestLocationParsingAndConfiguration(unittest.TestCase):
+    def test_malformed_line_reports_line_number_and_field_count(self):
+        for line in ('one two three', 'one two three four five six seven'):
+            with self.subTest(line=line):
+                with self.assertRaisesRegex(
+                        MalformedLocationError, 'Line 7: expected 6 fields'):
+                    parse_location_line(line, 7)
+
+    def test_blank_line_is_ignored(self):
+        self.assertIsNone(parse_location_line('  \n', 3))
+
+    def test_literal_none_values_are_parsed(self):
+        parsed = parse_location_line(
+            '{} INTERNET_ARCHIVE {} None None None'.format(
+                PUBLICATION_ID, LANDING_PAGE
+            ),
+            4,
         )
 
-        from write_locations import write_thoth_location
+        self.assertIsNone(parsed.full_text_url)
+        self.assertIsNone(parsed.checksum)
+        self.assertIsNone(parsed.checksum_algorithm)
 
-        with self.assertRaises(ThothError):
-            write_thoth_location(
-                "pub-1", "OAPEN",
-                "https://library.oapen.org/handle/123",
-                "https://library.oapen.org/bitstream/handle/123/file.pdf",
-                None, None
+    def test_partial_checksum_pair_reports_line_number(self):
+        with self.assertRaisesRegex(
+                MalformedLocationError, 'Line 9 incoming location'):
+            parse_location_line(
+                '{} INTERNET_ARCHIVE {} {} {} None'.format(
+                    PUBLICATION_ID, LANDING_PAGE, FULL_TEXT_URL, CHECKSUM
+                ),
+                9,
             )
 
     @patch('write_locations.get_thoth_client')
-    @patch('write_locations.environ')
-    def test_successful_write_prints_location_id(self, mock_environ, mock_get_thoth):
-        """Successful location creation prints the location ID."""
-        mock_environ.__getitem__.return_value = 'fake-token'
-        mock_thoth = MagicMock()
-        mock_get_thoth.return_value = mock_thoth
-        mock_thoth.create_location.return_value = "loc-123"
+    def test_missing_thoth_pat_is_distinct(self, get_client):
+        with patch.dict('write_locations.environ', {}, clear=True):
+            with self.assertRaisesRegex(MissingTokenError, 'THOTH_PAT'):
+                configure_thoth_client()
 
-        from write_locations import write_thoth_location
+        get_client.assert_not_called()
 
-        with patch('builtins.print') as mock_print:
-            write_thoth_location(
-                "pub-1", "OAPEN",
-                "https://library.oapen.org/handle/123",
-                "https://library.oapen.org/bitstream/handle/123/file.pdf",
-                None, None
-            )
+    def test_native_booleans_are_rendered_as_graphql_booleans(self):
+        patch_thoth_client_mutations()
 
-        mock_print.assert_called_once_with("loc-123")
+        mutation = ThothMutation('createLocation', {
+            'publicationId': PUBLICATION_ID,
+            'landingPage': LANDING_PAGE,
+            'fullTextUrl': FULL_TEXT_URL,
+            'locationPlatform': 'INTERNET_ARCHIVE',
+            'canonical': False,
+            'checksum': CHECKSUM,
+            'checksumAlgorithm': 'MD5',
+        })
+
+        self.assertIn('canonical: false', mutation.request)
+        self.assertNotIn('canonical: False', mutation.request)
+
+    def test_main_returns_nonzero_for_malformed_input(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'locations.txt'
+            path.write_text('too few fields\n')
+
+            with patch('write_locations.logging.error') as log_error:
+                result = main([str(path)])
+
+        self.assertEqual(result, 1)
+        self.assertIn('Line 1', str(log_error.call_args))
 
 
 if __name__ == '__main__':

--- a/tests/test_write_locations.py
+++ b/tests/test_write_locations.py
@@ -1,6 +1,8 @@
 import json
+import io
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -20,6 +22,7 @@ from write_locations import (
     main,
     parse_location_line,
     upsert_location,
+    write_thoth_location,
 )
 
 
@@ -79,6 +82,46 @@ def mock_thoth_with_locations(*responses):
 
 
 class TestLocationUpsert(unittest.TestCase):
+    def test_upsert_returns_created_id_without_printing_by_default(self):
+        thoth = mock_thoth_with_locations([])
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            result = upsert_location(thoth, location_input())
+
+        self.assertEqual(result, 'created-location')
+        self.assertEqual(stdout.getvalue(), '')
+
+    def test_successful_mutation_logs_action_id_publication_and_platform(self):
+        thoth = mock_thoth_with_locations([])
+
+        with self.assertLogs(level='INFO') as logs:
+            upsert_location(thoth, location_input())
+
+        message = '\n'.join(logs.output)
+        self.assertIn('create', message)
+        self.assertIn('created-location', message)
+        self.assertIn(PUBLICATION_ID, message)
+        self.assertIn('INTERNET_ARCHIVE', message)
+
+    def test_compatibility_entrypoint_explicitly_emits_location_id(self):
+        thoth = mock_thoth_with_locations([])
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            result = write_thoth_location(
+                PUBLICATION_ID,
+                'INTERNET_ARCHIVE',
+                LANDING_PAGE,
+                FULL_TEXT_URL,
+                CHECKSUM,
+                'MD5',
+                thoth=thoth,
+            )
+
+        self.assertEqual(result, 'created-location')
+        self.assertEqual(stdout.getvalue(), 'created-location\n')
+
     def test_no_existing_platform_location_creates(self):
         thoth = mock_thoth_with_locations([])
 
@@ -447,6 +490,34 @@ class TestLocationParsingAndConfiguration(unittest.TestCase):
 
         self.assertEqual(result, 1)
         self.assertIn('Line 1', str(log_error.call_args))
+
+    def test_standalone_cli_explicitly_emits_each_successful_location_id(self):
+        thoth = mock_thoth_with_locations([], [])
+        thoth.create_location.side_effect = [
+            'first-location',
+            'second-location',
+        ]
+        line = '{} INTERNET_ARCHIVE {} {} {} MD5\n'.format(
+            PUBLICATION_ID,
+            LANDING_PAGE,
+            FULL_TEXT_URL,
+            CHECKSUM,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'locations.txt'
+            path.write_text(line + line)
+            stdout = io.StringIO()
+            with patch(
+                    'write_locations.configure_thoth_client',
+                    return_value=thoth), redirect_stdout(stdout):
+                status = main([str(path)])
+
+        self.assertEqual(status, 0)
+        self.assertEqual(
+            stdout.getvalue().splitlines(),
+            ['first-location', 'second-location'],
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_write_locations.py
+++ b/tests/test_write_locations.py
@@ -129,6 +129,18 @@ class TestLocationUpsert(unittest.TestCase):
         self.assertEqual(update['fullTextUrl'], FULL_TEXT_URL)
         thoth.create_location.assert_not_called()
 
+    def test_clearing_full_text_url_sends_explicit_graphql_null(self):
+        thoth = mock_thoth_with_locations([existing_location()])
+
+        upsert_location(thoth, location_input(full_text_url=None))
+
+        update = thoth.update_location.call_args.args[0]
+        patch_thoth_client_mutations()
+        request = ThothMutation('updateLocation', update).request
+        self.assertIn('fullTextUrl: null', request)
+        self.assertNotIn('fullTextUrl: "null"', request)
+        thoth.create_location.assert_not_called()
+
     def test_changed_checksum_and_algorithm_update(self):
         thoth = mock_thoth_with_locations([
             existing_location(checksum='old', checksumAlgorithm='SHA1')

--- a/thothapi.py
+++ b/thothapi.py
@@ -23,6 +23,39 @@ query PublicationLocations($publicationId: Uuid!, $limit: Int!, $offset: Int!) {
 }
 """
 
+INTERNET_ARCHIVE_SELECTION_QUERY = """
+query InternetArchiveSelection(
+  $limit: Int!
+  $offset: Int!
+  $publishers: [Uuid!]!
+  $workTypes: [WorkType!]!
+  $workStatuses: [WorkStatus!]!
+  $updatedAtWithRelations: TimeExpression!
+) {
+  works(
+    limit: $limit
+    offset: $offset
+    publishers: $publishers
+    workTypes: $workTypes
+    workStatuses: $workStatuses
+    order: {field: UPDATED_AT_WITH_RELATIONS, direction: ASC}
+    updatedAtWithRelations: $updatedAtWithRelations
+  ) {
+    workId
+    updatedAtWithRelations
+    workStatus
+    workType
+    publications {
+      publicationType
+      locations {
+        canonical
+        fullTextUrl
+      }
+    }
+  }
+}
+"""
+
 
 class ThothGraphQLTransportError(RuntimeError):
     """The Thoth GraphQL endpoint could not return a usable response."""
@@ -165,6 +198,75 @@ def get_publication_locations(thoth, publication_id):
         all_locations.extend(page)
         if len(page) < page_size:
             return all_locations
+        offset += page_size
+
+
+def get_internet_archive_selection_works(
+        thoth, publisher_ids, work_types, updated_after, page_size=100):
+    """Return every IA selection candidate using a bounded GraphQL query."""
+    if not isinstance(page_size, int) or page_size < 1 or page_size > 100:
+        raise ValueError('page_size must be between 1 and 100')
+
+    offset = 0
+    all_works = []
+    while True:
+        variables = {
+            'limit': page_size,
+            'offset': offset,
+            'publishers': list(publisher_ids),
+            'workTypes': list(work_types),
+            'workStatuses': ['ACTIVE'],
+            'updatedAtWithRelations': {
+                'timestamp': updated_after,
+                'expression': 'GREATER_THAN',
+            },
+        }
+        try:
+            response = thoth.client.execute(
+                INTERNET_ARCHIVE_SELECTION_QUERY, variables)
+        except Exception as error:
+            raise ThothGraphQLTransportError(
+                'Unable to query Internet Archive selection candidates: {}'.format(
+                    error)
+            ) from error
+
+        try:
+            payload = json.loads(response) if isinstance(response, str) else response
+        except (TypeError, ValueError) as error:
+            raise ThothGraphQLTransportError(
+                'Invalid JSON response from Thoth: {}'.format(error)
+            ) from error
+
+        if not isinstance(payload, dict):
+            raise ThothGraphQLTransportError(
+                'Thoth selection response was not an object')
+        if payload.get('errors'):
+            useful_errors = []
+            for error in payload['errors']:
+                if isinstance(error, dict):
+                    useful_errors.append({
+                        key: error[key] for key in ('message', 'path')
+                        if key in error
+                    })
+                else:
+                    useful_errors.append(str(error))
+            raise ThothGraphQLResponseError(
+                json.dumps(useful_errors, sort_keys=True)
+            )
+
+        try:
+            page = payload['data']['works']
+        except (KeyError, TypeError) as error:
+            raise ThothGraphQLTransportError(
+                'Thoth selection response did not contain a works list'
+            ) from error
+        if not isinstance(page, list):
+            raise ThothGraphQLTransportError(
+                'Thoth selection response did not contain a works list')
+
+        all_works.extend(page)
+        if len(page) < page_size:
+            return all_works
         offset += page_size
 
 

--- a/thothapi.py
+++ b/thothapi.py
@@ -1,7 +1,35 @@
 #!/usr/bin/env python3
 """Helpers for configuring and patching Thoth client access."""
 
+import json
 from os import environ
+
+
+PUBLICATION_LOCATIONS_QUERY = """
+query PublicationLocations($publicationId: Uuid!, $limit: Int!, $offset: Int!) {
+  publication(publicationId: $publicationId) {
+    publicationId
+    locations(limit: $limit, offset: $offset) {
+      locationId
+      publicationId
+      locationPlatform
+      landingPage
+      fullTextUrl
+      canonical
+      checksum
+      checksumAlgorithm
+    }
+  }
+}
+"""
+
+
+class ThothGraphQLTransportError(RuntimeError):
+    """The Thoth GraphQL endpoint could not return a usable response."""
+
+
+class ThothGraphQLResponseError(RuntimeError):
+    """The Thoth GraphQL endpoint returned one or more GraphQL errors."""
 
 
 def get_thoth_client_url(client_url=None):
@@ -50,10 +78,92 @@ def patch_thoth_client_queries():
         ]
 
 
+def patch_thoth_client_mutations():
+    """Render native Python booleans as valid GraphQL boolean literals."""
+    from thothlibrary.mutation import ThothMutation
+
+    if getattr(ThothMutation, '_thoth_dissemination_boolean_patch', False):
+        return
+
+    original_statement = ThothMutation._statement
+
+    @staticmethod
+    def statement(key, value, enclose):
+        if isinstance(value, bool):
+            return '{}: {}'.format(key, str(value).lower())
+        return original_statement(key, value, enclose)
+
+    ThothMutation._statement = statement
+    ThothMutation._thoth_dissemination_boolean_patch = True
+
+
+def get_publication_locations(thoth, publication_id):
+    """Return complete location data for one publication."""
+    page_size = 100
+    offset = 0
+    all_locations = []
+
+    while True:
+        try:
+            response = thoth.client.execute(
+                PUBLICATION_LOCATIONS_QUERY,
+                {
+                    'publicationId': publication_id,
+                    'limit': page_size,
+                    'offset': offset,
+                },
+            )
+        except Exception as error:
+            raise ThothGraphQLTransportError(str(error)) from error
+
+        try:
+            payload = json.loads(response)
+        except (TypeError, ValueError) as error:
+            raise ThothGraphQLTransportError(
+                'Invalid JSON response from Thoth: {}'.format(error)
+            ) from error
+
+        if payload.get('errors'):
+            raise ThothGraphQLResponseError(
+                json.dumps(payload['errors'], sort_keys=True)
+            )
+
+        try:
+            publication = payload['data']['publication']
+        except (KeyError, TypeError) as error:
+            raise ThothGraphQLTransportError(
+                'Thoth response did not contain publication data'
+            ) from error
+
+        if publication is None:
+            raise ThothGraphQLResponseError(
+                'Publication {} was not found'.format(publication_id)
+            )
+        if publication.get('publicationId') != publication_id:
+            raise ThothGraphQLTransportError(
+                'Thoth returned publication {} while looking up {}'.format(
+                    publication.get('publicationId'), publication_id
+                )
+            )
+        page = publication.get('locations')
+        if not isinstance(page, list):
+            raise ThothGraphQLTransportError(
+                'Thoth response did not contain a locations list for publication {}'.format(
+                    publication_id
+                )
+            )
+
+        all_locations.extend(page)
+        if len(page) < page_size:
+            return all_locations
+        offset += page_size
+
+
 def get_thoth_client(client_url=None):
     """Instantiate a patched Thoth client using an optional endpoint override."""
     from thothlibrary import ThothClient
 
     patch_thoth_client_queries()
+    patch_thoth_client_mutations()
     resolved_url = get_thoth_client_url(client_url)
     return ThothClient(resolved_url) if resolved_url else ThothClient()

--- a/thothapi.py
+++ b/thothapi.py
@@ -32,6 +32,13 @@ class ThothGraphQLResponseError(RuntimeError):
     """The Thoth GraphQL endpoint returned one or more GraphQL errors."""
 
 
+class _ExplicitGraphQLNull:
+    """Sentinel for nullable mutation fields that must be explicitly cleared."""
+
+
+EXPLICIT_GRAPHQL_NULL = _ExplicitGraphQLNull()
+
+
 def get_thoth_client_url(client_url=None):
     """
     Return the Thoth API base URL expected by thothlibrary.
@@ -89,6 +96,8 @@ def patch_thoth_client_mutations():
 
     @staticmethod
     def statement(key, value, enclose):
+        if value is EXPLICIT_GRAPHQL_NULL:
+            return '{}: null'.format(key)
         if isinstance(value, bool):
             return '{}: {}'.format(key, str(value).lower())
         return original_statement(key, value, enclose)

--- a/uploader.py
+++ b/uploader.py
@@ -182,9 +182,14 @@ class Uploader():
                 full_title = title if subtitle is None else '{}: {}'.format(
                     title, subtitle)
 
-            work.setdefault('title', title if title is not None else full_title)
-            work.setdefault('subtitle', subtitle)
-            work.setdefault('fullTitle', full_title)
+            title_fields = {
+                'title': title if title is not None else full_title,
+                'subtitle': subtitle,
+                'fullTitle': full_title,
+            }
+            for field, value in title_fields.items():
+                if field not in work or work[field] is None:
+                    work[field] = value
 
         long_abstract = cls.get_canonical_metadata_entry(
             work.get('abstracts'),

--- a/uploader.py
+++ b/uploader.py
@@ -80,10 +80,20 @@ class Location():
 
 class Publication():
     def __init__(self, publication_type, publication_id, publication_bytes,
-                 file_extension):
+                 file_extension, source_url=None):
         self.type = publication_type
         self.id = publication_id
         self.bytes = publication_bytes
+        self.file_ext = file_extension
+        self.source_url = source_url
+
+
+class PublicationSource():
+    def __init__(self, publication_type, publication_id, source_url,
+                 file_extension):
+        self.type = publication_type
+        self.id = publication_id
+        self.url = source_url
         self.file_ext = file_extension
 
 
@@ -243,8 +253,25 @@ class Uploader():
         Retrieve publication details for specified type from work metadata:
         Thoth ID, canonical content file (via location URL) and extension
         """
+        source = self.get_publication_source(publication_type)
+        try:
+            publication_bytes = self.get_data_from_url(
+                source.url, PUB_FORMATS[publication_type]['content_type'])
+        except DisseminationError:
+            raise
+
+        return Publication(
+            publication_type,
+            source.id,
+            publication_bytes,
+            source.file_ext,
+            source.url,
+        )
+
+    def get_publication_source(self, publication_type):
+        """Return the canonical source descriptor without downloading it."""
         publications = self.metadata.get(
-            'data').get('work').get('publications')
+            'data', {}).get('work', {}).get('publications') or []
         # There should be a maximum of one publication per type;
         # more than one would be a Thoth database error
         try:
@@ -258,22 +285,17 @@ class Uploader():
             publication_url = [n['fullTextUrl']
                                for n in publication['locations']
                                if n['canonical']][0]
-        except (IndexError, KeyError):
+        except (IndexError, KeyError, TypeError):
             raise DisseminationError(
                 'No {} Full Text URL found for Work'.format(publication_type))
-        try:
-            publication_bytes = self.get_data_from_url(
-                publication_url, PUB_FORMATS[publication_type]['content_type'])
-        except DisseminationError:
-            raise
 
         file_extension = PUB_FORMATS[publication_type]['file_extension']
 
-        return Publication(
+        return PublicationSource(
             publication_type,
             publication_id,
-            publication_bytes,
-            file_extension
+            publication_url,
+            file_extension,
         )
 
     def get_cover_url(self):

--- a/uploader.py
+++ b/uploader.py
@@ -202,11 +202,7 @@ class Uploader():
         """Retrieve work metadata from Thoth Export API in specified format"""
         metadata_url = self.export_url + '/specifications/' + \
             format + '/work/' + self.work_id
-        try:
-            return self.get_data_from_url(metadata_url)
-        except DisseminationError as error:
-            logging.error(error)
-            sys.exit(1)
+        return self.get_data_from_url(metadata_url)
 
     def get_cover_image(self, required_format=None):
         """

--- a/version.py
+++ b/version.py
@@ -1,0 +1,3 @@
+"""Dissemination service version shared by command-line entrypoints."""
+
+__version__ = '1.3.2'

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 """Dissemination service version shared by command-line entrypoints."""
 
-__version__ = '1.3.2'
+__version__ = '1.5.0'

--- a/write_locations.py
+++ b/write_locations.py
@@ -7,6 +7,7 @@ from os import environ
 import sys
 
 from thothapi import (
+    EXPLICIT_GRAPHQL_NULL,
     ThothGraphQLResponseError,
     ThothGraphQLTransportError,
     get_publication_locations,
@@ -278,8 +279,12 @@ def perform_location_plan(thoth, plan):
         thoth.create_location if plan.action == 'create'
         else thoth.update_location
     )
+    mutation_data = plan.data
+    if plan.action == 'update' and plan.data['fullTextUrl'] is None:
+        mutation_data = dict(plan.data)
+        mutation_data['fullTextUrl'] = EXPLICIT_GRAPHQL_NULL
     try:
-        location_id = mutation(plan.data)
+        location_id = mutation(mutation_data)
     except Exception as error:
         if _is_authentication_error(error):
             raise AuthenticationError(

--- a/write_locations.py
+++ b/write_locations.py
@@ -264,7 +264,7 @@ def decide_location_action(location_input, existing_locations):
     return LocationPlan('update', desired)
 
 
-def perform_location_plan(thoth, plan):
+def perform_location_plan(thoth, plan, progress=None):
     """Perform the planned mutation, if any, and return its location ID."""
     if plan.action == 'noop':
         logging.info(
@@ -283,6 +283,9 @@ def perform_location_plan(thoth, plan):
     if plan.action == 'update' and plan.data['fullTextUrl'] is None:
         mutation_data = dict(plan.data)
         mutation_data['fullTextUrl'] = EXPLICIT_GRAPHQL_NULL
+    action = '{}_thoth_location'.format(plan.action)
+    if progress is not None:
+        progress(action, 'attempted')
     try:
         location_id = mutation(mutation_data)
     except Exception as error:
@@ -301,14 +304,16 @@ def perform_location_plan(thoth, plan):
             )
         ) from error
 
+    if progress is not None:
+        progress(action, 'completed')
     print(location_id)
     return location_id
 
 
-def upsert_location(thoth, location_input):
+def upsert_location(thoth, location_input, progress=None):
     existing = retrieve_existing_locations(thoth, location_input.publication_id)
     plan = decide_location_action(location_input, existing)
-    return perform_location_plan(thoth, plan)
+    return perform_location_plan(thoth, plan, progress=progress)
 
 
 def write_thoth_location(publication_id, location_platform, landing_page,

--- a/write_locations.py
+++ b/write_locations.py
@@ -1,71 +1,350 @@
 #!/usr/bin/env python3
-"""
-Write one or more sets of publication location information to Thoth.
-Input: path to file containing location information, one location per line,
-containing publication ID, location platform, landing page and full text URL,
-separated by spaces.
-Requires: Thoth personal access token as THOTH_PAT env var.
-"""
+"""Converge Thoth publication locations from dissemination output."""
 
-# Third-party package already included in thoth-dissemination/requirements.txt
-from thothlibrary import ThothError
+from dataclasses import dataclass
+import logging
 from os import environ
 import sys
-import logging
-from thothapi import get_thoth_client
+
+from thothapi import (
+    ThothGraphQLResponseError,
+    ThothGraphQLTransportError,
+    get_publication_locations,
+    get_thoth_client,
+)
 
 
 logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(asctime)s: %(message)s')
 
 
-def write_thoth_location(publication_id, location_platform, landing_page,
-                         full_text_url, checksum, checksum_algorithm):
+class LocationWriteError(RuntimeError):
+    """A requested location could not be safely converged."""
+
+
+class MissingTokenError(LocationWriteError):
+    """The required Thoth personal access token is missing."""
+
+
+class AuthenticationError(LocationWriteError):
+    """Thoth rejected the request as unauthenticated or unauthorised."""
+
+
+class PublicationNotFoundError(LocationWriteError):
+    """The requested publication does not exist in Thoth."""
+
+
+class DuplicateLocationsError(LocationWriteError):
+    """Multiple existing locations make an update ambiguous."""
+
+
+class LocationLookupError(LocationWriteError):
+    """Existing Thoth locations could not be retrieved safely."""
+
+
+class LocationMutationError(LocationWriteError):
+    """A Thoth location create or update mutation failed."""
+
+
+class MalformedLocationError(ValueError, LocationWriteError):
+    """A dissemination location line is malformed."""
+
+
+@dataclass(frozen=True)
+class LocationInput:
+    publication_id: str
+    location_platform: str
+    landing_page: str
+    full_text_url: str | None
+    checksum: str | None
+    checksum_algorithm: str | None
+
+
+@dataclass(frozen=True)
+class LocationPlan:
+    action: str
+    data: dict
+
+
+MANAGED_FIELDS = (
+    'landingPage',
+    'fullTextUrl',
+    'locationPlatform',
+    'checksum',
+    'checksumAlgorithm',
+)
+
+REQUIRED_EXISTING_FIELDS = (
+    'locationId',
+    'publicationId',
+    'locationPlatform',
+    'landingPage',
+    'fullTextUrl',
+    'canonical',
+    'checksum',
+    'checksumAlgorithm',
+)
+
+
+def validate_checksum_pair(checksum, checksum_algorithm, description):
+    if (checksum is None) != (checksum_algorithm is None):
+        raise MalformedLocationError(
+            '{} must provide both checksum and checksum algorithm, or neither'.format(
+                description
+            )
+        )
+
+
+def parse_location_line(line, line_number):
+    """Parse one six-field ``Location.__str__()`` output line."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    parts = stripped.split()
+    if len(parts) != 6:
+        raise MalformedLocationError(
+            'Line {}: expected 6 fields, found {} in {!r}'.format(
+                line_number, len(parts), stripped
+            )
+        )
+
+    for index in (3, 4, 5):
+        if parts[index] == 'None':
+            parts[index] = None
+
+    parsed = LocationInput(*parts)
+    try:
+        validate_checksum_pair(
+            parsed.checksum,
+            parsed.checksum_algorithm,
+            'Line {} incoming location'.format(line_number),
+        )
+    except MalformedLocationError as error:
+        raise MalformedLocationError(str(error)) from error
+    return parsed
+
+
+def configure_thoth_client():
+    """Return a PAT-authenticated Thoth client."""
+    token = environ.get('THOTH_PAT')
+    if not token:
+        raise MissingTokenError(
+            'No Thoth token provided (THOTH_PAT environment variable not set)'
+        )
     thoth = get_thoth_client()
-    try:
-        token = environ['THOTH_PAT']
-    except KeyError as e:
-        raise KeyError('No Thoth token provided (THOTH_PAT environment variable not set)') from e
-
     thoth.set_token(token)
+    return thoth
 
-    location = {
-        'publicationId': publication_id,
-        'landingPage': landing_page,
-        'fullTextUrl': full_text_url,
-        'locationPlatform': location_platform,
-        'canonical': 'false',
-        'checksum': checksum,
-        'checksumAlgorithm': checksum_algorithm
-    }
+
+def _is_authentication_error(error):
+    text = str(error).lower()
+    return any(marker in text for marker in (
+        'authentication', 'unauthenticated', 'unauthorized', 'unauthorised',
+        'authorization', 'authorisation', 'not authorized', 'not authorised',
+        'forbidden', 'permission denied',
+        'status code 401', 'status code 403',
+    ))
+
+
+def _is_publication_not_found_error(error):
+    text = str(error).lower()
+    return 'publication' in text and any(marker in text for marker in (
+        'not found', 'no record was found', 'could not find',
+    ))
+
+
+def retrieve_existing_locations(thoth, publication_id):
+    """Retrieve complete existing location state for a publication."""
     try:
-        location_id = thoth.create_location(location)
-    except ThothError as e:
-        error_message = str(e)
-        if "A location on the selected platform already exists." in error_message:
-            logging.info(
-                "Location already exists for publication {} on {} - skipping".format(
-                    publication_id, location_platform
+        locations = get_publication_locations(thoth, publication_id)
+    except ThothGraphQLResponseError as error:
+        if _is_authentication_error(error):
+            raise AuthenticationError(
+                'Thoth authentication or authorisation failed: {}'.format(error)
+            ) from error
+        if _is_publication_not_found_error(error):
+            raise PublicationNotFoundError(
+                'Publication {} was not found: {}'.format(publication_id, error)
+            ) from error
+        raise LocationLookupError(
+            'Thoth GraphQL lookup failed for publication {}: {}'.format(
+                publication_id, error
+            )
+        ) from error
+    except ThothGraphQLTransportError as error:
+        raise LocationLookupError(
+            'Thoth GraphQL transport failed for publication {}: {}'.format(
+                publication_id, error
+            )
+        ) from error
+
+    for location in locations:
+        missing = [
+            field for field in REQUIRED_EXISTING_FIELDS
+            if field not in location
+        ]
+        if missing:
+            raise LocationLookupError(
+                'Location {} for publication {} omitted required fields: {}'.format(
+                    location.get('locationId', '<unknown>'),
+                    publication_id,
+                    ', '.join(missing),
                 )
             )
-            return
-        raise
+        if location['publicationId'] != publication_id:
+            raise LocationLookupError(
+                'Location {} belongs to publication {}, expected {}'.format(
+                    location['locationId'],
+                    location['publicationId'],
+                    publication_id,
+                )
+            )
+    return locations
+
+
+def construct_desired_location(location_input, existing=None):
+    """Build complete create/update state while preserving unmanaged values."""
+    validate_checksum_pair(
+        location_input.checksum,
+        location_input.checksum_algorithm,
+        'Incoming location',
+    )
+
+    checksum = location_input.checksum
+    checksum_algorithm = location_input.checksum_algorithm
+    if existing is not None and checksum is None:
+        validate_checksum_pair(
+            existing['checksum'],
+            existing['checksumAlgorithm'],
+            'Existing location {}'.format(existing['locationId']),
+        )
+        checksum = existing['checksum']
+        checksum_algorithm = existing['checksumAlgorithm']
+
+    desired = {
+        'publicationId': location_input.publication_id,
+        'landingPage': location_input.landing_page,
+        'fullTextUrl': location_input.full_text_url,
+        'locationPlatform': location_input.location_platform,
+        'canonical': existing['canonical'] if existing is not None else False,
+        'checksum': checksum,
+        'checksumAlgorithm': checksum_algorithm,
+    }
+    if existing is not None:
+        desired['locationId'] = existing['locationId']
+    return desired
+
+
+def decide_location_action(location_input, existing_locations):
+    """Return a create, update, or no-op plan for one input location."""
+    matches = [
+        location for location in existing_locations
+        if location['locationPlatform'] == location_input.location_platform
+    ]
+    if len(matches) > 1:
+        location_ids = [location['locationId'] for location in matches]
+        raise DuplicateLocationsError(
+            'Publication {} has multiple {} locations: {}'.format(
+                location_input.publication_id,
+                location_input.location_platform,
+                ', '.join(location_ids),
+            )
+        )
+
+    if not matches:
+        return LocationPlan(
+            'create', construct_desired_location(location_input)
+        )
+
+    existing = matches[0]
+    desired = construct_desired_location(location_input, existing)
+    if all(existing[field] == desired[field] for field in MANAGED_FIELDS):
+        return LocationPlan('noop', desired)
+    return LocationPlan('update', desired)
+
+
+def perform_location_plan(thoth, plan):
+    """Perform the planned mutation, if any, and return its location ID."""
+    if plan.action == 'noop':
+        logging.info(
+            'Location %s for publication %s on %s is already current; no mutation needed',
+            plan.data['locationId'],
+            plan.data['publicationId'],
+            plan.data['locationPlatform'],
+        )
+        return None
+
+    mutation = (
+        thoth.create_location if plan.action == 'create'
+        else thoth.update_location
+    )
+    try:
+        location_id = mutation(plan.data)
+    except Exception as error:
+        if _is_authentication_error(error):
+            raise AuthenticationError(
+                'Thoth authentication or authorisation failed during {}: {}'.format(
+                    plan.action, error
+                )
+            ) from error
+        raise LocationMutationError(
+            'Thoth {} location mutation failed for publication {} on {}: {}'.format(
+                plan.action,
+                plan.data['publicationId'],
+                plan.data['locationPlatform'],
+                error,
+            )
+        ) from error
+
     print(location_id)
+    return location_id
+
+
+def upsert_location(thoth, location_input):
+    existing = retrieve_existing_locations(thoth, location_input.publication_id)
+    plan = decide_location_action(location_input, existing)
+    return perform_location_plan(thoth, plan)
+
+
+def write_thoth_location(publication_id, location_platform, landing_page,
+                         full_text_url, checksum, checksum_algorithm,
+                         thoth=None):
+    """Compatibility entrypoint for converging one location."""
+    location_input = LocationInput(
+        publication_id,
+        location_platform,
+        landing_page,
+        full_text_url,
+        checksum,
+        checksum_algorithm,
+    )
+    return upsert_location(thoth or configure_thoth_client(), location_input)
+
+
+def process_locations_file(locations_file):
+    thoth = None
+    with open(locations_file, 'r') as locations:
+        for line_number, line in enumerate(locations, start=1):
+            location_input = parse_location_line(line, line_number)
+            if location_input is None:
+                continue
+            if thoth is None:
+                thoth = configure_thoth_client()
+            upsert_location(thoth, location_input)
+
+
+def main(argv=None):
+    arguments = sys.argv[1:] if argv is None else argv
+    if len(arguments) != 1:
+        logging.error('Usage: python write_locations.py <locations-file>')
+        return 2
+    try:
+        process_locations_file(arguments[0])
+    except (LocationWriteError, OSError) as error:
+        logging.error('%s', error)
+        return 1
+    return 0
 
 
 if __name__ == '__main__':
-    locations_file = sys.argv[1]
-    with open(locations_file, 'r') as locations:
-        for location in locations:
-            parts = location.rstrip().split(' ')
-            try:
-                # Handle locations which only have a landing page, no full text URL
-                if parts[3] == "None":
-                    parts[3] = None
-                # Handle locations which don't have a checksum
-                if parts[4] == "None":
-                    parts[4] = None
-                if parts[5] == "None":
-                    parts[5] = None
-                write_thoth_location(parts[0], parts[1], parts[2], parts[3], parts[4], parts[5])
-            except IndexError:
-                raise ValueError('Not enough data in entry "{}"'.format(location.rstrip()))
+    sys.exit(main())

--- a/write_locations.py
+++ b/write_locations.py
@@ -264,7 +264,8 @@ def decide_location_action(location_input, existing_locations):
     return LocationPlan('update', desired)
 
 
-def perform_location_plan(thoth, plan, progress=None):
+def perform_location_plan(
+        thoth, plan, progress=None, emit_location_id=False):
     """Perform the planned mutation, if any, and return its location ID."""
     if plan.action == 'noop':
         logging.info(
@@ -306,14 +307,28 @@ def perform_location_plan(thoth, plan, progress=None):
 
     if progress is not None:
         progress(action, 'completed')
-    print(location_id)
+    logging.info(
+        'Thoth location %s succeeded: location_id=%s publication_id=%s platform=%s',
+        plan.action,
+        location_id,
+        plan.data['publicationId'],
+        plan.data['locationPlatform'],
+    )
+    if emit_location_id:
+        print(location_id)
     return location_id
 
 
-def upsert_location(thoth, location_input, progress=None):
+def upsert_location(
+        thoth, location_input, progress=None, emit_location_id=False):
     existing = retrieve_existing_locations(thoth, location_input.publication_id)
     plan = decide_location_action(location_input, existing)
-    return perform_location_plan(thoth, plan, progress=progress)
+    return perform_location_plan(
+        thoth,
+        plan,
+        progress=progress,
+        emit_location_id=emit_location_id,
+    )
 
 
 def write_thoth_location(publication_id, location_platform, landing_page,
@@ -328,7 +343,11 @@ def write_thoth_location(publication_id, location_platform, landing_page,
         checksum,
         checksum_algorithm,
     )
-    return upsert_location(thoth or configure_thoth_client(), location_input)
+    return upsert_location(
+        thoth or configure_thoth_client(),
+        location_input,
+        emit_location_id=True,
+    )
 
 
 def process_locations_file(locations_file):
@@ -340,7 +359,7 @@ def process_locations_file(locations_file):
                 continue
             if thoth is None:
                 thoth = configure_thoth_client()
-            upsert_location(thoth, location_input)
+            upsert_location(thoth, location_input, emit_location_id=True)
 
 
 def main(argv=None):


### PR DESCRIPTION
## Summary

- make Internet Archive dissemination converge existing items by updating only changed managed files and metadata, then verify final remote state
- make Thoth Internet Archive location write-back converge create, update, and no-op states
- provide credential-free, read-only reconciliation with guarded apply repair and deterministic reports
- run scheduled Internet Archive dissemination daily at 04:40 UTC
- select configured-publisher works by `updatedAtWithRelations` within one captured UTC window
- use a default 30-hour lookback, giving ordinary daily runs a six-hour overlap
- require active IA-supported book-level works with a usable canonical PDF source
- process eligible works deterministically by oldest update, then work UUID
- cap scheduled selection at 200 works and disseminate at most four works concurrently
- retain a 30-day selection report/log artifact and write aggregate Step Summaries
- finish the bounded selected batch before failing visibly when overflow occurred
- prevent simultaneous ordinary dissemination of the same platform/work pair
- emit compact valid JSON arrays from all automatic ID finders

## Update-aware scheduled selection

`InternetArchive` now maps to a dedicated `InternetArchiveIDFinder`; the existing monthly finder and every other platform mapping and schedule are unchanged.

The selector validates `IA_ENV_PUBLISHERS` as a non-empty JSON array of known publisher UUIDs and `IA_ENV_EXCEPTIONS` as an optional JSON UUID array. UUIDs are normalised and deterministically deduplicated. Invalid or unknown configuration fails selection before dissemination.

One timezone-aware `now` value is captured per run. The selected interval is:

```text
updatedAtWithRelations > window_start
updatedAtWithRelations <= window_end
```

The live Thoth schema supports the lower `GREATER_THAN` expression but not two simultaneous timestamp expressions, so the bounded GraphQL query applies the start filter and the selector enforces the captured upper boundary locally. Updates after `window_end` are reported and left for the next run.

The unauthenticated GraphQL helper retrieves only work ID, relation-aware update timestamp, status, type, publication type, and canonical/full-text location fields. It uses 100-record pages until exhaustion, active status, the shared IA-supported work-type policy, configured publisher filtering, and `UPDATED_AT_WITH_RELATIONS` ordering. Selection never downloads a PDF, requests a JSON export, or makes a HEAD/GET request to a source URL.

Eligibility requires an active `MONOGRAPH`, `EDITED_BOOK`, `JOURNAL_ISSUE`, `TEXTBOOK`, or `BOOK_SET` with a PDF publication and non-empty canonical PDF `fullTextUrl`. Exceptions, eligibility filtering, and work-ID deduplication happen before the cap. Duplicate records retain the newest valid relation-aware update timestamp.

Selected and omitted records are ordered by relation-aware update ascending and work UUID ascending. At most 200 selected IDs enter the matrix. Every overflow record remains in the report; the workflow completes the bounded selected batch and then fails the final guard with the artifact name and operator guidance.

## Workflow safety and observability

- scheduled trigger: `40 4 * * *`
- manual lookback: positive finite hours, default 30, maximum 168
- manual work limit: integer 1-200, default 200
- workflow concurrency: `internet-archive-scheduled-dissemination`, non-cancelling
- selection job: read-only repository permission, no GitHub environment, no Archive credentials, no `THOTH_PAT`
- selection inputs: only `IA_ENV_PUBLISHERS` and `IA_ENV_EXCEPTIONS`
- matrix: `fail-fast: false`, `max-parallel: 4`, selected work IDs only
- reusable dissemination concurrency: one ordinary run per platform/work pair, non-cancelling
- diagnostics: always-uploaded 30-day `ia-selection-<run_id>-<attempt>` report/log artifact and concise Step Summary
- final status: fails on selection failure, any matrix failure, or truncation; non-truncated empty selections succeed

Unchanged selected works safely converge as no-ops through the existing idempotent uploader and location writer.

## Reconciliation and mutation safety

The reconciliation CLI and manual workflow remain read-only by default. Apply mode is explicit, credential-gated, protected, and reuses the uploader/location convergence paths. Identifier collisions, unavailable identifiers, ambiguous ownership, duplicate locations, unavailable sources, immutable metadata conflicts, and collection-membership conflicts remain non-mutating.

No scheduled, reconciliation-apply, or live dissemination workflow was dispatched while implementing this change. No live Internet Archive or Thoth mutation was performed.

## Validation

- `python3 -m unittest discover -v` — 324 passed
- `python3 -m unittest -v tests.test_obtain_new_ids` — 59 passed
- `python3 -m unittest -v tests.test_iauploader` — 58 passed
- `python3 -m unittest -v tests.test_write_locations` — 34 passed
- `python3 -m unittest -v tests.test_reconcile_internet_archive` — 106 passed
- `python3 -m unittest -v tests.test_reconcile_cli` — 20 passed
- `python3 -m unittest -v tests.test_ia_reconcile_workflow` — 7 passed
- `python3 -m unittest -v tests.test_ia_bulk_disseminate_workflow` — 26 passed
- `python3 -m compileall -q .` — passed
- `git diff --check` and staged whitespace check — passed
- official Actionlint v1.7.7 against `ia_bulk_disseminate.yml`, `disseminate.yml`, `ia_reconcile.yml`, `tests.yml`, and `bulk_disseminate.yml` — passed with no findings
- live read-only schema inspection confirmed the timestamp, ordering, status, work-type, publication, and location query contract
- credential-free live selection smoke — not run because `IA_ENV_PUBLISHERS` is unavailable locally

## Exact-head GitHub Actions

- push event on `9dc7afa5f0454e85ef613ba31562c6254e4d8b3c` — [passed](https://github.com/thoth-pub/thoth-dissemination/actions/runs/30030067263)
- pull-request event on the same SHA — [passed](https://github.com/thoth-pub/thoth-dissemination/actions/runs/30030073597)

## Fresh Codex review

- review of `ed7799fba51b9628be3b7851fa46d41adc6c5932` found one actionable P2: refresh and reclassify Archive ownership immediately before mutation
- fixed in `9dc7afa5f0454e85ef613ba31562c6254e4d8b3c`; the item is refreshed, ownership is reclassified, and the repair diff is recomputed before credentials or mutation
- focused collision, lost-legacy-membership, and refresh-failure tests prove the path fails with zero Archive mutations
- validation after the review fix: 324 full-suite tests and 58 uploader tests passed; compileall, diff checks, and Actionlint remained clean
- the review thread was replied to with exact-head evidence and resolved; no unresolved review threads remain
- three exact-head review triggers were attempted after the fix; GitHub's Codex connector returned its code-review usage-limit response each time
- a delayed clean response explicitly reviewed the older `ed7799fba5` commit, so it is not being represented as an exact-head review of `9dc7afa5f0`

PR remains open and unmerged.