### PR TITLE
Handle delayed IA original-file propagation

### DIFF
--- a/.github/scripts/ia_reconcile_workflow.py
+++ b/.github/scripts/ia_reconcile_workflow.py
@@ -16,6 +16,19 @@ WORK_IDS_PATH = Path("normalised-work-ids.txt")
 REPORT_PATH = Path("internet-archive-reconciliation.json")
 STATUS_PATH = Path("reconciliation-exit-status.txt")
 
+# Dry-run only inspects item state, so it may discover a large candidate batch.
+DRY_RUN_MAX_BATCH_SIZE = 200
+# Apply runs mutate IA and each affected work can incur ~932s of extended
+# upload-propagation polling; a conservative cap keeps a fully lagging batch
+# within the 180-minute apply job timeout with margin for source retrieval,
+# uploads and report generation. Larger campaigns use multiple sequential runs.
+APPLY_MAX_BATCH_SIZE = 7
+
+
+def maximum_batch_size(mode):
+    """Return the worst-case selectable-works cap for the given mode."""
+    return DRY_RUN_MAX_BATCH_SIZE if mode == "dry-run" else APPLY_MAX_BATCH_SIZE
+
 
 def annotation(title, message):
     """Emit an escaped GitHub error annotation."""
@@ -89,6 +102,7 @@ def validate_inputs(mode):
         errors.append(message)
         annotation("No selection criteria", message)
 
+    maximum_batch = maximum_batch_size(mode)
     possible_batch = None
     if limit is not None:
         possible_batch = (
@@ -96,13 +110,21 @@ def validate_inputs(mode):
             if publisher_raw
             else len(explicit_ids)
         )
-        if possible_batch > 200:
-            message = (
-                "The requested batch can select up to "
-                f"{possible_batch} works; the hard limit is 200"
-            )
+        if possible_batch > maximum_batch:
+            if mode == "apply":
+                message = (
+                    f"Apply batches may select at most {APPLY_MAX_BATCH_SIZE} "
+                    f"works; this request can select up to {possible_batch}."
+                )
+                annotation("Apply batch exceeds cap", message)
+            else:
+                message = (
+                    "The requested batch can select up to "
+                    f"{possible_batch} works; the hard limit is "
+                    f"{DRY_RUN_MAX_BATCH_SIZE}"
+                )
+                annotation("Combined batch exceeds 200", message)
             errors.append(message)
-            annotation("Combined batch exceeds 200", message)
 
     if mode == "apply":
         if os.environ.get("INPUT_CONFIRM_APPLY") != "APPLY":
@@ -122,6 +144,7 @@ def validate_inputs(mode):
         "explicit_work_id_count": len(explicit_ids),
         "github_ref": os.environ.get("GITHUB_REF"),
         "limit": limit,
+        "maximum_batch_size": maximum_batch,
         "mode": mode,
         "offset": offset,
         "possible_batch_size": possible_batch,

--- a/.github/workflows/ia_reconcile.yml
+++ b/.github/workflows/ia_reconcile.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
       limit:
-        description: 'Maximum publisher works to select (1-200)'
+        description: 'Maximum publisher works to select (dry-run: 1-200; apply: maximum 7 total works)'
         required: true
         default: 100
         type: number

--- a/iauploader.py
+++ b/iauploader.py
@@ -41,8 +41,15 @@ class IAUploader(Uploader):
     """Dissemination logic for Internet Archive."""
 
     THOTH_COLLECTION = 'thoth-archiving-network'
+    # Phase 1 (ordinary) verification: metadata + all expected originals.
     VERIFICATION_ATTEMPTS = 10
     VERIFICATION_SLEEP_SECONDS = 20
+    # Phase 2 (extended) verification: only for originals successfully uploaded
+    # during this invocation whose new bytes Internet Archive has accepted but
+    # not yet exposed (eventual consistency). Bounded backoff, no re-upload.
+    UPLOAD_PROPAGATION_ATTEMPTS = 8
+    UPLOAD_PROPAGATION_INITIAL_SLEEP_SECONDS = 30
+    UPLOAD_PROPAGATION_MAX_SLEEP_SECONDS = 180
     REPEATABLE_METADATA_FIELDS = {
         'collection', 'creator', 'isbn', 'subject', 'language', 'issn'
     }
@@ -464,6 +471,7 @@ class IAUploader(Uploader):
             secret_key = secret_key or self.get_variable_from_env(
                 'ia_s3_secret', 'Internet Archive')
 
+        uploaded_file_names = set()
         for index, name in enumerate(files_to_upload):
             action = (
                 'upload_pdf_original' if name.endswith('.pdf')
@@ -480,6 +488,10 @@ class IAUploader(Uploader):
                 access_key,
                 secret_key,
             )
+            # Only record the file as uploaded after the S3 request was
+            # accepted (i.e. _upload_files returned without raising). Internet
+            # Archive may still take minutes to expose the new original.
+            uploaded_file_names.add(name)
             if progress is not None and creating_item and index == 0:
                 progress('create_archive_item', 'completed')
             if progress is not None:
@@ -502,6 +514,7 @@ class IAUploader(Uploader):
             desired.expected_md5s,
             desired.metadata,
             desired.absent_metadata_fields,
