### PR TITLE
Make Internet Archive JSON sidecars deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+  - Normalise the Internet Archive JSON sidecar into a deterministic canonical representation before upload and checksum calculation, stripping only the volatile top-level `jsonGeneratedAt` generation timestamp, so semantically unchanged Thoth metadata no longer produces a different expected JSON MD5 on every run and managed JSON originals can converge to `current`
 
 ## [[1.6.2]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v1.6.2) - 2026-07-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
   - Normalise the Internet Archive JSON sidecar into a deterministic canonical representation before upload and checksum calculation, stripping only the volatile top-level `jsonGeneratedAt` generation timestamp, so semantically unchanged Thoth metadata no longer produces a different expected JSON MD5 on every run and managed JSON originals can converge to `current`
+  - Preserve exact JSON numbers when canonicalising the Internet Archive sidecar: fractional tokens are parsed with `parse_float=Decimal` and re-serialised as unquoted JSON numbers by an explicit canonical encoder, so a high-precision metadata value (e.g. `9007199254740993.0`) is no longer silently rounded through a binary float and distinct source values can no longer collapse to the same expected MD5; non-standard `NaN`/`Infinity` constants are now rejected during parsing before any non-finite float is constructed
 
 ## [[1.6.2]](https://github.com/thoth-pub/thoth-dissemination/releases/tag/v1.6.2) - 2026-07-27
 ### Fixed

