### PR TITLE
Exclude IA-derived metadata from final verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+  - Exclude Internet Archive-derived metadata (`imagecount`) from apply-time final-state verification, matching read-only inspection, so metadata repairs converge instead of timing out (and no longer abort before Thoth location creation) on items where Internet Archive holds a derived value
 
 ## [[1.6.0]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v1.6.0) - 2026-07-24
 ### Changed

--- a/iauploader.py
+++ b/iauploader.py
@@ -93,6 +93,15 @@ class IAUploader(Uploader):
     MUTABLE_MANAGED_METADATA_FIELDS = (
         MANAGED_METADATA_FIELDS - NON_AUTOMUTABLE_METADATA_FIELDS
     )
+    # Managed fields whose final remote state we can verify. Internet
+    # Archive-derived fields are excluded because IA owns their value after
+    # upload (e.g. it recomputes `imagecount` from the deposited PDF), so
+    # neither a divergent value nor its presence when we sent none is a
+    # verification failure. This keeps final-state verification consistent with
+    # `inspect_item`, which already scopes its checks to the non-derived subsets.
+    FINAL_VERIFICATION_METADATA_FIELDS = (
+        MANAGED_METADATA_FIELDS - DERIVED_METADATA_FIELDS
+    )
 
     def upload_to_platform(self):
         """Create or idempotently update a work in Internet Archive."""
@@ -755,7 +764,8 @@ class IAUploader(Uploader):
                             '{} has MD5 {!r}, expected {!r}'.format(
                                 name, remote_md5, expected_md5))
                 metadata_problems = self._metadata_verification_problems(
-                    item.metadata, desired_metadata, absent_fields)
+                    item.metadata, desired_metadata, absent_fields,
+                    fields=self.FINAL_VERIFICATION_METADATA_FIELDS)
                 last_file_problems = file_problems
                 last_metadata_problems = metadata_problems
                 last_refresh_problem = None

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -360,6 +360,75 @@ class TestIAUploader(unittest.TestCase):
         self.assertNotIn('imagecount', IAUploader.INITIAL_ONLY_METADATA_FIELDS)
         self.assertNotIn('imagecount', IAUploader.ADMIN_ONLY_METADATA_FIELDS)
 
+    def test_final_verification_field_scope_excludes_only_derived(self):
+        # Final verification must cover every managed field except the ones
+        # Internet Archive derives and owns, keeping it consistent with
+        # inspect_item's non-derived scoping.
+        self.assertEqual(
+            IAUploader.FINAL_VERIFICATION_METADATA_FIELDS,
+            IAUploader.MANAGED_METADATA_FIELDS
+            - IAUploader.DERIVED_METADATA_FIELDS)
+        self.assertNotIn(
+            'imagecount', IAUploader.FINAL_VERIFICATION_METADATA_FIELDS)
+        for field in ('mediatype', 'collection', 'title', 'description',
+                      'thoth-work-id', 'thoth-dissemination-service'):
+            self.assertIn(
+                field, IAUploader.FINAL_VERIFICATION_METADATA_FIELDS)
+
+    def test_final_verification_ignores_present_derived_field(self):
+        # Reproduces the post-PR #90 canary failure: Thoth has no pageCount so
+        # desired metadata omits imagecount, but Internet Archive holds a
+        # derived imagecount. Final verification must not demand its absence.
+        self.uploader.metadata['data']['work']['pageCount'] = None
+        desired = self._desired_metadata()
+        self.assertNotIn('imagecount', desired)
+        stale = dict(desired, description='Stale description', imagecount='120')
+        self._set_existing_item(metadata=stale)
+
+        locations = self.uploader.upload_to_platform()
+
+        # The stale mutable field is repaired, but imagecount is neither
+        # patched nor removed, and final verification succeeds.
+        self.item.modify_metadata.assert_called_once()
+        patch = self.item.modify_metadata.call_args.args[0]
+        self.assertIn('description', patch)
+        self.assertNotIn('imagecount', patch)
+        self.assertEqual(self.item.metadata.get('imagecount'), '120')
+        self.mock_upload.assert_not_called()
+        self._assert_location(locations[0])
+
+    def test_final_verification_ignores_divergent_derived_field(self):
+        # Desired imagecount (from pageCount) differs from IA's derived value.
+        desired = self._desired_metadata()
+        self.assertEqual(desired.get('imagecount'), '250')
+        stale = dict(desired, description='Stale description', imagecount='247')
+        self._set_existing_item(metadata=stale)
+
+        locations = self.uploader.upload_to_platform()
+
+        patch = self.item.modify_metadata.call_args.args[0]
+        self.assertNotIn('imagecount', patch)
+        self.assertEqual(self.item.metadata.get('imagecount'), '247')
+        self.mock_upload.assert_not_called()
+        self._assert_location(locations[0])
+
+    def test_final_verification_still_fails_on_stale_mutable_field(self):
+        # A genuine mutable field that stays stale after the update must still
+        # raise, proving the fix is a field-scope correction, not a bypass.
+        metadata = dict(self._desired_metadata(), title='Old title')
+        self._set_existing_item(metadata=metadata)
+        # Acknowledge the patch without applying it, so the field stays stale.
+        self.item.modify_metadata.side_effect = \
+            lambda *args, **kwargs: make_response()
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 1):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader.upload_to_platform()
+
+        self.assertIn('metadata discrepancies', str(raised.exception))
+        self.assertIn('title', str(raised.exception))
+        self.assertIn('Old title', str(raised.exception))
+
     def test_genuine_description_change_is_still_detected(self):
         desired = self.uploader.build_desired_state()
         metadata = self._desired_metadata()