+            uploaded_file_names=frozenset(uploaded_file_names),
         )
 
     def _assert_item_owned_by_thoth(
@@ -743,62 +756,155 @@ class IAUploader(Uploader):
             return None
         return value
 
-    def _verify_final_state(
+    @classmethod
+    def _upload_propagation_sleeps(cls):
+        """Bounded backoff schedule (seconds) for extended propagation waits."""
+        sleeps = []
+        seconds = cls.UPLOAD_PROPAGATION_INITIAL_SLEEP_SECONDS
+        for _ in range(cls.UPLOAD_PROPAGATION_ATTEMPTS):
+            sleeps.append(min(seconds, cls.UPLOAD_PROPAGATION_MAX_SLEEP_SECONDS))
+            seconds = int(seconds * 1.5)
+        return sleeps
+
+    @staticmethod
+    def _describe_file_problem(problem):
+        if problem['kind'] == 'missing':
+            return '{} is missing as an original file'.format(problem['name'])
+        return '{} has MD5 {!r}, expected {!r}'.format(
+            problem['name'], problem['remote_md5'], problem['expected_md5'])
+
+    def _check_final_state(
             self, item, expected_md5s, desired_metadata, absent_fields):
-        last_file_problems = ['item file metadata was not available']
-        last_metadata_problems = ['item metadata was not available']
-        last_refresh_problem = None
+        """Refresh once and compare originals + metadata.
+
+        Returns a dict: ``verified`` (name->md5 map or None), ``file_problems``
+        (structured list or None), ``metadata_problems`` (list or None) and
+        ``refresh_error`` (str or None).
+        """
+        try:
+            item.refresh()
+        except req_except.RequestException as error:
+            return {'verified': None, 'file_problems': None,
+                    'metadata_problems': None,
+                    'refresh_error': 'refresh failed: {}'.format(error)}
+        originals = self._original_files(item.files)
+        file_problems = []
+        for name, expected_md5 in expected_md5s.items():
+            if name not in originals:
+                file_problems.append({
+                    'name': name, 'kind': 'missing',
+                    'remote_md5': None, 'expected_md5': expected_md5})
+                continue
+            remote_md5 = self._file_value(originals[name], 'md5')
+            if remote_md5 != expected_md5:
+                file_problems.append({
+                    'name': name, 'kind': 'stale',
+                    'remote_md5': remote_md5, 'expected_md5': expected_md5})
+        metadata_problems = self._metadata_verification_problems(
+            item.metadata, desired_metadata, absent_fields,
+            fields=self.FINAL_VERIFICATION_METADATA_FIELDS)
+        verified = None
+        if not file_problems and not metadata_problems:
+            verified = {name: self._file_value(originals[name], 'md5')
+                        for name in expected_md5s}
+        return {'verified': verified, 'file_problems': file_problems,
+                'metadata_problems': metadata_problems, 'refresh_error': None}
+
+    @staticmethod
+    def _is_upload_propagation_only(result, uploaded_file_names):
+        """True when the only remaining discrepancies are originals uploaded in
+        this invocation that Internet Archive has accepted but not yet exposed.
+
+        Deliberately conservative: any refresh error, metadata discrepancy, or
+        a file discrepancy for a file not uploaded in this invocation disqualifies
+        the extended phase.
+        """
+        if result.get('refresh_error'):
+            return False
+        if result.get('metadata_problems'):
+            return False
+        file_problems = result.get('file_problems')
+        if not file_problems:
+            return False
+        for problem in file_problems:
+            if problem['name'] not in uploaded_file_names:
+                return False
+            if problem['kind'] not in ('missing', 'stale'):
+                return False
+        return True
+
+    @staticmethod
+    def _problem_summary(result):
+        groups = []
+        if result.get('file_problems'):
+            groups.append('file discrepancies: {}'.format('; '.join(
+                IAUploader._describe_file_problem(p)
+                for p in result['file_problems'])))
+        if result.get('metadata_problems'):
+            groups.append('metadata discrepancies: {}'.format(
+                '; '.join(result['metadata_problems'])))
+        if result.get('refresh_error'):
+            groups.append(result['refresh_error'])
+        return '; '.join(groups) or 'no item state was available'
+
+    def _verify_final_state(
+            self, item, expected_md5s, desired_metadata, absent_fields,
+            uploaded_file_names=frozenset()):
+        # --- Phase 1: ordinary verification (metadata + all originals) ---
+        result = {'file_problems': None, 'metadata_problems': None,
+                  'refresh_error': 'item state was not available',
+                  'verified': None}
         for attempt in range(1, self.VERIFICATION_ATTEMPTS + 1):
-            try:
-                item.refresh()
-                originals = self._original_files(item.files)
-                file_problems = []
-                for name, expected_md5 in expected_md5s.items():
-                    if name not in originals:
-                        file_problems.append(
-                            '{} is missing as an original file'.format(name))
-                        continue
-                    remote_md5 = self._file_value(originals[name], 'md5')
-                    if remote_md5 != expected_md5:
-                        file_problems.append(
-                            '{} has MD5 {!r}, expected {!r}'.format(
-                                name, remote_md5, expected_md5))
-                metadata_problems = self._metadata_verification_problems(
-                    item.metadata, desired_metadata, absent_fields,
-                    fields=self.FINAL_VERIFICATION_METADATA_FIELDS)
-                last_file_problems = file_problems
-                last_metadata_problems = metadata_problems
-                last_refresh_problem = None
-                if not file_problems and not metadata_problems:
-                    return {
-                        name: self._file_value(originals[name], 'md5')
-                        for name in expected_md5s
-                    }
-            except req_except.RequestException as error:
-                last_refresh_problem = 'refresh failed: {}'.format(error)
-
-            problem_groups = []
-            if last_file_problems:
-                problem_groups.append(
-                    'file discrepancies: {}'.format(
-                        '; '.join(last_file_problems)))
-            if last_metadata_problems:
-                problem_groups.append(
-                    'metadata discrepancies: {}'.format(
-                        '; '.join(last_metadata_problems)))
-            if last_refresh_problem:
-                problem_groups.append(last_refresh_problem)
-            last_problem = '; '.join(problem_groups)
-
+            result = self._check_final_state(
+                item, expected_md5s, desired_metadata, absent_fields)
+            if result['verified'] is not None:
+                return result['verified']
             if attempt < self.VERIFICATION_ATTEMPTS:
                 logging.debug(
                     'Internet Archive verification incomplete on attempt %s: %s',
-                    attempt, last_problem)
+                    attempt, self._problem_summary(result))
                 sleep(self.VERIFICATION_SLEEP_SECONDS)
+
+        # --- Phase 2 gate ---
+        if self._is_upload_propagation_only(result, uploaded_file_names):
+            return self._verify_uploaded_file_propagation(
+                item, expected_md5s, desired_metadata, absent_fields,
+                uploaded_file_names, result)
 
         raise InternetArchiveVerificationError(
             'Timed out verifying Internet Archive item {} after {} attempts: {}'
-            .format(self.work_id, self.VERIFICATION_ATTEMPTS, last_problem))
+            .format(self.work_id, self.VERIFICATION_ATTEMPTS,
+                    self._problem_summary(result)))
+
+    def _verify_uploaded_file_propagation(
+            self, item, expected_md5s, desired_metadata, absent_fields,
+            uploaded_file_names, last_result):
+        """Extended, bounded wait for accepted-but-pending original uploads.
+
+        Never re-uploads. Only re-reads the item state on a backoff schedule.
+        """
+        result = last_result
+        sleeps = self._upload_propagation_sleeps()
+        for attempt, sleep_seconds in enumerate(sleeps, start=1):
+            logging.info(
+                'Waiting %ss for Internet Archive to expose accepted upload(s) '
+                'for %s (extended attempt %s/%s)',
+                sleep_seconds, self.work_id, attempt, len(sleeps))
+            sleep(sleep_seconds)
+            result = self._check_final_state(
+                item, expected_md5s, desired_metadata, absent_fields)
+            if result['verified'] is not None:
+                return result['verified']
+            # If a non-propagation problem surfaces (metadata drift, refresh
+            # error, or a file we did not upload), stop waiting and fail.
+            if not self._is_upload_propagation_only(result, uploaded_file_names):
+                break
+
+        raise InternetArchiveVerificationError(
+            'Timed out waiting for accepted Internet Archive upload propagation '
+            'for item {} after {} extended attempts (~{}s): {}'.format(
+                self.work_id, len(sleeps), sum(sleeps),
+                self._problem_summary(result)))
 
     def parse_metadata(self):
         """Convert work metadata into Internet Archive format."""