--- a/iauploader.py
+++ b/iauploader.py
@@ -4,6 +4,7 @@ Retrieve and disseminate files and metadata to Internet Archive
 """
 
 import hashlib
+import json
 import logging
 from dataclasses import dataclass
 from io import BytesIO
@@ -145,14 +146,86 @@ class IAUploader(Uploader):
             location.checksum_algorithm,
         )]
 
+    @staticmethod
+    def _normalise_json_sidecar(metadata_bytes):
+        """Return canonical, deterministic bytes for a ``json::thoth`` sidecar.
+
+        Thoth's ``json::thoth`` export is generated per request and begins with
+        a top-level ``jsonGeneratedAt`` wall-clock timestamp, so uploading the
+        raw export byte-for-byte gives an unchanged work a different expected
+        MD5 on every run, making a stable ``current`` state structurally
+        impossible for managed JSON originals. This removes only that single
+        volatile top-level field and re-serialises the remaining semantic
+        payload canonically (sorted keys, no insignificant whitespace, a single
+        trailing newline), so two exports that differ only by ``jsonGeneratedAt``
+        (or by whitespace or key ordering) yield identical bytes while any real
+        metadata change still yields different bytes.
+
+        Failures raise ``InternetArchiveDesiredStateError`` for the ``json``
+        component with a concise reason and never expose the full payload; the
+        caller adds the work UUID. The raw response is never used as a silent
+        fallback.
+        """
+        if not isinstance(metadata_bytes, bytes):
+            raise InternetArchiveDesiredStateError(
+                'json',
+                'response was not bytes (got {})'.format(
+                    type(metadata_bytes).__name__),
+            )
+        try:
+            decoded = metadata_bytes.decode('utf-8')
+        except UnicodeDecodeError as error:
+            raise InternetArchiveDesiredStateError(
+                'json', 'response was not valid UTF-8: {}'.format(error),
+            ) from error
+        try:
+            payload = json.loads(decoded)
+        except ValueError as error:
+            raise InternetArchiveDesiredStateError(
+                'json', 'response was not valid JSON: {}'.format(error),
+            ) from error
+        if not isinstance(payload, dict):
+            raise InternetArchiveDesiredStateError(
+                'json',
+                'JSON root value is {}, expected a JSON object'.format(
+                    type(payload).__name__),
+            )
+        # Remove only the top-level volatile generation timestamp; any nested
+        # field of the same name is deliberately left untouched.
+        payload.pop('jsonGeneratedAt', None)
+        try:
+            canonical = json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(',', ':'),
+                allow_nan=False,
+            )
+        except ValueError as error:
+            raise InternetArchiveDesiredStateError(
+                'json',
+                'response contained values that canonical JSON serialisation '
+                'refuses: {}'.format(error),
+            ) from error
+        return canonical.encode('utf-8') + b'\n'
+
     def build_desired_state(self):
         """Construct Archive and Thoth location state without mutating either."""
         try:
-            metadata_bytes = self.get_formatted_metadata('json::thoth')
+            raw_metadata_bytes = self.get_formatted_metadata('json::thoth')
         except Exception as error:
             raise InternetArchiveDesiredStateError(
                 'json',
                 'JSON export unavailable for {}: {}'.format(
+                    self.work_id, error),
+            ) from error
+
+        try:
+            metadata_bytes = self._normalise_json_sidecar(raw_metadata_bytes)
+        except InternetArchiveDesiredStateError as error:
+            raise InternetArchiveDesiredStateError(
+                'json',
+                'JSON sidecar normalisation failed for {}: {}'.format(
                     self.work_id, error),
             ) from error
 
@@ -165,12 +238,6 @@ class IAUploader(Uploader):
                     self.work_id, error),
             ) from error
 
-        if not isinstance(metadata_bytes, bytes):
-            raise InternetArchiveDesiredStateError(
-                'json',
-                'JSON export unavailable for {}: response was not bytes'.format(
-                    self.work_id),
-            )
         if not isinstance(publication.bytes, bytes) or not publication.bytes:
             raise InternetArchiveDesiredStateError(
                 'pdf',

--- a/iauploader.py
+++ b/iauploader.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 from dataclasses import dataclass
+from decimal import Decimal
 from io import BytesIO
 from time import sleep
 
@@ -22,6 +23,68 @@ from errors import (
     InternetArchiveVerificationError,
 )
 from uploader import Uploader, Location
+
+
+def _reject_non_standard_json_constant(token):
+    """Reject the non-standard JSON constants ``json.loads`` otherwise accepts.
+
+    ``json.loads`` calls this for the bare tokens ``NaN``, ``Infinity`` and
+    ``-Infinity``. Rejecting them here means we never construct a non-finite
+    binary float in the first place; the raised ``ValueError`` is caught by the
+    normalisation caller and reported as an ``InternetArchiveDesiredStateError``
+    for the ``json`` component. Only the offending token name is surfaced, never
+    the surrounding payload.
+    """
+    raise ValueError(
+        'non-finite JSON constant {!r} is not permitted'.format(token))
+
+
+def _canonical_json_encode(value):
+    """Serialise ``value`` as canonical JSON text preserving exact numbers.
+
+    Unlike ``json.dumps``, this encodes ``Decimal`` values (produced by parsing
+    JSON fractional tokens with ``parse_float=Decimal``) as unquoted JSON
+    numbers holding their exact decimal value, so no metadata number is ever
+    rounded through a binary float. It implements exactly the JSON data model
+    (object, array, string, number, ``true``/``false``, ``null``) with sorted
+    object keys and no insignificant whitespace. Unsupported internal types are
+    rejected rather than coerced.
+    """
+    # ``bool`` must be checked before ``int`` because it subclasses ``int``.
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    if value is None:
+        return 'null'
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, int):
+        # ``int`` preserves arbitrary precision exactly; base-10 is canonical.
+        return str(value)
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise ValueError(
+                'non-finite decimal number is not permitted in canonical JSON')
+        # ``str(Decimal)`` yields the exact value as a valid JSON number token
+        # (plain or E-notation) without any binary-float rounding.
+        return str(value)
+    if isinstance(value, dict):
+        items = []
+        for key in sorted(value):
+            if not isinstance(key, str):
+                raise ValueError(
+                    'JSON object keys must be strings, got {}'.format(
+                        type(key).__name__))
+            items.append(
+                '{}:{}'.format(
+                    json.dumps(key, ensure_ascii=False),
+                    _canonical_json_encode(value[key])))
+        return '{' + ','.join(items) + '}'
+    if isinstance(value, (list, tuple)):
+        return '[' + ','.join(
+            _canonical_json_encode(element) for element in value) + ']'
+    raise ValueError(
+        'value of type {} is not part of the JSON data model'.format(
+            type(value).__name__))
 
 
 @dataclass(frozen=True)
@@ -161,6 +224,14 @@ class IAUploader(Uploader):
         (or by whitespace or key ordering) yield identical bytes while any real
         metadata change still yields different bytes.
 
+        Fractional JSON numbers are parsed with ``parse_float=Decimal`` and
+        re-serialised as unquoted JSON numbers by an explicit canonical encoder,
+        so an exact metadata value is never silently rounded through a binary
+        float (e.g. ``9007199254740993.0`` is preserved rather than collapsing
+        to ``9007199254740992.0``). Integers keep Python's arbitrary precision.
+        Non-standard constants (``NaN``, ``Infinity``, ``-Infinity``) are
+        rejected during parsing before any non-finite float can be constructed.
+
         Failures raise ``InternetArchiveDesiredStateError`` for the ``json``
         component with a concise reason and never expose the full payload; the
         caller adds the work UUID. The raw response is never used as a silent
@@ -179,7 +250,11 @@ class IAUploader(Uploader):
                 'json', 'response was not valid UTF-8: {}'.format(error),
             ) from error
         try:
-            payload = json.loads(decoded)
+            payload = json.loads(
+                decoded,
+                parse_float=Decimal,
+                parse_constant=_reject_non_standard_json_constant,
+            )
         except ValueError as error:
             raise InternetArchiveDesiredStateError(
                 'json', 'response was not valid JSON: {}'.format(error),
@@ -194,13 +269,7 @@ class IAUploader(Uploader):
         # field of the same name is deliberately left untouched.
         payload.pop('jsonGeneratedAt', None)
         try:
-            canonical = json.dumps(
-                payload,
-                ensure_ascii=False,
-                sort_keys=True,
-                separators=(',', ':'),
-                allow_nan=False,
-            )
+            canonical = _canonical_json_encode(payload)
         except ValueError as error:
             raise InternetArchiveDesiredStateError(
                 'json',

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -3,6 +3,7 @@ import importlib
 import json
 import sys
 import unittest
+from decimal import Decimal
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
@@ -1696,13 +1697,88 @@ class TestJsonSidecarNormalisation(unittest.TestCase):
 
     def test_values_canonical_json_refuses_are_rejected(self):
         # Python's json.loads accepts NaN/Infinity, but canonical serialisation
-        # with allow_nan=False must refuse them rather than emit invalid JSON.
+        # must refuse them rather than emit invalid JSON. They are now rejected
+        # during parsing (parse_constant) before any non-finite float is built.
         for raw in (b'{"x": NaN}', b'{"x": Infinity}', b'{"x": -Infinity}'):
             with self.subTest(raw=raw):
                 with self.assertRaises(
                         InternetArchiveDesiredStateError) as raised:
                     self.normalise(raw)
                 self.assertEqual(raised.exception.source, 'json')
+
+    def test_high_precision_decimal_is_not_rounded_through_binary_float(self):
+        # Regression for the P2 precision-preservation finding: a decimal token
+        # needing more precision than a binary float must survive exactly.
+        # 9007199254740993.0 is not representable as a double and ordinary
+        # json.loads would round it down to 9007199254740992.0.
+        result = self.normalise(b'{"value":9007199254740993.0}')
+
+        self.assertIn(b'9007199254740993.0', result)
+        self.assertNotIn(b'9007199254740992.0', result)
+        parsed = json.loads(result.decode('utf-8'), parse_float=Decimal)
+        self.assertEqual(parsed['value'], Decimal('9007199254740993.0'))
+
+    def test_adjacent_high_precision_decimals_stay_distinct(self):
+        # The two tokens collapse to the same Python float; the canonical
+        # bytes and MD5s must nonetheless differ.
+        higher = self.normalise(b'{"value":9007199254740993.0}')
+        lower = self.normalise(b'{"value":9007199254740992.0}')
+
+        self.assertNotEqual(higher, lower)
+        self.assertNotEqual(
+            hashlib.md5(higher).hexdigest(),
+            hashlib.md5(lower).hexdigest())
+
+    def test_long_fractional_value_is_preserved_exactly(self):
+        raw = b'{"value":0.123456789012345678901234567890}'
+        result = self.normalise(raw)
+
+        self.assertIn(b'0.123456789012345678901234567890', result)
+        parsed = json.loads(result.decode('utf-8'), parse_float=Decimal)
+        self.assertEqual(
+            parsed['value'], Decimal('0.123456789012345678901234567890'))
+
+    def test_exact_decimals_survive_in_nested_structures(self):
+        raw = (
+            b'{"obj":{"n":1.5},'
+            b'"arr":[2.5,3.5],'
+            b'"obj_in_arr":[{"n":4.5}]}')
+        result = self.normalise(raw)
+
+        parsed = json.loads(result.decode('utf-8'), parse_float=Decimal)
+        self.assertEqual(parsed['obj']['n'], Decimal('1.5'))
+        self.assertEqual(parsed['arr'], [Decimal('2.5'), Decimal('3.5')])
+        self.assertEqual(parsed['obj_in_arr'][0]['n'], Decimal('4.5'))
+
+    def test_negative_and_exponent_decimals_are_preserved(self):
+        raw = b'{"neg":-3.14,"exp":6.022e23,"small":1e-7}'
+        result = self.normalise(raw)
+
+        parsed = json.loads(result.decode('utf-8'), parse_float=Decimal)
+        self.assertEqual(parsed['neg'], Decimal('-3.14'))
+        self.assertEqual(parsed['exp'], Decimal('6.022e23'))
+        self.assertEqual(parsed['small'], Decimal('1e-7'))
+
+    def test_numbers_remain_json_numbers_not_quoted_strings(self):
+        result = self.normalise(
+            b'{"i":42,"f":1.5,"big":9007199254740993.0}')
+
+        # Parse without parse_float so a quoted number would surface as str.
+        parsed = json.loads(result.decode('utf-8'))
+        self.assertIsInstance(parsed['i'], int)
+        self.assertIsInstance(parsed['f'], float)
+        self.assertIsInstance(parsed['big'], float)
+        self.assertNotIsInstance(parsed['big'], str)
+
+    def test_output_with_exact_decimals_is_idempotent(self):
+        once = self.normalise(
+            b'{"jsonGeneratedAt":"t",'
+            b'"value":9007199254740993.0,'
+            b'"nested":{"long":0.123456789012345678901234567890},'
+            b'"arr":[-3.14,6.022e23]}')
+        twice = self.normalise(once)
+
+        self.assertEqual(once, twice)
 
 
 class TestDisseminatorCLI(unittest.TestCase):

--- a/tests/test_iauploader.py
+++ b/tests/test_iauploader.py
@@ -11,6 +11,7 @@ from requests.exceptions import ConnectionError as ReqConnectionError, HTTPError
 
 from errors import (
     DisseminationError,
+    InternetArchiveDesiredStateError,
     InternetArchiveIdentifierCollisionError,
     InternetArchiveImmutableMetadataError,
     InternetArchiveRestrictedMetadataError,
@@ -90,7 +91,12 @@ class TestIAUploader(unittest.TestCase):
         self.addCleanup(self.sleep_patcher.stop)
 
         self.pdf_bytes = b'current PDF bytes'
-        self.json_bytes = b'{"current":"metadata"}'
+        # Canonical sidecar bytes: the deterministic representation produced by
+        # IAUploader._normalise_json_sidecar (sorted keys, compact separators,
+        # single trailing newline). Using the canonical form here means the raw
+        # export and its normalisation are byte-identical, so remote originals
+        # seeded with these bytes still compare as current.
+        self.json_bytes = b'{"current":"metadata"}\n'
         self.uploader = IAUploader.__new__(IAUploader)
         self.uploader.work_id = WORK_ID
         self.uploader.export_url = 'https://export.example'
@@ -1394,6 +1400,309 @@ class TestIAUploader(unittest.TestCase):
         self.mock_upload.assert_not_called()
         self.item.modify_metadata.assert_not_called()
         self.item.refresh.assert_not_called()
+
+    # --- Deterministic JSON sidecar: desired-state behaviour ---
+
+    # A pair of raw json::thoth exports that are semantically identical but
+    # carry different top-level generation timestamps. Both must normalise to
+    # the canonical self.json_bytes.
+    RAW_EXPORT_EARLY = (
+        b'{"jsonGeneratedAt":"2026-07-27T10:00:00.000000Z",'
+        b'"current":"metadata"}')
+    RAW_EXPORT_LATE = (
+        b'  {\n  "current": "metadata",\n'
+        b'  "jsonGeneratedAt": "2026-07-27T11:30:00.000000Z"\n}\n')
+
+    def test_build_desired_state_stores_normalised_json_bytes(self):
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_EARLY
+
+        desired = self.uploader.build_desired_state()
+
+        self.assertEqual(desired.file_bytes[JSON_NAME], self.json_bytes)
+
+    def test_expected_json_md5_is_calculated_from_normalised_bytes(self):
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_EARLY
+
+        desired = self.uploader.build_desired_state()
+
+        self.assertEqual(
+            desired.expected_md5s[JSON_NAME],
+            hashlib.md5(self.json_bytes).hexdigest())
+        # Never the MD5 of the raw timestamp-bearing export.
+        self.assertNotEqual(
+            desired.expected_md5s[JSON_NAME],
+            hashlib.md5(self.RAW_EXPORT_EARLY).hexdigest())
+
+    def test_uploader_sends_exact_normalised_json_bytes(self):
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_LATE
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, b'legacy raw sidecar'),
+        ])
+
+        sent = {}
+
+        def capture_upload(**kwargs):
+            for name, file_object in kwargs['files'].items():
+                contents = file_object.read()
+                sent[name] = contents
+                self.item.set_original(name, contents)
+            self.item.exists = True
+            return [make_response() for _ in kwargs['files']]
+
+        self.mock_upload.side_effect = capture_upload
+
+        self.uploader.upload_to_platform()
+
+        self.assertEqual(set(sent), {JSON_NAME})
+        self.assertEqual(sent[JSON_NAME], self.json_bytes)
+
+    def test_two_desired_builds_differing_only_by_timestamp_share_json_md5(self):
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_EARLY
+        early = self.uploader.build_desired_state()
+
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_LATE
+        late = self.uploader.build_desired_state()
+
+        self.assertEqual(early.file_bytes[JSON_NAME], late.file_bytes[JSON_NAME])
+        self.assertEqual(
+            early.expected_md5s[JSON_NAME], late.expected_md5s[JSON_NAME])
+
+    def test_remote_canonical_json_is_current_despite_new_timestamp(self):
+        # Remote already holds the canonical bytes; the next raw export carries
+        # a different generation timestamp. The sidecar must remain current.
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, self.json_bytes),
+        ])
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_LATE
+        desired = self.uploader.build_desired_state()
+
+        inspection = self.uploader.inspect_item(self.item, desired)
+
+        self.assertTrue(inspection['files'][JSON_NAME]['current'])
+        self.assertTrue(inspection['files'][PDF_NAME]['current'])
+
+    def test_legacy_timestamp_sidecar_is_stale_and_proposes_one_json_upload(self):
+        # A pre-fix original still carrying the raw timestamp bytes must be
+        # classified stale exactly once, proposing only the JSON upload.
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, self.RAW_EXPORT_EARLY),
+        ])
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_LATE
+        desired = self.uploader.build_desired_state()
+
+        inspection = self.uploader.inspect_item(self.item, desired)
+
+        self.assertFalse(inspection['files'][JSON_NAME]['current'])
+        self.assertTrue(inspection['files'][PDF_NAME]['current'])
+        self.assertEqual(inspection['metadata_patch'], {})
+
+    def test_legacy_sidecar_upload_then_reinspection_is_current(self):
+        # End-to-end determinism: repair uploads the canonical bytes, and a
+        # later build with yet another timestamp classifies the item current.
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, self.RAW_EXPORT_EARLY),
+        ])
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_LATE
+
+        self.uploader.upload_to_platform()
+
+        self.assertEqual(
+            set(self.mock_upload.call_args.kwargs['files']), {JSON_NAME})
+        # Remote now holds the canonical bytes; a fresh export with a different
+        # timestamp must produce no further action.
+        self.uploader.get_formatted_metadata.return_value = (
+            b'{"jsonGeneratedAt":"2026-07-28T00:00:00.000000Z",'
+            b'"current":"metadata"}')
+        desired = self.uploader.build_desired_state()
+        inspection = self.uploader.inspect_item(self.item, desired)
+
+        self.assertTrue(inspection['files'][JSON_NAME]['current'])
+        self.assertTrue(inspection['files'][PDF_NAME]['current'])
+        self.assertEqual(inspection['metadata_patch'], {})
+
+    def test_current_item_with_new_timestamp_export_makes_no_api_calls(self):
+        # The current-item fast path must still read no credentials and perform
+        # no upload when only the volatile timestamp changed.
+        self._set_existing_item(files=[
+            original_file(PDF_NAME, self.pdf_bytes),
+            original_file(JSON_NAME, self.json_bytes),
+        ])
+        self.uploader.get_formatted_metadata.return_value = self.RAW_EXPORT_LATE
+
+        self.uploader.upload_to_platform()
+
+        self.mock_upload.assert_not_called()
+        self.item.modify_metadata.assert_not_called()
+        self.uploader.get_variable_from_env.assert_not_called()
+
+    # --- Deterministic JSON sidecar: error behaviour via build_desired_state ---
+
+    def test_invalid_utf8_export_raises_desired_state_error_for_json(self):
+        self.uploader.get_formatted_metadata.return_value = b'\xff\xfe not utf8'
+
+        with self.assertRaises(InternetArchiveDesiredStateError) as raised:
+            self.uploader.build_desired_state()
+
+        self.assertEqual(raised.exception.source, 'json')
+
+    def test_malformed_json_export_raises_desired_state_error_for_json(self):
+        self.uploader.get_formatted_metadata.return_value = b'{"current":'
+
+        with self.assertRaises(InternetArchiveDesiredStateError) as raised:
+            self.uploader.build_desired_state()
+
+        self.assertEqual(raised.exception.source, 'json')
+
+    def test_non_object_json_roots_are_rejected(self):
+        for raw in (b'[1, 2, 3]', b'"a string"', b'42', b'true', b'null'):
+            with self.subTest(raw=raw):
+                self.uploader.get_formatted_metadata.return_value = raw
+                with self.assertRaises(
+                        InternetArchiveDesiredStateError) as raised:
+                    self.uploader.build_desired_state()
+                self.assertEqual(raised.exception.source, 'json')
+
+    def test_non_bytes_export_response_is_rejected(self):
+        self.uploader.get_formatted_metadata.return_value = {'not': 'bytes'}
+
+        with self.assertRaises(InternetArchiveDesiredStateError) as raised:
+            self.uploader.build_desired_state()
+
+        self.assertEqual(raised.exception.source, 'json')
+
+    def test_desired_state_json_error_includes_uuid_not_full_payload(self):
+        secret_marker = 'do-not-leak-this-entire-payload-marker'
+        self.uploader.get_formatted_metadata.return_value = (
+            '["{}", NaN]'.format(secret_marker).encode('utf-8'))
+
+        with self.assertRaises(InternetArchiveDesiredStateError) as raised:
+            self.uploader.build_desired_state()
+
+        message = str(raised.exception)
+        self.assertEqual(raised.exception.source, 'json')
+        self.assertIn(WORK_ID, message)
+        self.assertNotIn(secret_marker, message)
+
+
+class TestJsonSidecarNormalisation(unittest.TestCase):
+    """Pure canonicalisation contract for IAUploader._normalise_json_sidecar."""
+
+    def normalise(self, metadata_bytes):
+        return IAUploader._normalise_json_sidecar(metadata_bytes)
+
+    def test_different_top_level_timestamps_produce_identical_bytes_and_md5(self):
+        early = self.normalise(
+            b'{"jsonGeneratedAt":"2026-01-01T00:00:00Z","title":"Book"}')
+        late = self.normalise(
+            b'{"jsonGeneratedAt":"2026-12-31T23:59:59Z","title":"Book"}')
+
+        self.assertEqual(early, late)
+        self.assertEqual(
+            hashlib.md5(early).hexdigest(), hashlib.md5(late).hexdigest())
+
+    def test_key_order_and_whitespace_do_not_affect_output(self):
+        compact = self.normalise(b'{"a":1,"b":2,"c":3}')
+        reordered = self.normalise(
+            b'{\n  "c": 3,\n  "b": 2,\n  "a": 1\n}\n')
+
+        self.assertEqual(compact, reordered)
+
+    def test_non_ascii_text_is_preserved(self):
+        result = self.normalise(
+            '{"title":"Café Möbius — 日本語"}'.encode('utf-8'))
+
+        self.assertEqual(
+            result, '{"title":"Café Möbius — 日本語"}\n'.encode('utf-8'))
+        self.assertEqual(
+            json.loads(result.decode('utf-8'))['title'],
+            'Café Möbius — 日本語')
+
+    def test_real_metadata_change_produces_different_bytes_and_md5(self):
+        original = self.normalise(
+            b'{"jsonGeneratedAt":"2026-01-01T00:00:00Z","title":"Book"}')
+        changed = self.normalise(
+            b'{"jsonGeneratedAt":"2026-01-01T00:00:00Z","title":"Revised"}')
+
+        self.assertNotEqual(original, changed)
+        self.assertNotEqual(
+            hashlib.md5(original).hexdigest(),
+            hashlib.md5(changed).hexdigest())
+
+    def test_missing_top_level_timestamp_is_accepted(self):
+        result = self.normalise(b'{"title":"Book"}')
+
+        self.assertEqual(result, b'{"title":"Book"}\n')
+
+    def test_nested_timestamp_field_is_preserved(self):
+        result = self.normalise(
+            b'{"jsonGeneratedAt":"2026-01-01T00:00:00Z",'
+            b'"work":{"jsonGeneratedAt":"nested-value","id":"x"}}')
+
+        payload = json.loads(result.decode('utf-8'))
+        self.assertNotIn('jsonGeneratedAt', payload)
+        self.assertEqual(payload['work']['jsonGeneratedAt'], 'nested-value')
+
+    def test_only_top_level_timestamp_field_is_removed(self):
+        result = self.normalise(
+            b'{"jsonGeneratedAt":"t","keep":"me","also":"here"}')
+
+        payload = json.loads(result.decode('utf-8'))
+        self.assertEqual(payload, {'keep': 'me', 'also': 'here'})
+
+    def test_output_is_exact_documented_canonical_representation(self):
+        result = self.normalise(
+            b'{\n  "b": "second",\n'
+            b'  "jsonGeneratedAt": "2026-01-01T00:00:00Z",\n'
+            b'  "a": "first"\n}\n')
+
+        self.assertEqual(result, b'{"a":"first","b":"second"}\n')
+
+    def test_output_is_idempotent(self):
+        once = self.normalise(
+            b'{"jsonGeneratedAt":"2026-01-01T00:00:00Z","x":[1,2,{"y":"z"}]}')
+        twice = self.normalise(once)
+
+        self.assertEqual(once, twice)
+
+    def test_non_bytes_input_is_rejected(self):
+        for value in ('a string', {'a': 'dict'}, 42, None, ['list']):
+            with self.subTest(value=value):
+                with self.assertRaises(
+                        InternetArchiveDesiredStateError) as raised:
+                    self.normalise(value)
+                self.assertEqual(raised.exception.source, 'json')
+
+    def test_invalid_utf8_is_rejected(self):
+        with self.assertRaises(InternetArchiveDesiredStateError) as raised:
+            self.normalise(b'{"title": "\xff\xfe"}')
+        self.assertEqual(raised.exception.source, 'json')
+
+    def test_malformed_json_is_rejected(self):
+        with self.assertRaises(InternetArchiveDesiredStateError) as raised:
+            self.normalise(b'{"title": ')
+        self.assertEqual(raised.exception.source, 'json')
+
+    def test_non_object_roots_are_rejected(self):
+        for raw in (b'[1,2,3]', b'"a string"', b'42', b'true', b'null'):
+            with self.subTest(raw=raw):
+                with self.assertRaises(
+                        InternetArchiveDesiredStateError) as raised:
+                    self.normalise(raw)
+                self.assertEqual(raised.exception.source, 'json')
+
+    def test_values_canonical_json_refuses_are_rejected(self):
+        # Python's json.loads accepts NaN/Infinity, but canonical serialisation
+        # with allow_nan=False must refuse them rather than emit invalid JSON.
+        for raw in (b'{"x": NaN}', b'{"x": Infinity}', b'{"x": -Infinity}'):
+            with self.subTest(raw=raw):
+                with self.assertRaises(
+                        InternetArchiveDesiredStateError) as raised:
+                    self.normalise(raw)
+                self.assertEqual(raised.exception.source, 'json')
 
 
 class TestDisseminatorCLI(unittest.TestCase):

--- a/tests/test_reconcile_internet_archive.py
+++ b/tests/test_reconcile_internet_archive.py
@@ -30,7 +30,12 @@ WORK_ID_3 = '33333333-4444-5555-6666-777777777777'
 PUBLISHER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
 PUBLICATION_ID = '99999999-8888-7777-6666-555555555555'
 PDF_BYTES = b'current PDF bytes'
-JSON_BYTES = b'{"current":"metadata"}'
+# Canonical sidecar bytes: the deterministic representation produced by
+# IAUploader._normalise_json_sidecar (sorted keys, compact separators, single
+# trailing newline). Using the canonical form means the raw export and its
+# normalisation are byte-identical, so remote originals seeded with these bytes
+# still compare as current.
+JSON_BYTES = b'{"current":"metadata"}\n'
 PDF_MD5 = hashlib.md5(PDF_BYTES).hexdigest()
 PDF_NAME = '{}.pdf'.format(WORK_ID)
 JSON_NAME = '{}.json'.format(WORK_ID)


### PR DESCRIPTION
## Summary

Make the JSON sidecar uploaded to Internet Archive **deterministic** for semantically unchanged Thoth metadata, so managed JSON originals can converge to `current` instead of being re-flagged stale on every reconciliation run — while **preserving the exact value of every JSON number** so canonicalisation never alters real metadata.

## Production evidence

The Edizioni Ca' Foscari seven-work Adobe-PDF production canary ran on v1.6.2. Four item-missing works uploaded successfully:

```
63135b1a-b832-419e-9014-417acfb9ceaf
887a533a-9426-49d3-9779-ed314dc32543
9c46001f-5382-45bf-8bf0-62861ff9fb22
a00b60ba-5877-45d9-8c6a-9b202e5896e8
```

For all four, during the **protected apply** (run `30257828523`): the PDF uploaded once and its remote MD5 matched the source; the JSON sidecar uploaded once and its remote MD5 matched the expected MD5 for that invocation; metadata became current; the Thoth location was created with the verified PDF checksum; no extended propagation wait was required.

A **fresh dry-run** (run `30279348670`) then reclassified all four as `files_stale`, proposing only:

```
upload_json_original
```

The remote JSON bytes had **not** changed. Instead, the *expected* JSON MD5 changed between runs.

## Root cause — expected-state non-determinism, not IA propagation lag

The `json::thoth` export from Thoth's Export API begins with a top-level field:

```json
"jsonGeneratedAt": "<wall-clock timestamp>"
```

generated server-side on **every** request to `get_formatted_metadata('json::thoth')`. The uploader placed the returned bytes directly into `file_bytes` and calculated the expected MD5 over those raw bytes. An unchanged work therefore produced a different expected JSON checksum on every run, making a stable `current` state structurally impossible for managed JSON originals. This is deterministic expected-state drift on our side, **not** Internet Archive eventual-consistency/propagation lag: the remote bytes were stable; only our recomputed expectation moved.

## Fix

Added `IAUploader._normalise_json_sidecar(metadata_bytes)`, which:

1. requires `metadata_bytes` to be `bytes`;
2. decodes as UTF-8;
3. parses the JSON **preserving exact numeric values** (see below);
4. requires the root value to be a JSON object;
5. removes **only** the top-level `jsonGeneratedAt` field;
6. leaves any **nested** `jsonGeneratedAt` untouched;
7. leaves every other field and value untouched;
8. serialises canonically and deterministically.

The raw server export is **no longer uploaded byte-for-byte**. The semantic JSON payload is preserved except for the volatile top-level generation timestamp.

### Exact numeric precision (P2 review follow-up)

An earlier revision parsed with an ordinary `json.loads` and re-serialised with `json.dumps(...)`. `json.loads` decodes JSON fractional tokens as **binary floats**, so a value needing more precision than an IEEE-754 double was silently rounded *before* the canonical bytes were produced — e.g. `9007199254740993.0` was serialised as `9007199254740992.0`. Two distinct source values could therefore collapse to the same canonical bytes and the same expected MD5, and canonicalisation altered real metadata rather than only stripping the timestamp.

The parser now preserves exact values:

```python
payload = json.loads(
    decoded,
    parse_float=Decimal,
    parse_constant=_reject_non_standard_json_constant,
)
```

- fractional tokens become `decimal.Decimal`, preserving the exact value without any binary-float rounding;
- integers stay Python `int`, which already has arbitrary precision;
- `NaN` / `Infinity` / `-Infinity` are rejected **during parsing** (via `parse_constant`) before any non-finite float is constructed.

### Canonical serialisation format

`json.dumps` cannot emit a `Decimal` as an unquoted JSON number, so the canonical form is produced by an explicit standard-library-only recursive encoder, `_canonical_json_encode`, implementing exactly the JSON data model:

```text
dict     -> sort string keys lexicographically; keys via json.dumps(key, ensure_ascii=False);
            values recursive; ":" / "," separators, no insignificant whitespace
list     -> elements recursive; "," separator
str      -> json.dumps(value, ensure_ascii=False)   (non-ASCII preserved, not \u-escaped)
bool     -> true / false        (checked BEFORE int, since bool subclasses int)
None     -> null
int      -> exact base-10 representation
Decimal  -> exact finite decimal value as an UNQUOTED JSON number (str(Decimal))
           (non-finite Decimal rejected; any other type rejected, not coerced)
```

then `.encode('utf-8') + b'\n'` (single trailing newline).

The result is sorted keys, no insignificant whitespace, non-ASCII preserved, JSON numbers left **unquoted** with their exact value, and `NaN`/`Infinity` refused. The canonical lexical form of a number may differ from the source token (e.g. `6.022e23` → `6.022E+23`) but the exact mathematical value is preserved, and the output is deterministic and idempotent.

`build_desired_state()` retrieves the raw export, normalises it, and uses the **identical** normalised bytes for inspection, expected-MD5 calculation, upload, and final verification.

### Error handling

Normalisation failures raise `InternetArchiveDesiredStateError` with component `json`, retaining the work UUID and a useful reason **without exposing the complete metadata payload**. Covered: invalid UTF-8, malformed JSON, non-object roots (array/string/number/boolean/null), non-standard constants (NaN/Infinity, rejected at parse time), and non-bytes responses. There is **no silent fallback** to hashing the raw response.

## Preserved invariants

No PDF, metadata, ownership, location, or propagation behaviour is weakened. Specifically unchanged: strict remote-MD5 verification; upload acceptance ≠ verification; no automatic upload retry; no upload during dry-run; no write for fully current items; files tracked as uploaded only after the upload request returns; extended propagation only for accepted uploads from the current invocation; strict metadata verification; ownership/collision protections; derived `imagecount` handling; PDF bytes/MD5 handling; and location checksums that continue to use the verified **PDF** MD5, not the JSON MD5. The four canary UUIDs are **not** special-cased — the fix applies generically to every IA JSON sidecar.

## Pre-fix reproduction

**Determinism.** Two determinism tests were run against the **pre-fix** `develop` `iauploader.py` and **failed** because the expected JSON MD5 changed when `jsonGeneratedAt` changed (`test_two_desired_builds_differing_only_by_timestamp_share_json_md5`, `test_expected_json_md5_is_calculated_from_normalised_bytes`). Restoring the fixed implementation, both pass.

**Precision.** Against the previous PR head (`json.loads` + `json.dumps`), normalising `{"value":9007199254740993.0}` and `{"value":9007199254740992.0}` produced **identical** canonical bytes `{"value":9007199254740992.0}\n` and therefore an **identical** MD5 (`4f102558247be7ee895c973278b41784`) — the higher value was rounded down and the two distinct values collapsed. With the `parse_float=Decimal` + `_canonical_json_encode` correction, the higher value serialises as `9007199254740993.0`, the two produce different bytes and different MD5s, and the regression tests below pass.

No production data was manipulated to reproduce either issue.

## Tests

New focused tests in `tests/test_iauploader.py` cover:

- **Canonicalisation contract** — timestamp/whitespace/key-order invariance, non-ASCII preservation, real-change divergence, missing/nested/top-level-only `jsonGeneratedAt`, exact canonical bytes, idempotency, NaN/Infinity rejection.
- **Exact numeric precision (new)** — `9007199254740993.0` is not rounded to `...992.0`; it stays distinct from `9007199254740992.0` in both bytes and MD5; a long fractional value (`0.123456789012345678901234567890`) survives exactly; exact decimals are preserved nested in an object, an array, and an object-in-array; negative and exponent-form decimals are preserved; numbers remain JSON numbers (not quoted strings); canonical output containing exact decimals is idempotent.
- **Desired-state behaviour** — normalised bytes in `file_bytes`, expected MD5 from normalised bytes, exact bytes sent, cross-build MD5 equality, remote-canonical-is-current-despite-new-timestamp, legacy-timestamp-sidecar stale → one `upload_json_original` → subsequently current, current-item fast path reads no credentials / performs no upload.
- **Error behaviour** — invalid UTF-8, malformed JSON, non-object roots, non-bytes, UUID-present/payload-absent.

Results:
- `tests/test_iauploader.py` — **112 passed, 20 subtests**
- `tests/test_reconcile_internet_archive.py` — **106 passed, 2 subtests**
- `tests/test_ia_reconcile_workflow.py` — **17 passed, 2 subtests**
- full suite `python3 -m pytest -q` — **395 passed, 68 subtests** (1 pre-existing unrelated `imp` deprecation warning)
- `python3 -m compileall -q .` — clean
- `git diff --check` — clean

All sleeps are mocked (`iauploader.sleep` patched in the shared fixture); no test performs a live request (`get_item`/`upload`/`get_formatted_metadata`/`get_publication_details` are mocked).

## Migration impact

**No database migration required.** No Thoth schema, export API, or location semantics change.

## One-time effect on existing IA JSON originals

Existing timestamp-bearing sidecars will be identified as stale **once** and replaced with the deterministic representation (a single `upload_json_original` each). After that replacement, stable sidecars converge to `current` and stay there. The service version is **not** bumped in this PR; an `[Unreleased]` changelog entry was added per the repo convention.

## Rollout plan (describe-only — not executed here)

1. Release the deterministic-sidecar fix.
2. Dry-run the four successfully uploaded canary works.
3. Require the only proposed action to be `upload_json_original`.
4. Run one protected apply for those four works.
5. Run a fresh final dry-run.
6. Require all four to be `current` with zero proposed actions.
7. Do **not** include the three PDF-rejected works in that verification.

## Rollback notes

Pure code change, no data migration. Reverting the commit restores the prior behaviour; any sidecars already rewritten to canonical form remain valid JSON and simply revert to being re-flagged stale each run (the pre-fix status quo). No PDF, metadata, ownership, or location state is affected by a rollback.

## Out of scope / non-goals

This PR does **not** retry the seven-work canary, upload any JSON or PDF to IA, mutate Thoth locations, or dispatch any workflow. The three synchronously **PDF-rejected** works remain a separate follow-up and are neither uploaded nor modified here:

```
11bf9d9a-d7af-4d5b-8dff-800dda38e771
c884f5c6-9391-4705-af97-7a56e77ea2e9
e0305c0b-0f31-4ff2-98de-6367bcc66cae
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