### PR DESCRIPTION
## Problem

The post-PR #90 reconciliation canary exposed an apply-time verification bug.

- Canary runs: dry-run **30105108257**, apply **30105391003**, follow-up **30106828377**.
- The apply timed out for **five** works, each with:
  > `Timed out verifying … imagecount is still present with value 'N', expected it to be absent`
- The follow-up dry-run proved all seven IA metadata updates had *landed*; four works were left `location_missing` only because the verification timeout aborted the apply path before the Thoth location step. No PDF or JSON was uploaded.

## Root cause

`inspect_item()` scopes its metadata verification explicitly to the non-derived subsets — `MUTABLE_MANAGED_METADATA_FIELDS`, `INITIAL_ONLY_METADATA_FIELDS`, `ADMIN_ONLY_METADATA_FIELDS` — all of which exclude `DERIVED_METADATA_FIELDS` (`imagecount`). So the **dry-run correctly ignored** IA's derived `imagecount`.

But `_verify_final_state()` called `_metadata_verification_problems(item.metadata, desired_metadata, absent_fields)` **without `fields=`**, which defaults to `MANAGED_METADATA_FIELDS` — still containing `imagecount`. Apply-time verification therefore demanded a field IA owns and derives, could never converge (the field is non-mutable, and IA re-derives it), and timed out. This made **dry-run inspection and apply-time verification inconsistent**.

## Fix

Introduce a named constant and use it for final verification:

```python
FINAL_VERIFICATION_METADATA_FIELDS = MANAGED_METADATA_FIELDS - DERIVED_METADATA_FIELDS
```
```python
self._metadata_verification_problems(
    item.metadata, desired_metadata, absent_fields,
    fields=self.FINAL_VERIFICATION_METADATA_FIELDS)
```

`MANAGED_METADATA_FIELDS - DERIVED_METADATA_FIELDS` is the correct scope because IA **owns** derived fields after upload: neither a divergent value nor its presence-when-we-sent-none is a real discrepancy. Both the "differs" and "expected absent" checks in the helper are gated by `fields`, so both cases are handled. There is **no special-casing of the literal `"imagecount"`** — any field later added to `DERIVED_METADATA_FIELDS` is honoured automatically.

## What remains verified

Restricted and mutable metadata are unchanged: final verification still checks mutable fields (`title`, `description`, `thoth-dissemination-service`), initial-only `mediatype`, admin-only `collection`, ownership `thoth-work-id`, absence of obsolete **non-derived** managed fields, and file MD5s. `imagecount` remains in `MANAGED_METADATA_FIELDS` (still seeded on creation when Thoth has `pageCount`) and is not made mutable/initial-only/admin-only. **Retry count and sleep duration are unchanged**; the `InternetArchiveVerificationError` is not suppressed. This is a field-scope correction, not a timeout workaround.

## Tests (`tests/test_iauploader.py`)

- **Reproduction** — existing owned item, Thoth `pageCount=None` (desired omits `imagecount`), IA holds a derived `imagecount`, a stale `description` needs repair: the repair applies, `imagecount` is neither patched nor removed, no file upload, and final verification succeeds. **This test fails on the pre-fix commit** (raises `imagecount is still present … expected it to be absent`) and passes after the fix.
- **Divergent derived value** — desired `imagecount` differs from IA's retained value; verification succeeds, `imagecount` not re-patched.
- **Genuine mutable failure still fails** — a stale `title` after update still raises `InternetArchiveVerificationError` (with `VERIFICATION_ATTEMPTS = 1`).
- **Scope consistency** — asserts `FINAL_VERIFICATION_METADATA_FIELDS == MANAGED_METADATA_FIELDS - DERIVED_METADATA_FIELDS`, excludes `imagecount`, and includes `mediatype`, `collection`, `title`, `description`, `thoth-work-id`, `thoth-dissemination-service`.
- Existing restricted-field verification tests (new-item `mediatype` / Thoth `collection`) and the `imagecount` seeding/scoping tests are retained unchanged.

### Results
- Pre-fix reproduction: `FAILED … imagecount is still present with value '120', expected it to be absent` (confirmed by reverting only `iauploader.py`).
- `python3 -m pytest -q` → **340 passed, 50 subtests passed**.
- `python3 -m pytest -q tests/test_iauploader.py` → all pass.
- `python3 -m compileall -q .` clean; `git diff --check` clean.

The production canary can only be re-verified after this PR is merged and the workflow runs from updated `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)