--- a/iauploader.py
+++ b/iauploader.py
@@ -885,25 +885,41 @@ class IAUploader(Uploader):
         """
         result = last_result
         sleeps = self._upload_propagation_sleeps()
+        completed_attempts = 0
+        elapsed_seconds = 0
+        stopped_early = False
         for attempt, sleep_seconds in enumerate(sleeps, start=1):
             logging.info(
                 'Waiting %ss for Internet Archive to expose accepted upload(s) '
                 'for %s (extended attempt %s/%s)',
                 sleep_seconds, self.work_id, attempt, len(sleeps))
             sleep(sleep_seconds)
+            completed_attempts = attempt
+            elapsed_seconds += sleep_seconds
             result = self._check_final_state(
                 item, expected_md5s, desired_metadata, absent_fields)
             if result['verified'] is not None:
                 return result['verified']
-            # If a non-propagation problem surfaces (metadata drift, refresh
-            # error, or a file we did not upload), stop waiting and fail.
+            # If a new non-propagation problem surfaces (metadata drift, refresh
+            # error, or a file we did not upload), stop waiting immediately and
+            # report the transition accurately -- do not claim the full
+            # propagation deadline expired.
             if not self._is_upload_propagation_only(result, uploaded_file_names):
+                stopped_early = True
                 break
+
+        if stopped_early:
+            raise InternetArchiveVerificationError(
+                'Internet Archive verification stopped during upload '
+                'propagation for item {} after {} extended attempts (~{}s): '
+                '{}'.format(
+                    self.work_id, completed_attempts, elapsed_seconds,
+                    self._problem_summary(result)))
 
         raise InternetArchiveVerificationError(
             'Timed out waiting for accepted Internet Archive upload propagation '
             'for item {} after {} extended attempts (~{}s): {}'.format(
-                self.work_id, len(sleeps), sum(sleeps),
+                self.work_id, completed_attempts, elapsed_seconds,
                 self._problem_summary(result)))
 
     def parse_metadata(self):

--- a/tests/test_ia_reconcile_workflow.py
+++ b/tests/test_ia_reconcile_workflow.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from uuid import UUID
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -12,6 +13,13 @@ HELPER = ROOT / ".github" / "scripts" / "ia_reconcile_workflow.py"
 WORK_ID = "11111111-2222-3333-4444-555555555555"
 WORK_ID_2 = "22222222-3333-4444-5555-666666666666"
 PUBLISHER_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+DRY_RUN_MAX_BATCH_SIZE = 200
+APPLY_MAX_BATCH_SIZE = 7
+
+
+def distinct_work_ids(count):
+    """Return `count` distinct valid UUIDs (explicit IDs are deduplicated)."""
+    return [str(UUID(int=index + 1)) for index in range(count)]
 
 
 class TestIAReconcileWorkflow(unittest.TestCase):
@@ -190,6 +198,185 @@ class TestIAReconcileWorkflow(unittest.TestCase):
         self.assertIn("- Applied actions: 1", summary)
         self.assertIn("- Uncertain actions: 1", summary)
         self.assertNotIn(WORK_ID, summary)
+
+    def _context(self, workdir):
+        return json.loads(
+            (workdir / "reconciliation-run-context.json").read_text()
+        )
+
+    def test_dry_run_publisher_limit_200_succeeds(self):
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "dry-run",
+            INPUT_LIMIT="200",
+            INPUT_PUBLISHER_ID=PUBLISHER_ID,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        context = self._context(workdir)
+        self.assertEqual(context["possible_batch_size"], 200)
+        self.assertEqual(
+            context["maximum_batch_size"], DRY_RUN_MAX_BATCH_SIZE
+        )
+        self.assertEqual(context["validation_errors"], [])
+
+    def test_dry_run_200_explicit_ids_succeeds(self):
+        ids = distinct_work_ids(200)
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "dry-run",
+            INPUT_WORK_IDS="\n".join(ids),
+        )
+
+        self.assertEqual(result.returncode, 0)
+        context = self._context(workdir)
+        self.assertEqual(context["explicit_work_id_count"], 200)
+        self.assertEqual(context["possible_batch_size"], 200)
+        self.assertEqual(context["validation_errors"], [])
+
+    def test_apply_seven_explicit_ids_succeeds(self):
+        ids = distinct_work_ids(7)
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_CONFIRM_APPLY="APPLY",
+            INPUT_WORK_IDS="\n".join(ids),
+        )
+
+        self.assertEqual(result.returncode, 0)
+        context = self._context(workdir)
+        self.assertEqual(context["possible_batch_size"], 7)
+        self.assertEqual(context["maximum_batch_size"], APPLY_MAX_BATCH_SIZE)
+        self.assertEqual(context["validation_errors"], [])
+
+    def test_apply_eight_explicit_ids_is_rejected(self):
+        ids = distinct_work_ids(8)
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_CONFIRM_APPLY="APPLY",
+            INPUT_WORK_IDS="\n".join(ids),
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("title=Apply batch exceeds cap", result.stdout)
+        context = self._context(workdir)
+        self.assertEqual(context["possible_batch_size"], 8)
+        self.assertIn(
+            "Apply batches may select at most 7 works; "
+            "this request can select up to 8.",
+            context["validation_errors"],
+        )
+
+    def test_apply_publisher_limit_7_succeeds(self):
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_CONFIRM_APPLY="APPLY",
+            INPUT_LIMIT="7",
+            INPUT_PUBLISHER_ID=PUBLISHER_ID,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        context = self._context(workdir)
+        self.assertEqual(context["possible_batch_size"], 7)
+        self.assertEqual(context["validation_errors"], [])
+
+    def test_apply_publisher_limit_8_is_rejected(self):
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_CONFIRM_APPLY="APPLY",
+            INPUT_LIMIT="8",
+            INPUT_PUBLISHER_ID=PUBLISHER_ID,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("title=Apply batch exceeds cap", result.stdout)
+        context = self._context(workdir)
+        self.assertEqual(context["possible_batch_size"], 8)
+
+    def test_apply_publisher_limit_5_plus_2_explicit_succeeds(self):
+        ids = distinct_work_ids(2)
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_CONFIRM_APPLY="APPLY",
+            INPUT_LIMIT="5",
+            INPUT_PUBLISHER_ID=PUBLISHER_ID,
+            INPUT_WORK_IDS="\n".join(ids),
+        )
+
+        self.assertEqual(result.returncode, 0)
+        context = self._context(workdir)
+        self.assertEqual(context["possible_batch_size"], 7)
+        self.assertEqual(context["validation_errors"], [])
+
+    def test_apply_publisher_limit_5_plus_3_explicit_is_rejected(self):
+        ids = distinct_work_ids(3)
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_CONFIRM_APPLY="APPLY",
+            INPUT_LIMIT="5",
+            INPUT_PUBLISHER_ID=PUBLISHER_ID,
+            INPUT_WORK_IDS="\n".join(ids),
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("title=Apply batch exceeds cap", result.stdout)
+        context = self._context(workdir)
+        self.assertEqual(context["possible_batch_size"], 8)
+
+    def test_oversized_apply_records_validation_error_in_context(self):
+        ids = distinct_work_ids(8)
+        result, workdir = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_CONFIRM_APPLY="APPLY",
+            INPUT_WORK_IDS="\n".join(ids),
+        )
+
+        self.assertEqual(result.returncode, 2)
+        context = self._context(workdir)
+        self.assertEqual(context["mode"], "apply")
+        self.assertEqual(context["possible_batch_size"], 8)
+        self.assertEqual(context["maximum_batch_size"], APPLY_MAX_BATCH_SIZE)
+        self.assertTrue(
+            any(
+                "Apply batches may select at most" in error
+                for error in context["validation_errors"]
+            )
+        )
+        self.assertIn(
+            "VALIDATION ERROR:",
+            (workdir / "internet-archive-reconciliation.log").read_text(),
+        )
+
+    def test_apply_cap_does_not_relax_confirmation_or_branch_restrictions(self):
+        # A within-cap apply request on the wrong ref without confirmation is
+        # still rejected: the batch cap does not weaken existing protections.
+        ids = distinct_work_ids(3)
+        result, _ = self.run_helper(
+            "validate",
+            "--mode",
+            "apply",
+            INPUT_WORK_IDS="\n".join(ids),
+            GITHUB_REF="refs/heads/feature/make-ia-idempotent",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("title=Missing apply confirmation", result.stdout)
+        self.assertIn("title=Apply ref restriction", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -988,6 +988,67 @@ class TestIAUploader(unittest.TestCase):
         self.assertIn('is missing as an original file', msg)
         self.assertEqual(self.mock_upload.call_count, 1)
 
+    def test_refresh_failure_during_extended_phase_stops_immediately(self):
+        # Phase 2 begins legitimately (uploaded JSON still stale), then the next
+        # refresh fails. Stop at once and report the actual, not full, window.
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, b'old json bytes'),
+        ])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+
+        def fail_on_first_extended_refresh(item):
+            # 1 pre-mutation + 2 ordinary refreshes, then the first extended.
+            if item.refresh.call_count >= 4:
+                raise ReqConnectionError('connection reset')
+        self.item.refresh_hook = fail_on_first_extended_refresh
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 8):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader.upload_to_platform()
+
+        msg = str(raised.exception)
+        self.assertIn('stopped during upload propagation', msg)
+        self.assertIn('refresh failed', msg)
+        self.assertIn('after 1 extended attempts (~30s)', msg)
+        self.assertNotIn('8 extended attempts', msg)
+        self.assertNotIn('932', msg)
+        self.assertNotIn('Timed out waiting', msg)
+        # Ordinary sleep (20) once, then exactly one extended sleep (30).
+        self.assertEqual(
+            [c.args[0] for c in self.mock_sleep.call_args_list], [20, 30])
+        self.assertEqual(self.mock_upload.call_count, 1)   # no duplicate upload
+
+    def test_metadata_drift_during_extended_phase_stops_immediately(self):
+        # Phase 2 begins legitimately, then a mutable metadata field goes stale.
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, b'old json bytes'),
+        ])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+
+        def drift_metadata_during_extended(item):
+            if item.refresh.call_count >= 4:
+                item.metadata = dict(item.metadata, title='Old title')
+        self.item.refresh_hook = drift_metadata_during_extended
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 8):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader.upload_to_platform()
+
+        msg = str(raised.exception)
+        self.assertIn('stopped during upload propagation', msg)
+        self.assertIn('metadata discrepancies', msg)
+        self.assertIn('title', msg)
+        self.assertIn('after 1 extended attempts (~30s)', msg)
+        self.assertNotIn('Timed out waiting', msg)
+        self.assertNotIn('932', msg)
+        self.assertEqual(
+            [c.args[0] for c in self.mock_sleep.call_args_list], [20, 30])
+        self.assertEqual(self.mock_upload.call_count, 1)
+
     def test_non_uploaded_stale_file_is_not_extended(self):
         self._set_existing_item(files=[
             original_file(PDF_NAME, b'wrong pdf bytes'),

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -7,7 +7,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 from requests import Response
-from requests.exceptions import HTTPError
+from requests.exceptions import ConnectionError as ReqConnectionError, HTTPError
 
 from errors import (
     DisseminationError,
@@ -892,17 +892,183 @@ class TestIAUploader(unittest.TestCase):
         self.item.modify_metadata.assert_not_called()
 
     def test_checksum_verification_timeout_is_bounded(self):
+        # Accepted uploads whose originals never appear: ordinary verification
+        # expires, the extended propagation phase runs (both files were
+        # uploaded this invocation), and the whole process is still bounded.
         self._set_existing_item(files=[])
         self.mock_upload.side_effect = lambda **kwargs: [make_response()]
 
-        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 3):
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 3), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 2):
             with self.assertRaisesRegex(
                     InternetArchiveVerificationError,
-                    'after 3 attempts'):
+                    'upload propagation'):
                 self.uploader.upload_to_platform()
 
-        self.assertEqual(self.item.refresh.call_count, 4)
-        self.assertEqual(self.mock_sleep.call_count, 2)
+        # 1 pre-mutation refresh + 3 ordinary + 2 extended = 6 (bounded).
+        self.assertEqual(self.item.refresh.call_count, 6)
+        # 2 ordinary sleeps (between 3 attempts) + 2 extended sleeps.
+        self.assertEqual(self.mock_sleep.call_count, 4)
+
+    def test_uploaded_json_verified_after_extended_propagation(self):
+        # Accepted JSON upload not yet exposed by IA during ordinary
+        # verification, then revealed during the extended phase.
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, b'old json bytes'),
+        ])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+
+        def reveal(item):
+            if item.refresh.call_count >= 5:
+                item.set_original(JSON_NAME, self.json_bytes)
+        self.item.refresh_hook = reveal
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 3):
+            locations = self.uploader.upload_to_platform()
+
+        self.assertEqual(self.mock_upload.call_count, 1)   # no duplicate upload
+        self.assertEqual(self.item.refresh.call_count, 5)
+        self.assertEqual(
+            [c.args[0] for c in self.mock_sleep.call_args_list], [20, 30, 45])
+        self._assert_location(locations[0])
+
+    def test_uploaded_pdf_verified_after_extended_propagation(self):
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, b'old pdf bytes'),
+            original_file(JSON_NAME, self.json_bytes),
+        ])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+
+        def reveal(item):
+            if item.refresh.call_count >= 5:
+                item.set_original(PDF_NAME, self.pdf_bytes)
+        self.item.refresh_hook = reveal
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 3):
+            locations = self.uploader.upload_to_platform()
+
+        self.assertEqual(self.mock_upload.call_count, 1)   # no duplicate upload
+        self.assertEqual(
+            locations[0].checksum, hashlib.md5(self.pdf_bytes).hexdigest())
+        self._assert_location(locations[0])
+
+    def test_uploaded_file_propagation_times_out_when_still_stale(self):
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, b'old json bytes'),
+        ])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 2):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader.upload_to_platform()
+
+        msg = str(raised.exception)
+        self.assertIn('upload propagation', msg)
+        self.assertIn(JSON_NAME, msg)
+        self.assertIn(hashlib.md5(self.json_bytes).hexdigest(), msg)     # expected
+        self.assertIn(hashlib.md5(b'old json bytes').hexdigest(), msg)   # observed
+        self.assertEqual(self.mock_upload.call_count, 1)   # no second upload
+
+    def test_uploaded_file_propagation_times_out_when_missing(self):
+        self._set_existing_item(files=[original_file(PDF_NAME, self.pdf_bytes)])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 2):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader.upload_to_platform()
+
+        msg = str(raised.exception)
+        self.assertIn('upload propagation', msg)
+        self.assertIn('is missing as an original file', msg)
+        self.assertEqual(self.mock_upload.call_count, 1)
+
+    def test_non_uploaded_stale_file_is_not_extended(self):
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, b'wrong pdf bytes'),
+            original_file(JSON_NAME, self.json_bytes),
+        ])
+        desired = self.uploader.build_desired_state()
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader._verify_final_state(
+                    self.item, desired.expected_md5s, desired.metadata,
+                    desired.absent_metadata_fields,
+                    uploaded_file_names=frozenset())
+
+        msg = str(raised.exception)
+        self.assertIn('after 2 attempts', msg)          # ordinary, not extended
+        self.assertNotIn('upload propagation', msg)
+        self.assertEqual(self.mock_sleep.call_count, 1)  # only ordinary backoff
+
+    def test_metadata_drift_does_not_get_extended_polling(self):
+        metadata = dict(self._desired_metadata(), title='Old title')
+        self._set_existing_item(metadata=metadata, files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, b'old json bytes'),
+        ])
+        self.mock_upload.side_effect = lambda **kwargs: [make_response()]
+        self.item.modify_metadata.side_effect = \
+            lambda *args, **kwargs: make_response()
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 5):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader.upload_to_platform()
+
+        msg = str(raised.exception)
+        self.assertIn('after 2 attempts', msg)   # metadata drift blocks extension
+        self.assertIn('title', msg)
+        self.assertNotIn('upload propagation', msg)
+        self.assertTrue(
+            all(c.args[0] == 20 for c in self.mock_sleep.call_args_list))
+
+    def test_refresh_failure_is_not_treated_as_propagation(self):
+        self.item.refresh = MagicMock(
+            side_effect=ReqConnectionError('connection reset'))
+        desired = self.uploader.build_desired_state()
+
+        with patch.object(IAUploader, 'VERIFICATION_ATTEMPTS', 2), \
+                patch.object(IAUploader, 'UPLOAD_PROPAGATION_ATTEMPTS', 3):
+            with self.assertRaises(InternetArchiveVerificationError) as raised:
+                self.uploader._verify_final_state(
+                    self.item, desired.expected_md5s, desired.metadata,
+                    desired.absent_metadata_fields,
+                    uploaded_file_names=frozenset({JSON_NAME}))
+
+        msg = str(raised.exception)
+        self.assertIn('after 2 attempts', msg)     # ordinary, not extended
+        self.assertIn('refresh failed', msg)
+        self.assertNotIn('upload propagation', msg)
+        self.assertEqual(self.mock_sleep.call_count, 1)
+
+    def test_current_item_uses_no_extended_polling(self):
+        self._set_existing_item()   # fully current
+
+        locations = self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.uploader.get_variable_from_env.assert_not_called()  # no credentials
+        self.mock_sleep.assert_not_called()                      # no polling
+        self._assert_location(locations[0])
+
+    def test_extended_propagation_schedule_is_bounded(self):
+        sleeps = IAUploader._upload_propagation_sleeps()
+        self.assertEqual(len(sleeps), IAUploader.UPLOAD_PROPAGATION_ATTEMPTS)
+        self.assertTrue(all(
+            s <= IAUploader.UPLOAD_PROPAGATION_MAX_SLEEP_SECONDS for s in sleeps))
+        total = sum(sleeps)
+        # Materially more than the ~200s ordinary window, but bounded well under
+        # the apply job's 180-minute workflow timeout.
+        self.assertGreater(total, 10 * 60)
+        self.assertLessEqual(total, 20 * 60)
 
     def test_derived_files_do_not_satisfy_final_verification(self):
         self._set_existing_item(files=[

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -1231,6 +1231,11 @@ CREDENTIALS = {
 class TestApplyMode(unittest.TestCase):
     def setUp(self):
         self.reconciler = InternetArchiveReconciler(thoth=MagicMock())
+        # Real-apply tests exercise IAUploader verification (including the
+        # bounded extended propagation phase); patch its sleep so no test waits.
+        self._sleep_patcher = patch('iauploader.sleep')
+        self._sleep_patcher.start()
+        self.addCleanup(self._sleep_patcher.stop)
 
     def _apply(self, before, context, final=None):
         final = final or current_result()


### PR DESCRIPTION
## Problem

Internet Archive exposes an accepted original-file upload in item metadata with **eventual consistency**. After `internetarchive.upload()` returns success, the new file MD5 can take **15–20 minutes** to appear (one earlier item took substantially longer). Meanwhile `_verify_final_state()` polls only ~200s and then raises `InternetArchiveVerificationError`, so the protected apply workflow concludes **`failure`** even though the upload was accepted and later converges.

Representative failed apply runs where accepted uploads later converged: **`30110562482`**, **`30116846348`**, **`30119623963`**. Every observed affected JSON original (`1af9089d…`, `8636e404…`, `8fb43f4b…`, `d1469a83…`, `bc48caf3…`, `e59e3714…`) **ultimately reached the expected MD5**.

**Why it matters now:** the next phase needs **316 PDF uploads**; PDFs are larger than the JSON sidecars that already exceeded the 200s window, so this will get worse without the fix.

**Upload acceptance ≠ remote MD5 verification:** an accepted S3 response only means IA queued the bytes; the original is not verified until its expected MD5 is visible in item metadata. This PR keeps that distinction strict.

## Design

- `apply_archive_repairs()` records a filename in `uploaded_file_names` **only after `_upload_files()` returns** for that file, and passes it to `_verify_final_state()`. Uploaded files are never inferred from desired state.
- **Phase 1 — ordinary (unchanged):** `VERIFICATION_ATTEMPTS=10 × VERIFICATION_SLEEP_SECONDS=20` ≈ **200s**. Verifies all managed metadata + all expected original MD5s + refresh availability.
- **Phase 2 — extended file propagation:** entered **only** when Phase 1 expired **and** metadata is fully current **and** no refresh error **and** every remaining discrepancy is an original uploaded *this invocation* that is either missing from the listing or still exposing a previous MD5. Bounded backoff `UPLOAD_PROPAGATION_ATTEMPTS=8`, `UPLOAD_PROPAGATION_INITIAL_SLEEP_SECONDS=30`, `UPLOAD_PROPAGATION_MAX_SLEEP_SECONDS=180` → schedule **`[30, 45, 67, 100, 150, 180, 180, 180]` = 932s (~15.5 min)**. **Never re-uploads** — it only re-reads item state.

**Extended phase is NOT entered for:** stale metadata; mediatype/collection/ownership problems; missing/mismatched files not uploaded here; refresh/request failures; unexpected filenames; source/desired-state errors. Those fail immediately with the ordinary `"Timed out verifying … after N attempts"` message.

**Outcome:** success only when every expected managed original has the correct MD5 and all required metadata is current. Extended-phase expiry raises `InternetArchiveVerificationError` with a distinct message — `"Timed out waiting for accepted Internet Archive upload propagation …"` — including identifier, filename, expected MD5, last-observed MD5 or missing state, and the elapsed window.

Helpers added: `_check_final_state`, `_is_upload_propagation_only`, `_verify_uploaded_file_propagation`, `_upload_propagation_sleeps`, `_describe_file_problem`, `_problem_summary` (no duplicated comparison loop; no async/background work).

**Max added wait per affected item:** ~932s (~15.5 min), and only for an item with an accepted-but-not-yet-visible upload.

## Action / progress semantics
Unchanged schema. Uploads are still reported `attempted` (initiated) → `completed` (request accepted); the overall op reports the file **verified** only when its remote MD5 appears. The improvement is behavioural: a propagating upload now reaches verified success (reported *applied*) instead of `uncertain`; if the extended phase still expires, the upload remains `uncertain` (accepted, unconfirmed) — never a hard upload failure.

## Workflow-timeout analysis
`.github/workflows/ia_reconcile.yml`: dry-run job `timeout-minutes: 120`, apply job `timeout-minutes: 180` — **left unchanged**. The extended propagation wait is strictly per-affected-item (≤~932s / ~15.5 min each) and reconciliation is processed sequentially, so a batch where *many* items lag could otherwise approach or exceed the 180-minute apply timeout before later works and the final authoritative report are produced.

The workflow does **not** enforce a 50-work batch; the `limit` input defaults to 100, accepts up to 200, and `possible_batch` (publisher `limit` + explicit IDs) was previously capped only at 200. That is safe for dry-run inspection but not for a fully-lagging apply run.

**Enforced mode-specific batch caps** (`.github/scripts/ia_reconcile_workflow.py`, named constants `DRY_RUN_MAX_BATCH_SIZE = 200`, `APPLY_MAX_BATCH_SIZE = 7`):
- **Dry-runs** can still inspect and discover up to **200** works (candidate discovery is read-only).
- **Protected apply runs are now capped at 7 total works** — this bounds `possible_batch`, i.e. the *maximum* number of works the request can select, counting explicit work IDs, the publisher `limit`, and any combination of the two.
- Seven worst-case per-item verification paths (7 × ~932s ≈ ~109 min) remain within the 180-minute apply job timeout with comfortable margin for source retrieval, uploads and report generation.
- The cap is **enforced by workflow input validation** (an oversized apply request is rejected with a `::error::` annotation and a recorded `validation_errors` entry), **not** merely an operational convention.
- Larger repair campaigns must be split into **multiple sequential apply runs**. **No concurrent apply runs or parallel upload processing are introduced.**

Accepted vs rejected examples (apply mode):

| Selection | `possible_batch` | Result |
| --- | ---: | --- |
| publisher only, `limit=7` | 7 | allowed |
| 7 explicit IDs | 7 | allowed |
| publisher `limit=5` + 2 explicit IDs | 7 | allowed |
| publisher `limit=7` + 1 explicit ID | 8 | rejected |
| 8 explicit IDs | 8 | rejected |
| publisher `limit=8` | 8 | rejected |

The `limit` input itself is still validated as an integer in the overall workflow-supported range (1–200); the `default: 100` is retained because dry-run is the default mode and apply validation independently rejects any oversized request. The 180-minute apply timeout is **unchanged**. `confirm_apply=APPLY`, the `develop`-branch restriction, UUID validation, environment protection and the dry-run hard limit are all preserved.

## Tests (`tests/test_iauploader.py`, all sleeps patched — no real waiting)
1. JSON verified after appearing during the extended phase (no duplicate upload; sleeps follow schedule; location returned).
2. PDF verified after delayed visibility (no duplicate upload; returned checksum is the verified PDF MD5).
3. Uploaded file stays stale → propagation-timeout error with expected + last-observed MD5; no second upload.
4. Missing uploaded file stays missing → bounded missing-file propagation error.
5. Non-uploaded stale file → ordinary failure, extended phase **not** entered, no long sleeps.
6. Metadata drift + a new upload → ordinary failure, no extended phase, metadata still strict.
7. Repeated refresh exceptions → not reclassified as propagation.
8. Fully current item → no credentials read, nothing uploaded, no polling.
9. All PR #90/#91 imagecount/derived-field regression tests retained and passing.
10. Extended schedule is finite and bounded (>10 min, ≤20 min).
`tests/test_reconcile_internet_archive.py` `TestApplyMode.setUp` now patches `iauploader.sleep` so its real-apply tests never wait.

### Results
- **Pre-fix reproduction:** reverting only `iauploader.py`, the 8 new extended-phase tests **fail** (the two-phase logic/constants don't exist). After the fix, all **pass**.
- `python3 -m pytest -q tests/test_iauploader.py` → **76 passed** in 0.13s.
- `python3 -m pytest -q` → **349 passed, 50 subtests** in ~2.6s (no real sleeping).
- `python3 -m compileall -q .` clean; `git diff --check` clean.

## Scope
No production operation occurred: no upload, no canary, no workflow dispatch, no PDF-byte changes, no `imagecount`/PLAIN_TEXT changes, no ownership/collision changes, no automatic upload retry, and strict MD5 verification is preserved. **This does not yet prove the PDF campaign is safe — that requires a post-merge production canary.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up correction (commit `ce950f6`)
The extended phase distinguishes **two exit paths**, and each now reports the **actual** completed extended attempts and elapsed wait (never a hard-coded `len(sleeps)`/`sum(sleeps)`):

- **Full schedule exhausted** while every remaining discrepancy stayed propagation-only → `"Timed out waiting for accepted Internet Archive upload propagation for item … after N extended attempts (~Ys)"` (here N/Y are the whole schedule, e.g. 8 / ~932s).
- **Early termination** because a *new* non-propagation problem appeared mid-phase (a refresh/request error, stale metadata, or a file not uploaded this invocation) → a distinct `"Internet Archive verification stopped during upload propagation for item … after N extended attempts (~Ys): <current problem>"`, reporting the real (partial) attempt count and elapsed wait and the actual refresh/metadata/file problem — **without** claiming the propagation deadline expired. No re-polling after the problem appears, no restart of the ordinary phase, no suppression of the genuine problem.

Two regression tests added for this (refresh failure and metadata drift appearing during the extended phase, each asserting immediate stop, the real `~30s`/1-attempt window, the distinct message, and no duplicate upload). Updated results: `pytest -q tests/test_iauploader.py` → **78 passed**; `pytest -q` → **351 passed, 50 subtests** (~2.3s, no real sleeping).

---

### Follow-up correction (enforced apply batch cap)
The workflow-timeout analysis previously assumed a 50-work batch that the repository did not enforce. The apply job is now bounded by an enforced input-validation cap instead of an assumption.

- `.github/scripts/ia_reconcile_workflow.py`: added named constants `DRY_RUN_MAX_BATCH_SIZE = 200` and `APPLY_MAX_BATCH_SIZE = 7`, selected `maximum_batch_size(mode)` after computing `possible_batch`, and reject any apply request where `possible_batch > APPLY_MAX_BATCH_SIZE` with the annotation `Apply batches may select at most 7 works; this request can select up to N.`. Dry-run continues to allow up to 200 works. `reconciliation-run-context.json` now also records `maximum_batch_size` alongside the existing `mode`, `possible_batch_size` and `validation_errors`.
- `.github/workflows/ia_reconcile.yml`: `limit` input description updated to `Maximum publisher works to select (dry-run: 1-200; apply: maximum 7 total works)`. The 180-minute apply timeout is unchanged; no concurrency or parallel upload processing is introduced.
- Tests: `tests/test_ia_reconcile_workflow.py` extended with focused cases — dry-run `limit=200` and 200 explicit IDs succeed; apply 7 explicit IDs / publisher `limit=7` / publisher `limit=5`+2 explicit succeed; apply 8 explicit IDs / publisher `limit=8` / publisher `limit=5`+3 explicit are rejected; an oversized apply records the validation error in the run context; and confirmation/branch restrictions remain enforced under the cap. Distinct generated UUIDs are used because explicit IDs are deduplicated.

Updated results: `pytest -q tests/test_ia_reconcile_workflow.py` → **17 passed, 2 subtests**; `pytest -q tests/test_iauploader.py` → **78 passed**; `pytest -q tests/test_reconcile_internet_archive.py` → **106 passed**; `pytest -q` → **361 passed, 50 subtests** (~2.4s, no real sleeping); `compileall` and `git diff --check` clean.

**Files changed in this PR:** `iauploader.py`, `.github/scripts/ia_reconcile_workflow.py`, `.github/workflows/ia_reconcile.yml`, `tests/test_iauploader.py`, `tests/test_reconcile_internet_archive.py`, `tests/test_ia_reconcile_workflow.py`.

